### PR TITLE
update(grevm): update grevm metrics to 0.24.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -441,7 +441,7 @@ reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types" }
 reth-revm = { path = "crates/revm", default-features = false }
-reth-grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", tag = "v2.0.1" }
+reth-grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", tag = "v2.0.2" }
 reth-rpc = { path = "crates/rpc/rpc" }
 reth-rpc-api = { path = "crates/rpc/rpc-api" }
 reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }


### PR DESCRIPTION
grevm 2.0.2 has updated metrics to 0.24.1, to compatible with gravity-reth.