### PR TITLE
feat(server): Add config to control whether do http response compression or not

### DIFF
--- a/crates/node/core/src/args/rpc_server.rs
+++ b/crates/node/core/src/args/rpc_server.rs
@@ -51,6 +51,10 @@ pub struct RpcServerArgs {
     #[arg(long = "http.port", default_value_t = constants::DEFAULT_HTTP_RPC_PORT)]
     pub http_port: u16,
 
+    /// Http server should compress responses
+    #[arg(long = "http.disable_compression", default_value_t = false)]
+    pub http_disable_compression: bool,
+
     /// Rpc Modules to be configured for the HTTP server
     #[arg(long = "http.api", value_parser = RpcModuleSelectionValueParser::default())]
     pub http_api: Option<RpcModuleSelection>,
@@ -303,6 +307,7 @@ impl Default for RpcServerArgs {
             http: false,
             http_addr: Ipv4Addr::LOCALHOST.into(),
             http_port: constants::DEFAULT_HTTP_RPC_PORT,
+            http_disable_compression: false,
             http_api: None,
             http_corsdomain: None,
             ws: false,

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -192,7 +192,8 @@ impl RethRpcServerConfig for RpcServerArgs {
                 .with_http_address(socket_address)
                 .with_http(self.http_ws_server_builder())
                 .with_http_cors(self.http_corsdomain.clone())
-                .with_ws_cors(self.ws_allowed_origins.clone());
+                .with_ws_cors(self.ws_allowed_origins.clone())
+                .with_http_disable_compression(self.http_disable_compression);
         }
 
         if self.ws {


### PR DESCRIPTION
The tonic service layer used by reth would do response compression by default once the request's header is attached with `accept-encoding: gzip`. This pr adds one option for the server to pass all the compression logic.