### PR TITLE
test(pipe): Add pipe test

### DIFF
--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -1084,15 +1084,6 @@ mod tests {
         ) -> ProviderResult<(B256, TrieUpdates)> {
             Ok((B256::random(), TrieUpdates::default()))
         }
-
-        fn state_root_with_updates_v2(
-            &self,
-            state: HashedPostState,
-            hashed_state_vec: Vec<Arc<HashedPostState>>,
-            trie_updates_vec: Vec<Arc<TrieUpdates>>,
-        ) -> ProviderResult<(B256, TrieUpdates)> {
-            Ok((B256::random(), TrieUpdates::default()))
-        }
     }
 
     impl HashedPostStateProvider for MockStateProvider {

--- a/crates/chain-state/src/memory_overlay.rs
+++ b/crates/chain-state/src/memory_overlay.rs
@@ -128,25 +128,6 @@ impl<N: NodePrimitives> StateRootProvider for MemoryOverlayStateProviderRef<'_, 
         self.state_root_from_nodes_with_updates(TrieInput::from_state(state))
     }
 
-    fn state_root_with_updates_v2(
-        &self,
-        state: HashedPostState,
-        hashed_state_vec: Vec<Arc<HashedPostState>>,
-        trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        let mut input = TrieInput::from_state(state);
-        let mut trie_state = MemoryOverlayTrieState::default();
-        hashed_state_vec.iter().for_each(|hashed_state| {
-            trie_state.state.extend_ref(hashed_state.as_ref());
-        });
-        trie_updates_vec.iter().for_each(|trie_updates| {
-            trie_state.nodes.extend_ref(trie_updates.as_ref());
-        });
-        let MemoryOverlayTrieState { nodes, state } = trie_state;
-        input.prepend_cached(nodes, state);
-        self.state_root_from_nodes_with_updates(input)
-    }
-
     fn state_root_from_nodes_with_updates(
         &self,
         mut input: TrieInput,

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -252,15 +252,6 @@ impl<S: StateRootProvider> StateRootProvider for CachedStateProvider<S> {
     ) -> ProviderResult<(B256, TrieUpdates)> {
         self.state_provider.state_root_with_updates(hashed_state)
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        state: HashedPostState,
-        hashed_state_vec: Vec<Arc<HashedPostState>>,
-        trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        todo!()
-    }
 }
 
 impl<S: StateProofProvider> StateProofProvider for CachedStateProvider<S> {

--- a/crates/ethereum/evm/src/debug_ext.rs
+++ b/crates/ethereum/evm/src/debug_ext.rs
@@ -8,7 +8,6 @@ use std::{
 
 use alloy_primitives::{Address, B256};
 use once_cell::sync::Lazy;
-use reth_primitives::Receipt;
 use reth_revm::{db::PlainAccount, CacheState, TransitionState};
 use revm_primitives::{EnvWithHandlerCfg, TxEnv};
 

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -159,10 +159,6 @@ where
             });
             let (results, parallel_state) = executor.take_result_and_state();
 
-            let should_dump = DEBUG_EXT
-                .dump_block_number
-                .map_or(false, |dump_block_number| block.number == dump_block_number);
-
             if output.is_err() ||
                 !crate::debug_ext::compare_transition_state(
                     seq_state.0.as_ref().unwrap(),

--- a/crates/pipe-exec-layer-ext-v2/Cargo.toml
+++ b/crates/pipe-exec-layer-ext-v2/Cargo.toml
@@ -39,4 +39,15 @@ metrics.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
+reth-cli.workspace = true
+reth-cli-commands.workspace = true
+reth-cli-runner.workspace = true
+reth-node-ethereum.workspace = true
+reth-node-builder.workspace = true
+reth-provider.workspace = true
+reth-ethereum-cli.workspace = true
+reth-db.workspace = true
+reth-node-api.workspace = true
+reth-tracing.workspace = true
+eyre.workspace = true
 rand.workspace = true

--- a/crates/pipe-exec-layer-ext-v2/tests/pipe_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/tests/pipe_test.rs
@@ -1,0 +1,195 @@
+use gravity_storage::block_view_storage::BlockViewStorage;
+use reth_chainspec::ChainSpec;
+use reth_cli_commands::NodeCommand;
+use reth_cli_runner::CliRunner;
+use reth_db::DatabaseEnv;
+use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth_node_api::NodeTypesWithDBAdapter;
+use reth_node_builder::{engine_tree_config, EngineNodeLauncher, NodeBuilder, WithLaunchContext};
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_pipe_exec_layer_ext_v2::{new_pipe_exec_layer_api, ExecutionArgs, PipeExecLayerApi};
+use reth_provider::{
+    providers::BlockchainProvider, BlockHashReader, BlockNumReader, BlockReader,
+    DatabaseProviderFactory, HeaderProvider, TransactionVariant,
+};
+use reth_tracing::{
+    tracing_subscriber::filter::LevelFilter, LayerInfo, LogFormat, RethTracer, Tracer,
+};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+type Provider = BlockchainProvider<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>;
+
+struct MockConsensus {
+    pipeline_api: PipeExecLayerApi<BlockViewStorage<Provider>>,
+    provider: Provider,
+}
+
+impl MockConsensus {
+    fn new(pipeline_api: PipeExecLayerApi<BlockViewStorage<Provider>>, provider: Provider) -> Self {
+        Self { pipeline_api, provider }
+    }
+
+    async fn run(self) {
+        let Self { pipeline_api, provider } = self;
+        let (start_block, target_block) = {
+            let db_provider = provider.database_provider_ro().unwrap();
+            let start_block = db_provider.best_block_number().unwrap() + 1;
+            let target_block = db_provider.last_block_number().unwrap();
+            (start_block, target_block)
+        };
+        println!("start_block={start_block} target_block={target_block}");
+
+        let pipeline_api = Arc::new(pipeline_api);
+        let (block_header_tx, mut block_header_rx) = tokio::sync::mpsc::channel(8);
+        tokio::spawn({
+            let pipeline_api = pipeline_api.clone();
+            async move {
+                for block_number in start_block..=target_block {
+                    let block = provider
+                        .block_with_senders(block_number.into(), TransactionVariant::WithHash)
+                        .unwrap()
+                        .unwrap();
+                    let block_hash = block.hash();
+                    let block_header = block.header().clone();
+                    if pipeline_api.push_history_block(block).is_none() {
+                        break;
+                    }
+
+                    block_header_tx.send((block_header, block_hash)).await.unwrap();
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        });
+
+        let (execution_result_tx, mut execution_result_rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn({
+            let pipeline_api = pipeline_api.clone();
+            async move {
+                let mut result_buffer = BTreeMap::new();
+                let mut next_block_number = start_block;
+                while let Some(result) = pipeline_api.pull_executed_block_hash().await {
+                    if result.block_number == next_block_number {
+                        execution_result_tx.send(result).unwrap();
+                        next_block_number += 1;
+                        while let Some((&block_number, _)) = result_buffer.first_key_value() {
+                            if block_number == next_block_number {
+                                execution_result_tx
+                                    .send(result_buffer.pop_first().unwrap().1)
+                                    .unwrap();
+                                next_block_number += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                    } else if next_block_number < result.block_number {
+                        result_buffer.insert(result.block_number, result);
+                    } else {
+                        panic!("next block number ({}) cannot be greater than pulled block number ({})", next_block_number, result.block_number);
+                    }
+                }
+            }
+        });
+
+        while let Some((header, block_hash)) = block_header_rx.recv().await {
+            let result = execution_result_rx.recv().await.unwrap();
+            assert_eq!(result.block_hash, block_hash, "block_hash mismatch: {header:?}");
+            pipeline_api
+                .commit_executed_block_hash(result.block_id, Some(result.block_hash))
+                .unwrap();
+        }
+    }
+}
+
+async fn run_pipe(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<()> {
+    let handle = builder
+        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                builder.task_executor().clone(),
+                builder.config().datadir(),
+                engine_tree_config::TreeConfig::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await?;
+
+    let chain_spec = handle.node.chain_spec();
+
+    let provider: Provider = handle.node.provider;
+    let db_provider = provider.database_provider_ro().unwrap();
+    let latest_block_number = db_provider.best_block_number().unwrap();
+    println!("The latest_block_number is {}", latest_block_number);
+    let latest_block_hash = db_provider.block_hash(latest_block_number).unwrap().unwrap();
+    let latest_block_header = db_provider.header_by_number(latest_block_number).unwrap().unwrap();
+
+    let mut block_number_to_id = BTreeMap::new();
+    for block_number in latest_block_number.saturating_sub(255)..latest_block_number {
+        let block_hash = db_provider.block_hash(block_number).unwrap().unwrap();
+        block_number_to_id.insert(block_number, block_hash);
+    }
+    drop(db_provider);
+    block_number_to_id.insert(latest_block_number, latest_block_hash);
+
+    // Load block number to hash from test data
+
+    let storage = BlockViewStorage::new(
+        provider.clone(),
+        latest_block_number,
+        latest_block_hash,
+        block_number_to_id,
+    );
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let pipeline_api =
+        new_pipe_exec_layer_api(chain_spec, storage, latest_block_header, latest_block_hash, rx);
+    tx.send(ExecutionArgs { block_number_to_block_id: BTreeMap::new() }).unwrap();
+
+    let consensus = MockConsensus::new(pipeline_api, provider);
+    consensus.run().await;
+
+    Ok(())
+}
+
+#[test]
+fn test() {
+    std::panic::set_hook(Box::new({
+        |panic_info| {
+            let backtrace = std::backtrace::Backtrace::capture();
+            eprintln!("Panic occurred: {panic_info}\nBacktrace:\n{backtrace}");
+            std::process::exit(1);
+        }
+    }));
+
+    let _ = RethTracer::new()
+        .with_stdout(LayerInfo::new(
+            LogFormat::Terminal,
+            LevelFilter::DEBUG.to_string(),
+            "".to_string(),
+            Some("always".to_string()),
+        ))
+        .init();
+
+    let datadir = std::env::var("PIPE_TEST_DATADIR").expect("Failed to get PIPE_TEST_DATADIR");
+
+    let runner = CliRunner::default();
+    let command: NodeCommand<EthereumChainSpecParser> = NodeCommand::try_parse_args_from([
+        "reth",
+        "--chain",
+        "mainnet",
+        "--with-unused-ports",
+        "--dev",
+        "--datadir",
+        &datadir,
+    ])
+    .unwrap();
+
+    runner
+        .run_command_until_exit(|ctx| {
+            command.execute(ctx, |builder, _| async move { run_pipe(builder).await })
+        })
+        .unwrap();
+}

--- a/crates/rpc/rpc-eth-types/src/cache/db.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/db.rs
@@ -8,7 +8,6 @@ use reth_revm::{database::StateProviderDatabase, db::CacheDB, DatabaseRef};
 use reth_storage_api::{HashedPostStateProvider, StateProvider};
 use reth_trie::{HashedStorage, MultiProofTargets};
 use revm::Database;
-use std::sync::Arc;
 
 /// Helper alias type for the state's [`CacheDB`]
 pub type StateCacheDb<'a> = CacheDB<StateProviderDatabase<StateProviderTraitObjWrapper<'a>>>;
@@ -45,15 +44,6 @@ impl reth_storage_api::StateRootProvider for StateProviderTraitObjWrapper<'_> {
         input: reth_trie::TrieInput,
     ) -> reth_errors::ProviderResult<(B256, reth_trie::updates::TrieUpdates)> {
         self.0.state_root_from_nodes_with_updates(input)
-    }
-
-    fn state_root_with_updates_v2(
-        &self,
-        state: reth_trie::HashedPostState,
-        hashed_state_vec: Vec<Arc<reth_trie::HashedPostState>>,
-        trie_updates_vec: Vec<Arc<reth_trie::updates::TrieUpdates>>,
-    ) -> ProviderResult<(B256, reth_trie::updates::TrieUpdates)> {
-        todo!()
     }
 }
 

--- a/crates/storage/provider/src/providers/bundle_state_provider.rs
+++ b/crates/storage/provider/src/providers/bundle_state_provider.rs
@@ -112,15 +112,6 @@ impl<SP: StateProvider, EDP: ExecutionDataProvider> StateRootProvider
         input.prepend(self.hashed_post_state(bundle_state));
         self.state_provider.state_root_from_nodes_with_updates(input)
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        state: HashedPostState,
-        hashed_state_vec: Vec<Arc<HashedPostState>>,
-        trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        todo!()
-    }
 }
 
 impl<SP: StateProvider, EDP: ExecutionDataProvider> StorageRootProvider

--- a/crates/storage/provider/src/providers/database/parallel_provider.rs
+++ b/crates/storage/provider/src/providers/database/parallel_provider.rs
@@ -166,15 +166,6 @@ impl StateRootProvider for ParallelStateProvider {
     ) -> ProviderResult<(B256, TrieUpdates)> {
         todo!()
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        state: HashedPostState,
-        hashed_state_vec: Vec<Arc<HashedPostState>>,
-        trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        todo!()
-    }
 }
 
 #[allow(unused)]

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -323,15 +323,6 @@ impl<Provider: DBProvider + BlockNumReader + StateCommitmentProvider> StateRootP
         )
         .map_err(|err| ProviderError::Database(err.into()))
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        state: HashedPostState,
-        hashed_state_vec: Vec<Arc<HashedPostState>>,
-        trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        todo!()
-    }
 }
 
 impl<Provider: DBProvider + BlockNumReader + StateCommitmentProvider> StorageRootProvider

--- a/crates/storage/provider/src/providers/state/latest.rs
+++ b/crates/storage/provider/src/providers/state/latest.rs
@@ -100,25 +100,6 @@ impl<Provider: DBProvider + StateCommitmentProvider> StateRootProvider
         StateRoot::overlay_root_from_nodes_with_updates(self.tx(), input, self.1.clone())
             .map_err(|err| ProviderError::Database(err.into()))
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        state: HashedPostState,
-        hashed_state_vec: Vec<Arc<HashedPostState>>,
-        trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        let mut input = TrieInput::from_state(state);
-        let mut state = HashedPostState::default();
-        let mut nodes = TrieUpdates::default();
-        hashed_state_vec.iter().for_each(|hashed_state| {
-            state.extend_ref(hashed_state.as_ref());
-        });
-        trie_updates_vec.iter().for_each(|trie_updates| {
-            nodes.extend_ref(trie_updates.as_ref());
-        });
-        input.prepend_cached(nodes, state);
-        self.state_root_from_nodes_with_updates(input)
-    }
 }
 
 impl<Provider: DBProvider + StateCommitmentProvider> StorageRootProvider

--- a/crates/storage/provider/src/test_utils/mock.rs
+++ b/crates/storage/provider/src/test_utils/mock.rs
@@ -671,16 +671,6 @@ impl<T: Transaction, ChainSpec: EthChainSpec> StateRootProvider for MockEthProvi
         let state_root = self.state_roots.lock().pop().unwrap_or_default();
         Ok((state_root, Default::default()))
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        _state: HashedPostState,
-        _hashed_state_vec: Vec<Arc<HashedPostState>>,
-        _trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        let state_root = self.state_roots.lock().pop().unwrap_or_default();
-        Ok((state_root, Default::default()))
-    }
 }
 
 impl<T: Transaction, ChainSpec: EthChainSpec> StorageRootProvider

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -165,6 +165,7 @@ where
             trie,
         } in blocks
         {
+            #[cfg(not(pipe_test))]
             self.database()
                 .insert_block(Arc::unwrap_or_clone(recovered_block), StorageLocation::Both)?;
 

--- a/crates/storage/storage-api/src/noop.rs
+++ b/crates/storage/storage-api/src/noop.rs
@@ -387,15 +387,6 @@ impl<C: Send + Sync, N: NodePrimitives> StateRootProvider for NoopProvider<C, N>
     ) -> ProviderResult<(B256, TrieUpdates)> {
         Ok((B256::default(), TrieUpdates::default()))
     }
-
-    fn state_root_with_updates_v2(
-        &self,
-        _state: HashedPostState,
-        _hashed_state_vec: Vec<Arc<HashedPostState>>,
-        _trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)> {
-        Ok((B256::default(), TrieUpdates::default()))
-    }
 }
 
 impl<C: Send + Sync, N: NodePrimitives> StorageRootProvider for NoopProvider<C, N> {

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -44,7 +44,19 @@ pub trait StateRootProvider: Send + Sync {
         state: HashedPostState,
         hashed_state_vec: Vec<Arc<HashedPostState>>,
         trie_updates_vec: Vec<Arc<TrieUpdates>>,
-    ) -> ProviderResult<(B256, TrieUpdates)>;
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        let mut input = TrieInput::from_state(state);
+        let mut state = HashedPostState::default();
+        let mut nodes = TrieUpdates::default();
+        hashed_state_vec.iter().for_each(|hashed_state| {
+            state.extend_ref(hashed_state.as_ref());
+        });
+        trie_updates_vec.iter().for_each(|trie_updates| {
+            nodes.extend_ref(trie_updates.as_ref());
+        });
+        input.prepend_cached(nodes, state);
+        self.state_root_from_nodes_with_updates(input)
+    }
 }
 
 /// A type that can compute the storage root for a given account.


### PR DESCRIPTION
Add pipe test to execute mainnet history blocks through pipeline execution layer, and compare the calculation results with the block hash of the historical blocks to verify the correctness of pipeline execution.