### PR TITLE
use nested state root in history sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10323,6 +10323,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "reth-trie-db",
+ "reth-trie-parallel",
  "serde",
  "tempfile",
  "thiserror 2.0.12",

--- a/crates/gravity-storage/src/block_view_storage/mod.rs
+++ b/crates/gravity-storage/src/block_view_storage/mod.rs
@@ -1,8 +1,9 @@
 use crate::GravityStorage;
 use alloy_primitives::{Address, B256, U256};
 use reth_provider::{
-    BlockNumReader, BlockReader, DatabaseProviderFactory, HeaderProvider, PersistBlockCache,
-    ProviderError, ProviderResult, StateCommitmentProvider, StateProviderBox, PERSIST_BLOCK_CACHE,
+    BlockNumReader, BlockReader, DBProvider, DatabaseProviderFactory, HeaderProvider,
+    PersistBlockCache, ProviderError, ProviderResult, StateCommitmentProvider, StateProviderBox,
+    PERSIST_BLOCK_CACHE,
 };
 use reth_revm::{
     bytecode::Bytecode, database::StateProviderDatabase, primitives::BLOCK_HASH_HISTORY,
@@ -62,7 +63,7 @@ where
         hashed_state: &HashedPostState,
         compatible: bool,
     ) -> ProviderResult<(B256, TrieUpdatesV2, Option<TrieUpdates>)> {
-        let provider = || self.client.database_provider_ro();
+        let provider = || self.client.database_provider_ro().map(|db| db.into_tx());
         let nested_hash = NestedStateRoot::new(provider, Some(self.cache.clone()));
         nested_hash.calculate(hashed_state, compatible)
     }

--- a/crates/pipe-exec-layer-ext-v2/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/src/lib.rs
@@ -340,7 +340,7 @@ impl<Storage: GravityStorage> Core<Storage> {
             self.make_canonical(ExecutedBlockWithTrieUpdates::new(
                 Arc::new(RecoveredBlock::new_sealed(sealed_block, senders)),
                 Arc::new(execution_outcome),
-                Default::default(),
+                Arc::new(hashed_state),
                 ExecutedTrieUpdates::empty(),
                 Arc::new(trie_updates),
             ))

--- a/crates/pipe-exec-layer-ext-v2/tests/pipe_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/tests/pipe_test.rs
@@ -138,12 +138,12 @@ async fn run_pipe(
     drop(db_provider);
 
     // write new state root
-    let nested_provider = || provider.database_provider_ro();
+    let nested_provider = || provider.database_provider_ro().map(|db| db.into_tx());
     let nested_hash = NestedStateRoot::new(nested_provider, None);
-    let hashed_state = nested_hash.read_hashed_state().unwrap();
+    let hashed_state = nested_hash.read_hashed_state(None).unwrap();
     let (root_hash, trie_updates, _) = nested_hash.calculate(&hashed_state, false).unwrap();
     let trie_write = provider.database_provider_rw().unwrap();
-    trie_write.write(&trie_updates).unwrap();
+    trie_write.write_trie_updatesv2(&trie_updates).unwrap();
     UnifiedStorageWriter::commit_unwind(trie_write)?;
 
     info!("Calculate and write state root={root_hash}");

--- a/crates/stages/api/src/stage.rs
+++ b/crates/stages/api/src/stage.rs
@@ -9,6 +9,9 @@ use std::{
     task::{Context, Poll},
 };
 
+/// Support to create concurrent reader
+pub type BoxedConcurrentProvider<P> = Box<dyn Fn() -> ProviderResult<P> + Send + Sync>;
+
 /// Stage execution input, see [`Stage::execute`].
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
 pub struct ExecInput {
@@ -240,7 +243,7 @@ pub trait Stage<Provider, ProviderRO>: Send + Sync {
     fn execute(
         &mut self,
         provider: &Provider,
-        provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError>;
 
@@ -257,7 +260,7 @@ pub trait Stage<Provider, ProviderRO>: Send + Sync {
     fn unwind(
         &mut self,
         provider: &Provider,
-        provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError>;
 

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -39,6 +39,7 @@ reth-stages-api.workspace = true
 reth-static-file-types.workspace = true
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-trie-parallel.workspace = true
 
 reth-testing-utils = { workspace = true, optional = true }
 

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -11,8 +11,8 @@ use reth_provider::{
     StaticFileProviderFactory, StatsReader, StorageLocation,
 };
 use reth_stages_api::{
-    EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
-    UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
+    StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_errors::provider::ProviderResult;
@@ -189,7 +189,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -230,7 +230,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.buffer.take();

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -13,9 +13,11 @@ use reth_provider::{
     BlockReader, BlockWriter, DBProvider, HeaderProvider, StageCheckpointWriter,
     StaticFileProviderFactory, StaticFileWriter,
 };
-use reth_stages_api::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
+use reth_stages_api::{
+    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
+};
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_errors::{ProviderError, ProviderResult};
+use reth_storage_errors::ProviderError;
 use std::{
     fmt::{Debug, Formatter},
     iter,
@@ -171,7 +173,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let height = if let Some(era) = self.item.take() {
@@ -227,7 +229,7 @@ where
     fn unwind(
         &mut self,
         _provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         Ok(UnwindOutput { checkpoint: input.checkpoint.with_block_number(input.unwind_to) })

--- a/crates/stages/stages/src/stages/finish.rs
+++ b/crates/stages/stages/src/stages/finish.rs
@@ -1,7 +1,7 @@
 use reth_stages_api::{
-    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
-use reth_storage_errors::ProviderResult;
 
 /// The finish stage.
 ///
@@ -19,7 +19,7 @@ impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for FinishStage {
     fn execute(
         &mut self,
         _provider: &Provider,
-        _provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
@@ -28,7 +28,7 @@ impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for FinishStage {
     fn unwind(
         &mut self,
         _provider: &Provider,
-        _provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -11,8 +11,8 @@ use reth_etl::Collector;
 use reth_primitives_traits::Account;
 use reth_provider::{AccountExtReader, DBProvider, HashingWriter, StatsReader};
 use reth_stages_api::{
-    AccountHashingCheckpoint, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
-    StageError, StageId, UnwindInput, UnwindOutput,
+    AccountHashingCheckpoint, BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput,
+    Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderResult;
 use std::{
@@ -145,7 +145,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -237,7 +237,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -12,8 +12,8 @@ use reth_etl::Collector;
 use reth_primitives_traits::StorageEntry;
 use reth_provider::{DBProvider, HashingWriter, StatsReader, StorageReader};
 use reth_stages_api::{
-    EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
-    StorageHashingCheckpoint, UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
+    StageError, StageId, StorageHashingCheckpoint, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderResult;
 use std::{
@@ -75,7 +75,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let tx = provider.tx_ref();
@@ -169,7 +169,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -24,9 +24,10 @@ use reth_stages_api::{
     StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_errors::{provider::ProviderError, ProviderResult};
+use reth_storage_errors::provider::ProviderError;
 use std::task::{ready, Context, Poll};
 
+use reth_stages_api::BoxedConcurrentProvider;
 use tokio::sync::watch;
 use tracing::*;
 
@@ -286,7 +287,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let current_checkpoint = input.checkpoint();
@@ -335,7 +336,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.sync_gap.take();

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -5,9 +5,9 @@ use reth_db_api::{models::ShardedKey, table::Decode, tables, transaction::DbTxMu
 use reth_provider::{DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter};
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
-    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
-use reth_storage_errors::ProviderResult;
 use std::fmt::Debug;
 use tracing::info;
 
@@ -56,7 +56,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -130,7 +130,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -9,8 +9,9 @@ use reth_db_api::{
 };
 use reth_provider::{DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter};
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
-use reth_stages_api::{ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput};
-use reth_storage_errors::ProviderResult;
+use reth_stages_api::{
+    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
+};
 use std::fmt::Debug;
 use tracing::info;
 
@@ -59,7 +60,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -137,7 +138,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -8,9 +8,9 @@ use reth_prune::{
     PruneMode, PruneModes, PruneSegment, PrunerBuilder, SegmentOutput, SegmentOutputCheckpoint,
 };
 use reth_stages_api::{
-    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
-use reth_storage_errors::ProviderResult;
 use tracing::info;
 
 /// The prune stage that runs the pruner with the provided prune modes.
@@ -52,7 +52,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let mut pruner = PrunerBuilder::default()
@@ -101,7 +101,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         // We cannot recover the data that was pruned in `execute`, so we just update the
@@ -147,7 +147,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let mut result = self.0.execute(provider, provider_ro, input)?;
@@ -169,7 +169,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.0.unwind(provider, provider_ro, input)

--- a/crates/stages/stages/src/stages/s3/mod.rs
+++ b/crates/stages/stages/src/stages/s3/mod.rs
@@ -10,10 +10,10 @@ use reth_provider::{
     DBProvider, StageCheckpointReader, StageCheckpointWriter, StaticFileProviderFactory,
 };
 use reth_stages_api::{
-    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
+    UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_errors::ProviderResult;
 use std::{
     path::PathBuf,
     task::{ready, Context, Poll},
@@ -91,7 +91,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError>
     where
@@ -125,7 +125,7 @@ where
     fn unwind(
         &mut self,
         _provider: &Provider,
-        _provider_ro: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         // TODO

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -16,11 +16,10 @@ use reth_provider::{
 };
 use reth_prune_types::PruneSegment;
 use reth_stages_api::{
-    BlockErrorKind, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError,
-    StageId, UnwindInput, UnwindOutput,
+    BlockErrorKind, BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage,
+    StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_errors::ProviderResult;
 use std::{fmt::Debug, ops::Range, sync::mpsc};
 use thiserror::Error;
 use tracing::*;
@@ -79,7 +78,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -129,7 +128,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -17,10 +17,10 @@ use reth_provider::{
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
-    EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
-    UnwindInput, UnwindOutput,
+    BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
+    StageError, StageId, UnwindInput, UnwindOutput,
 };
-use reth_storage_errors::{provider::ProviderError, ProviderResult};
+use reth_storage_errors::provider::ProviderError;
 use tracing::*;
 
 /// The transaction lookup stage.
@@ -76,7 +76,7 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -192,7 +192,7 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: Box<dyn Fn() -> ProviderResult<ProviderRO>>,
+        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let tx = provider.tx_ref();

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2307,7 +2307,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> StateWriter
 }
 
 impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriterV2 for DatabaseProvider<TX, N> {
-    fn write(&self, input: &TrieUpdatesV2) -> Result<usize, DatabaseError> {
+    fn write_trie_updatesv2(&self, input: &TrieUpdatesV2) -> Result<usize, DatabaseError> {
         let mut num_updated = 0;
         let tx = self.tx_ref();
         let mut account_trie_cursor = tx.cursor_write::<tables::AccountsTrieV2>()?;

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -187,7 +187,7 @@ where
             self.database().write_trie_updates(
                 trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(block_hash))?,
             )?;
-            let _ = self.database().write(triev2.as_ref())?;
+            let _ = self.database().write_trie_updatesv2(triev2.as_ref())?;
             PERSIST_BLOCK_CACHE.persist_tip(block_number);
         }
 

--- a/crates/storage/storage-api/src/cache.rs
+++ b/crates/storage/storage-api/src/cache.rs
@@ -10,7 +10,7 @@ use metrics_derive::Metrics;
 use once_cell::sync::Lazy;
 use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use reth_primitives_traits::Account;
-use reth_trie_common::{nested_trie::Node, updates::TrieUpdatesV2, Nibbles};
+use reth_trie_common::{nested_trie::Node, updates::TrieUpdatesV2, HashedPostState, Nibbles};
 use revm_bytecode::Bytecode;
 use revm_database::{states::StorageSlot, BundleAccount, OriginalValuesKnown};
 use std::{
@@ -572,3 +572,29 @@ impl PersistBlockCache {
         });
     }
 }
+
+/// Stage Data channel that from execution to merkle stage
+#[derive(Clone, Debug, Default)]
+pub struct ExecutionMerkleChannel {
+    data: Arc<Mutex<Option<(u64, HashedPostState)>>>,
+}
+
+impl ExecutionMerkleChannel {
+    /// send data to merkle stage
+    pub fn send(&self, block_number: u64, hashed_state: HashedPostState) {
+        let mut data = self.data.lock().unwrap();
+        assert!(data.is_none());
+        *data = Some((block_number, hashed_state));
+    }
+
+    /// consume data in merkle stage
+    pub fn consume(&self, block_number: u64) -> HashedPostState {
+        let data = self.data.lock().unwrap().take().unwrap();
+        assert_eq!(data.0, block_number);
+        data.1
+    }
+}
+
+/// Single instance of `ExecutionMerkleChannel`
+pub static EXECUTION_MERKLE_CHANNEL: Lazy<ExecutionMerkleChannel> =
+    Lazy::new(ExecutionMerkleChannel::default);

--- a/crates/storage/storage-api/src/trie.rs
+++ b/crates/storage/storage-api/src/trie.rs
@@ -144,5 +144,5 @@ pub trait StorageTrieWriter: Send + Sync {
 /// Trie writer for nested trie
 pub trait TrieWriterV2 {
     /// Write trie updates for nested trie
-    fn write(&self, input: &TrieUpdatesV2) -> Result<usize, DatabaseError>;
+    fn write_trie_updatesv2(&self, input: &TrieUpdatesV2) -> Result<usize, DatabaseError>;
 }

--- a/crates/trie/parallel/src/nested_hash.rs
+++ b/crates/trie/parallel/src/nested_hash.rs
@@ -1,20 +1,22 @@
 #![allow(clippy::type_complexity)]
 
-use std::sync::Mutex;
+use std::{ops::RangeInclusive, sync::Mutex};
 
 use alloy_primitives::{
+    keccak256,
     map::{B256Map, HashMap},
-    B256, KECCAK256_EMPTY,
+    BlockNumber, B256, U256,
 };
 use alloy_rlp::encode_fixed_size;
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
+    models::{AccountBeforeTx, BlockNumberAddress},
     tables,
     transaction::DbTx,
 };
 
 use reth_primitives_traits::Account;
-use reth_provider::{DBProvider, PersistBlockCache, ProviderResult};
+use reth_provider::{PersistBlockCache, ProviderResult};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     nested_trie::{Node, Trie, TrieReader},
@@ -87,19 +89,19 @@ where
 
 /// Root hash for nested trie
 #[derive(Debug)]
-pub struct NestedStateRoot<P, F>
+pub struct NestedStateRoot<Tx, F>
 where
-    P: DBProvider<Tx: DbTx>,
-    F: Fn() -> ProviderResult<P>,
+    Tx: DbTx,
+    F: Fn() -> ProviderResult<Tx>,
 {
     provider: F,
     cache: Option<PersistBlockCache>,
 }
 
-impl<P, F> NestedStateRoot<P, F>
+impl<Tx, F> NestedStateRoot<Tx, F>
 where
-    P: DBProvider<Tx: DbTx>,
-    F: Fn() -> ProviderResult<P>,
+    Tx: DbTx,
+    F: Fn() -> ProviderResult<Tx>,
 {
     /// Create a new `NestedStateRoot`
     pub const fn new(provider: F, cache: Option<PersistBlockCache>) -> Self {
@@ -107,34 +109,68 @@ where
     }
 
     /// Compatible with origin `BranchNodeCompact` trie
-    pub fn read_hashed_state(&self) -> ProviderResult<HashedPostState> {
+    pub fn read_hashed_state(
+        &self,
+        range: Option<RangeInclusive<BlockNumber>>,
+    ) -> ProviderResult<HashedPostState> {
         let mut accounts = HashMap::default();
         let mut storages: B256Map<HashedStorage> = HashMap::default();
+        let tx = (self.provider)()?;
+        if let Some(range) = range {
+            // Walk account changeset and insert account prefixes.
+            let mut account_changeset_cursor = tx.cursor_read::<tables::AccountChangeSets>()?;
+            let mut account_hashed_state_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+            for account_entry in account_changeset_cursor.walk_range(range.clone())? {
+                let (_, AccountBeforeTx { address, .. }) = account_entry?;
+                let hashed_address = keccak256(address);
+                let account = account_hashed_state_cursor.seek_exact(hashed_address)?;
+                accounts.insert(hashed_address, account.map(|a| a.1));
+            }
 
-        let mut account_cursor =
-            (self.provider)()?.tx_ref().cursor_read::<tables::HashedAccounts>()?;
-        let account_walker = account_cursor.walk(None)?;
-        for account in account_walker {
-            let (hashed_address, account) = account?;
-            accounts.insert(hashed_address, Some(account));
-        }
+            // Walk storage changeset and insert storage prefixes as well as account prefixes if
+            // missing from the account prefix set.
+            let mut storage_changeset_cursor = tx.cursor_dup_read::<tables::StorageChangeSets>()?;
+            let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+            let storage_range = BlockNumberAddress::range(range);
+            for storage_entry in storage_changeset_cursor.walk_range(storage_range)? {
+                let (BlockNumberAddress((_, address)), entry) = storage_entry?;
+                let hashed_address = keccak256(address);
+                if !accounts.contains_key(&hashed_address) {
+                    let account = account_hashed_state_cursor.seek_exact(hashed_address)?;
+                    accounts.insert(hashed_address, account.map(|a| a.1));
+                }
+                let hashed_slot = keccak256(entry.key);
+                let slot_value = storage_cursor
+                    .seek_by_key_subkey(hashed_address, hashed_slot)?
+                    .filter(|s| s.key == hashed_slot)
+                    .map(|s| s.value)
+                    .unwrap_or(U256::ZERO);
+                storages.entry(hashed_address).or_default().storage.insert(hashed_slot, slot_value);
+            }
+        } else {
+            let mut account_cursor = tx.cursor_read::<tables::HashedAccounts>()?;
+            let account_walker = account_cursor.walk(None)?;
+            for account in account_walker {
+                let (hashed_address, account) = account?;
+                accounts.insert(hashed_address, Some(account));
+            }
 
-        let mut storage_cursor =
-            (self.provider)()?.tx_ref().cursor_dup_read::<tables::HashedStorages>()?;
-        let storage_walker = storage_cursor.walk_dup(None, None)?;
-        for storage in storage_walker {
-            let (hashed_address, entry) = storage?;
-            storages.entry(hashed_address).or_default().storage.insert(entry.key, entry.value);
+            let mut storage_cursor = tx.cursor_dup_read::<tables::HashedStorages>()?;
+            let storage_walker = storage_cursor.walk_dup(None, None)?;
+            for storage in storage_walker {
+                let (hashed_address, entry) = storage?;
+                storages.entry(hashed_address).or_default().storage.insert(entry.key, entry.value);
+            }
         }
 
         Ok(HashedPostState { accounts, storages })
     }
 }
 
-impl<P, F> NestedStateRoot<P, F>
+impl<Tx, F> NestedStateRoot<Tx, F>
 where
-    P: DBProvider<Tx: DbTx>,
-    F: Fn() -> ProviderResult<P> + Send + Sync,
+    Tx: DbTx,
+    F: Fn() -> ProviderResult<Tx> + Send + Sync,
 {
     /// Calculate the root hash of nested trie
     pub fn calculate(
@@ -159,107 +195,14 @@ where
                     continue;
                 }
                 handles.push(scope.spawn(|| -> ProviderResult<()> {
+                    let tx = (self.provider)()?;
                     let index = (partition[0].0[0] >> 4) as usize;
                     let mut updated_account_nodes = updated_account_nodes[index].lock().unwrap();
                     for (hashed_address, account) in partition {
                         let hashed_address = *hashed_address;
                         let account = *account;
                         let path = Nibbles::unpack(hashed_address);
-                        if let Some(account) = account {
-                            let storage = hashed_storages.get(&hashed_address).cloned();
-                            if account.get_bytecode_hash() == KECCAK256_EMPTY &&
-                                storage.as_ref().map(|s| s.is_empty()).unwrap_or(true)
-                            {
-                                let account = account.into_trie_account(EMPTY_ROOT_HASH);
-                                let node = Some(Node::ValueNode(alloy_rlp::encode(account)));
-                                updated_account_nodes.push((path, node));
-                            } else {
-                                let mut updated_storage_nodes: [Vec<(Nibbles, Option<Node>)>; 16] =
-                                    Default::default();
-                                let create_reader = || {
-                                    let cursor = (self.provider)()?
-                                        .tx_ref()
-                                        .cursor_dup_read::<tables::StoragesTrieV2>()?;
-                                    Ok(StorageTrieReader::new(
-                                        cursor,
-                                        hashed_address,
-                                        self.cache.clone(),
-                                    ))
-                                };
-
-                                let cursor = (self.provider)()?
-                                    .tx_ref()
-                                    .cursor_dup_read::<tables::StoragesTrieV2>()?;
-                                let trie_reader = StorageTrieReader::new(
-                                    cursor,
-                                    hashed_address,
-                                    self.cache.clone(),
-                                );
-                                // only make the large storage trie parallel
-                                let parallel = storage
-                                    .as_ref()
-                                    .map(|s| s.storage.len() > 256)
-                                    .unwrap_or(false);
-                                let mut storage_trie =
-                                    Trie::new(trie_reader, parallel, compatible)?;
-                                if let Some(storage) = storage {
-                                    for (hashed_slot, value) in storage.storage {
-                                        let nibbles = Nibbles::unpack(hashed_slot);
-                                        let index = nibbles.get_unchecked(0) as usize;
-                                        let value = if value.is_zero() {
-                                            None
-                                        } else {
-                                            let value = encode_fixed_size(&value);
-                                            Some(Node::ValueNode(value.to_vec()))
-                                        };
-                                        updated_storage_nodes[index].push((nibbles, value));
-                                    }
-                                }
-                                storage_trie
-                                    .parallel_update(updated_storage_nodes, create_reader)?;
-                                let account = account.into_trie_account(storage_trie.hash());
-                                updated_account_nodes.push((
-                                    path,
-                                    Some(Node::ValueNode(alloy_rlp::encode(account))),
-                                ));
-
-                                let (trie_output, compatible_output) = storage_trie.take_output();
-                                if !trie_output.is_empty() {
-                                    assert!(trie_update
-                                        .lock()
-                                        .unwrap()
-                                        .storage_tries
-                                        .insert(
-                                            hashed_address,
-                                            StorageTrieUpdatesV2 {
-                                                is_deleted: false,
-                                                storage_nodes: trie_output.update_nodes,
-                                                removed_nodes: trie_output.removed_nodes,
-                                            }
-                                        )
-                                        .is_none());
-                                }
-                                if let Some(compatible) = compatible_trie_update.as_ref() {
-                                    let compatible_output = compatible_output.unwrap();
-                                    if !compatible_output.is_empty() {
-                                        assert!(compatible
-                                            .lock()
-                                            .unwrap()
-                                            .storage_tries
-                                            .insert(
-                                                hashed_address,
-                                                StorageTrieUpdates {
-                                                    is_deleted: false,
-                                                    storage_nodes: compatible_output.update_nodes,
-                                                    removed_nodes: compatible_output.removed_nodes,
-                                                }
-                                            )
-                                            .is_none());
-                                    }
-                                }
-                            }
-                        } else {
-                            updated_account_nodes.push((path, None));
+                        let deleted_storage = || {
                             trie_update
                                 .lock()
                                 .unwrap()
@@ -272,6 +215,93 @@ where
                                     .storage_tries
                                     .insert(hashed_address, StorageTrieUpdates::deleted());
                             }
+                        };
+                        if let Some(account) = account {
+                            let storage = hashed_storages.get(&hashed_address).cloned();
+                            if let Some(storage) = &storage {
+                                if storage.wiped {
+                                    let account = account.into_trie_account(EMPTY_ROOT_HASH);
+                                    let node = Some(Node::ValueNode(alloy_rlp::encode(account)));
+                                    updated_account_nodes.push((path, node));
+                                    deleted_storage();
+                                    continue;
+                                }
+                            }
+
+                            let mut updated_storage_nodes: [Vec<(Nibbles, Option<Node>)>; 16] =
+                                Default::default();
+                            let create_reader = || {
+                                let cursor = (self.provider)()?
+                                    .cursor_dup_read::<tables::StoragesTrieV2>()?;
+                                Ok(StorageTrieReader::new(
+                                    cursor,
+                                    hashed_address,
+                                    self.cache.clone(),
+                                ))
+                            };
+
+                            let cursor = tx.cursor_dup_read::<tables::StoragesTrieV2>()?;
+                            let trie_reader =
+                                StorageTrieReader::new(cursor, hashed_address, self.cache.clone());
+                            // only make the large storage trie parallel
+                            let parallel =
+                                storage.as_ref().map(|s| s.storage.len() > 256).unwrap_or(false);
+                            let mut storage_trie = Trie::new(trie_reader, parallel, compatible)?;
+                            if let Some(storage) = storage {
+                                for (hashed_slot, value) in storage.storage {
+                                    let nibbles = Nibbles::unpack(hashed_slot);
+                                    let index = nibbles.get_unchecked(0) as usize;
+                                    let value = if value.is_zero() {
+                                        None
+                                    } else {
+                                        let value = encode_fixed_size(&value);
+                                        Some(Node::ValueNode(value.to_vec()))
+                                    };
+                                    updated_storage_nodes[index].push((nibbles, value));
+                                }
+                            }
+                            storage_trie.parallel_update(updated_storage_nodes, create_reader)?;
+                            let account = account.into_trie_account(storage_trie.hash());
+                            updated_account_nodes
+                                .push((path, Some(Node::ValueNode(alloy_rlp::encode(account)))));
+
+                            let (trie_output, compatible_output) = storage_trie.take_output();
+                            if !trie_output.is_empty() {
+                                assert!(trie_update
+                                    .lock()
+                                    .unwrap()
+                                    .storage_tries
+                                    .insert(
+                                        hashed_address,
+                                        StorageTrieUpdatesV2 {
+                                            is_deleted: false,
+                                            storage_nodes: trie_output.update_nodes,
+                                            removed_nodes: trie_output.removed_nodes,
+                                        }
+                                    )
+                                    .is_none());
+                            }
+                            if let Some(compatible) = compatible_trie_update.as_ref() {
+                                let compatible_output = compatible_output.unwrap();
+                                if !compatible_output.is_empty() {
+                                    assert!(compatible
+                                        .lock()
+                                        .unwrap()
+                                        .storage_tries
+                                        .insert(
+                                            hashed_address,
+                                            StorageTrieUpdates {
+                                                is_deleted: false,
+                                                storage_nodes: compatible_output.update_nodes,
+                                                removed_nodes: compatible_output.removed_nodes,
+                                            }
+                                        )
+                                        .is_none());
+                                }
+                            }
+                        } else {
+                            updated_account_nodes.push((path, None));
+                            deleted_storage();
                         }
                     }
                     Ok(())
@@ -287,10 +317,10 @@ where
         let mut trie_update = trie_update.into_inner().unwrap();
         let mut compatible_trie_update = compatible_trie_update.map(|c| c.into_inner().unwrap());
         let create_reader = || {
-            let cursor = (self.provider)()?.tx_ref().cursor_read::<tables::AccountsTrieV2>()?;
+            let cursor = (self.provider)()?.cursor_read::<tables::AccountsTrieV2>()?;
             Ok(AccountTrieReader(cursor, self.cache.clone()))
         };
-        let cursor = (self.provider)()?.tx_ref().cursor_read::<tables::AccountsTrieV2>()?;
+        let cursor = (self.provider)()?.cursor_read::<tables::AccountsTrieV2>()?;
         let mut account_trie =
             Trie::new(AccountTrieReader(cursor, self.cache.clone()), true, compatible)?;
         account_trie.parallel_update(updated_account_nodes, create_reader)?;
@@ -357,7 +387,7 @@ mod tests {
     }
 
     impl TrieWriterV2 for InmemoryTrieDB {
-        fn write(&self, input: &TrieUpdatesV2) -> Result<usize, DatabaseError> {
+        fn write_trie_updatesv2(&self, input: &TrieUpdatesV2) -> Result<usize, DatabaseError> {
             let mut account_trie = self.account_trie.lock().unwrap();
             let mut storage_trie = self.storage_trie.lock().unwrap();
             let mut num_update = 0;
@@ -523,11 +553,11 @@ mod tests {
         assert_eq!(state_root1, test_utils::state_root(state1.clone()));
 
         // write into db
-        let _ = db.write(&trie_input1).unwrap();
+        let _ = db.write_trie_updatesv2(&trie_input1).unwrap();
         let state2 = random_state();
         let (state_root2, trie_input2) = calculate(state2.clone(), db.clone(), true);
         let state_merged = merge_state(state1.clone(), state2.clone());
-        let _ = db.write(&trie_input2).unwrap();
+        let _ = db.write_trie_updatesv2(&trie_input2).unwrap();
 
         // compare state root
         assert_eq!(state_root2, test_utils::state_root(state_merged.clone()));
@@ -539,11 +569,11 @@ mod tests {
         if state_merged.len() == state1.len() + state2.len() {
             let (delete_root1, delete_input1) = calculate(state2, db.clone(), false);
             assert_eq!(delete_root1, state_root1);
-            let _ = db.write(&delete_input1).unwrap();
+            let _ = db.write_trie_updatesv2(&delete_input1).unwrap();
             let (delete_root2, delete_input2) = calculate(state1, db.clone(), false);
             // has deleted all data, so the state root is EMPTY_ROOT_HASH
             assert_eq!(delete_root2, EMPTY_ROOT_HASH);
-            let _ = db.write(&delete_input2).unwrap();
+            let _ = db.write_trie_updatesv2(&delete_input2).unwrap();
             assert!(db.account_trie.lock().unwrap().is_empty());
             assert!(db.storage_trie.lock().unwrap().is_empty());
         }
@@ -554,7 +584,7 @@ mod tests {
         let state = random_state();
         // test paralle root hash
         let factory = create_test_provider_factory();
-        let provider = || factory.database_provider_ro();
+        let provider = || factory.database_provider_ro().map(|db| db.into_tx());
         let mut hashed_state = HashedPostState::default();
         for (address, (account, storage)) in state.clone() {
             let hashed_address = keccak256(address);


### PR DESCRIPTION
## Fix Bugs
1. The storage of a contract account may be all wiped, but the account may not be self-destructed.
2. An account with bytecode hash equals `KECCAK256_EMPTY` may have storage slots

 ## Remaining Works
1. An EOA may have storage slots, database must be read for confirmation, making it impossible to achieve a 100% cache hit rate (currently<85%)
2. Unwind stage depends on `tables::HashedAccounts` and `tables::HashedStorages`. This is the underlying principle design of Unwind, still unable to delete these two tables.