### PR TITLE
perf: use empty bootnodes for dev chain

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -633,6 +633,7 @@ impl ChainSpec {
             C::Optimism => Some(op_nodes()),
             C::BaseGoerli | C::BaseSepolia => Some(base_testnet_nodes()),
             C::OptimismSepolia | C::OptimismGoerli | C::OptimismKovan => Some(op_testnet_nodes()),
+            C::Dev => Some(vec![]), // empty bootnodes for dev
             _ => None,
         }
     }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -34,7 +34,7 @@ use reth_network::{
 };
 use reth_network_peers::{mainnet_nodes, TrustedPeer};
 use secp256k1::SecretKey;
-use tracing::error;
+use tracing::{error, debug};
 
 use crate::version::P2P_CLIENT_VERSION;
 
@@ -207,6 +207,7 @@ impl NetworkArgs {
         let chain_bootnodes = self
             .resolved_bootnodes()
             .unwrap_or_else(|| chain_spec.bootnodes().unwrap_or_else(mainnet_nodes));
+        debug!(target: "reth::cli", ?chain_bootnodes, "Using bootnodes");
         let peers_file = self.peers_file.clone().unwrap_or(default_peers_file);
 
         // Configure peer connections


### PR DESCRIPTION
Use empty bootnodes for dev chain, to prevent establishing TCP connections to mainnet nodes endlessly and futilely .