### PR TITLE
perf(state_root): compact trie node serialization and remove comptiable trie updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6093bc69509849435a2d68237a2e9fea79d27390c8e62f1e4012c460aabad8"
+checksum = "eda689f7287f15bd3582daba6be8d1545bad3740fd1fb778f629a1fe866bb43b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1cfed4fefd13b5620cb81cdb6ba397866ff0de514c1b24806e6e79cdff5570"
+checksum = "2b5659581e41e8fe350ecc3593cb5c9dcffddfd550896390f2b78a07af67b0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28074a21cd4f7c3a7ab218c4f38fae6be73944e1feae3b670c68b60bf85ca40"
+checksum = "944085cf3ac8f32d96299aa26c03db7c8ca6cdaafdbc467910b889f0328e6b70"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5937e2d544e9b71000942d875cbc57965b32859a666ea543cc57aae5a06d602d"
+checksum = "6f35887da30b5fc50267109a3c61cd63e6ca1f45967983641053a40ee83468c1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51b4c13e02a8104170a4de02ccf006d7c233e6c10ab290ee16e7041e6ac221d"
+checksum = "11d4009efea6f403b3a80531f9c6f70fc242399498ff71196a1688cc1c901f44"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819a3620fe125e0fff365363315ee5e24c23169173b19747dfd6deba33db8990"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b590caa6b6d8bc10e6e7a7696c59b1e550e89f27f50d1ee13071150d3a3e3f66"
+checksum = "883dee3b4020fcb5667ee627b4f401e899dad82bf37b246620339dd980720ed9"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36fe5af1fca03277daa56ad4ce5f6d623d3f4c2273ea30b9ee8674d18cefc1fa"
+checksum = "cd6e5b8ac1654a05c224390008e43634a2bdc74e181e02cf8ed591d8b3d4ad08"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793df1e3457573877fbde8872e4906638fde565ee2d3bd16d04aad17d43dbf0e"
+checksum = "80d7980333dd9391719756ac28bc2afa9baa705fc70ffd11dc86ab078dd64477"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2090f21bb6df43e147d976e754bc9a007ca851badbfc6685377aa679b5f151d9"
+checksum = "3417f4187eaf7f7fb0d7556f0197bca26f0b23c4bb3aca0c9d566dc1c5d727a2"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -413,7 +413,7 @@ dependencies = [
  "derive_more",
  "foldhash",
  "getrandom 0.3.3",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "itoa",
  "k256",
@@ -421,7 +421,7 @@ dependencies = [
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59879a772ebdcde9dc4eb38b2535d32e8503d3175687cc09e763a625c5fcf32"
+checksum = "478a42fe167057b7b919cd8b0c2844f0247f667473340dad100eaf969de5754e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -461,7 +461,6 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "http",
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
@@ -477,13 +476,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdfb2899b54b7cb0063fa8e61938320f9be6b81b681be69c203abf130a87baa"
+checksum = "b0a99b17987f40a066b29b6b56d75e84cd193b866cac27cae17b59f40338de95"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
+ "auto_impl",
  "bimap",
  "futures",
  "parking_lot",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f060e3bb9f319eb01867a2d6d1ff9e0114e8877f5ca8f5db447724136106cae"
+checksum = "8a0c6d723fbdf4a87454e2e3a275e161be27edcfbf46e2e3255dd66c138634b6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47b637369245d2dafef84b223b1ff5ea59e6cd3a98d2d3516e32788a0b216df"
+checksum = "c41492dac39365b86a954de86c47ec23dcc7452cdb2fde591caadc194b3e34c6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db29bf8f7c961533b017f383122cab6517c8da95712cf832e23c60415d520a58"
+checksum = "9c0f415ad97cc68d2f49eb08214f45c6827a6932a69773594f4ce178f8a41dc0"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b1f499acb3fc729615147bc113b8b798b17379f19d43058a687edc5792c102"
+checksum = "10493fa300a2757d8134f584800fef545c15905c95122bed1f6dde0b0d9dae27"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e26b4dd90b33bd158975307fb9cf5fafa737a0e33cbb772a8648bf8be13c104"
+checksum = "8f7eb22670a972ad6c222a6c6dac3eef905579acffe9d63ab42be24c7d158535"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9196cbbf4b82a3cc0c471a8e68ccb30102170d930948ac940d2bceadc1b1346b"
+checksum = "53381ffba0110a8aed4c9f108ef34a382ed21aeefb5f50f91c73451ae68b89aa"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -612,19 +612,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71841e6fc8e221892035a74f7d5b279c0a2bf27a7e1c93e7476c64ce9056624e"
+checksum = "a9b6f0482c82310366ec3dcf4e5212242f256a69fcf1a26e5017e6704091ee95"
 dependencies = [
  "alloy-primitives",
+ "derive_more",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f9cbf5f781b9ee39cfdddea078fdef6015424f4c8282ef0e5416d15ca352c4"
+checksum = "e24c171377c0684e3860385f6d93fbfcc8ecc74f6cce8304c822bf1a50bacce0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -643,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46586ec3c278639fc0e129f0eb73dbfa3d57f683c44b2ff5e066fab7ba63fa1f"
+checksum = "b777b98526bbe5b7892ca22a7fd5f18ed624ff664a79f40d0f9f2bf94ba79a84"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -665,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b6e80b501842c3f5803dd5752ae41b61f43bf6d2e1b8d29999d3312d67a8a5"
+checksum = "c15e8ccb6c16e196fcc968e16a71cd8ce4160f3ec5871d2ea196b75bf569ac02"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -680,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9a2184493c374ca1dbba9569d37215c23e489970f8c3994f731cb3ed6b0b7d"
+checksum = "d6a854af3fe8fce1cfe319fcf84ee8ba8cda352b14d3dd4221405b5fc6cce9e1"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -694,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aaf142f4f6c0bdd06839c422179bae135024407d731e6f365380f88cd4730e"
+checksum = "3cc803e9b8d16154c856a738c376e002abe4b388e5fef91c8aebc8373e99fd45"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -706,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1722bc30feef87cc0fa824e43c9013f9639cc6c037be7be28a31361c788be2"
+checksum = "ee8d2c52adebf3e6494976c8542fbdf12f10123b26e11ad56f77274c16a2a039"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -718,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3674beb29e68fbbc7be302b611cf35fe07b736e308012a280861df5a2361395"
+checksum = "7c0494d1e0f802716480aabbe25549c7f6bc2a25ff33b08fd332bbb4b7d06894"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -733,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7094c39cd41b03ed642145b0bd37251e31a9cf2ed19e1ce761f089867356a6"
+checksum = "59c2435eb8979a020763ced3fb478932071c56e5f75ea86db41f320915d325ba"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -821,12 +822,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89bec2f59a41c0e259b6fe92f78dfc49862c17d10f938db9c33150d5a7f42b6"
+checksum = "3c0107675e10c7f248bf7273c1e7fdb02409a717269cc744012e6f3c39959bfb"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
+ "auto_impl",
  "base64 0.22.1",
  "derive_more",
  "futures",
@@ -844,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3615ec64d775fec840f4e9d5c8e1f739eb1854d8d28db093fb3d4805e0cb53"
+checksum = "78e3736701b5433afd06eecff08f0688a71a10e0e1352e0bbf0bed72f0dd4e35"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -859,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374db72669d8ee09063b9aa1a316e812d5cdfce7fc9a99a3eceaa0e5512300d2"
+checksum = "c79064b5a08259581cb5614580010007c2df6deab1e8f3e8c7af8d7e9227008f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -879,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dbaa6851875d59c8803088f4b6ec72eaeddf7667547ae8995c1a19fbca6303"
+checksum = "77fd607158cb9bc54cbcfcaab4c5f36c5b26994c7dc58b6f095ce27a54f270f3"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -917,12 +919,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f916ff6d52f219c44a9684aea764ce2c7e1d53bd4a724c9b127863aeacc30bb"
+checksum = "6acb36318dfa50817154064fea7932adf2eec3f51c86680e2b37d7e8906c66bb"
 dependencies = [
  "alloy-primitives",
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -951,9 +953,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -981,22 +983,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1065,7 +1067,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -1211,7 +1213,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1480,9 +1482,9 @@ checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
 dependencies = [
  "fastrand 2.3.0",
  "tokio",
@@ -1744,7 +1746,7 @@ dependencies = [
  "cfg-if",
  "dashmap 6.1.0",
  "fast-float2",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "icu_normalizer 1.5.0",
  "indexmap 2.10.0",
  "intrusive-collections",
@@ -1779,7 +1781,7 @@ dependencies = [
  "boa_macros",
  "boa_profiler",
  "boa_string",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "thin-vec",
 ]
 
@@ -1791,7 +1793,7 @@ checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "once_cell",
  "phf",
@@ -1920,18 +1922,18 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1971,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
 dependencies = [
  "serde",
 ]
@@ -2138,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2148,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2304,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2651,8 +2653,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
+dependencies = [
+ "darling_core 0.21.1",
+ "darling_macro 0.21.1",
 ]
 
 [[package]]
@@ -2670,12 +2682,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
+dependencies = [
+ "darling_core 0.21.1",
  "quote",
  "syn 2.0.104",
 ]
@@ -2785,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2820,7 +2857,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -2912,7 +2949,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.2",
  "windows-sys 0.60.2",
 ]
 
@@ -2953,7 +2990,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -2985,9 +3022,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -3233,7 +3270,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd55d08012b4e0dfcc92b8d6081234df65f2986ad34cc76eeed69c5e2ce7506"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -4153,7 +4190,7 @@ dependencies = [
  "metrics",
  "metrics-derive",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "revm",
  "revm-context",
@@ -4176,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4232,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -4307,7 +4344,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "serde",
  "thiserror 2.0.12",
@@ -4330,7 +4367,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -4493,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4509,7 +4546,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -4527,7 +4564,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4561,7 +4598,7 @@ dependencies = [
  "potential_utf",
  "yoke 0.8.0",
  "zerofrom",
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -4574,7 +4611,7 @@ dependencies = [
  "litemap 0.8.0",
  "tinystr 0.8.1",
  "writeable 0.6.1",
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -4640,7 +4677,7 @@ dependencies = [
  "icu_properties 2.0.1",
  "icu_provider 2.0.0",
  "smallvec",
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -4683,7 +4720,7 @@ dependencies = [
  "icu_provider 2.0.0",
  "potential_utf",
  "zerotrie",
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -4729,7 +4766,7 @@ dependencies = [
  "yoke 0.8.0",
  "zerofrom",
  "zerotrie",
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -4821,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -4844,7 +4881,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -4896,7 +4933,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -4938,9 +4975,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -4953,7 +4990,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -5126,7 +5163,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -5339,7 +5376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5380,9 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -5523,7 +5560,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5532,7 +5569,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5679,12 +5716,12 @@ checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "metrics",
  "ordered-float",
  "quanta",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -5866,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.9.1",
  "fsevent-sys",
@@ -6077,9 +6114,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.18.12"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda4af86c3185b06f8d70986a591c087f054c5217cc7ce53cd0ec36dc42d7425"
+checksum = "0c88d2940558fd69f8f07b3cbd7bb3c02fc7d31159c1a7ba9deede50e7881024"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6103,9 +6140,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.18.12"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab526485e1aee4dbd929aaa431aaa9db8678c936ee7d1449760f783ae45afa01"
+checksum = "7071d7c3457d02aa0d35799cb8fbd93eabd51a21d100dcf411f4fcab6fdd2ea5"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6119,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.18.12"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f34feb6c3aef85c9ab9198f1402867030e54d13f6c66dda18235497ac808cb0"
+checksum = "327fc8be822ca7d4be006c69779853fa27e747cff4456a1c2ef521a68ac26432"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -6129,9 +6166,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.18.12"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98bfe0a4e1225930ffe288a9b3ce0d95c6fc2ee6696132e5ad7ecc7b0ee139a8"
+checksum = "f22201e53e8cbb67a053e88b534b4e7f02265c5406994bf35978482a9ad0ae26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6149,9 +6186,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.18.12"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a420102c1b857a4ba373fcaf674d5c0499fd3705ddce95be9a69f3561c337b3"
+checksum = "b2b4f977b51e9e177e69a4d241ab7c4b439df9a3a5a998c000ae01be724de271"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6286,7 +6323,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.12",
  "tracing",
@@ -6605,7 +6642,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -6635,9 +6672,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
@@ -6739,7 +6776,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -6846,7 +6883,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -6862,7 +6899,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -6883,7 +6920,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6936,9 +6973,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -7088,9 +7125,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -7108,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -7187,7 +7224,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "memchr",
 ]
 
@@ -7368,7 +7405,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -7518,7 +7555,7 @@ dependencies = [
  "eyre",
  "libc",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
@@ -7599,7 +7636,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
  "reth-ethereum-primitives",
@@ -7678,7 +7715,7 @@ dependencies = [
  "parity-scale-codec",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
@@ -7780,7 +7817,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
@@ -7804,7 +7841,7 @@ dependencies = [
  "hickory-resolver",
  "linked_hash_set",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-network-peers",
@@ -7834,7 +7871,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chainspec",
  "reth-config",
@@ -8050,7 +8087,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -8136,7 +8173,7 @@ dependencies = [
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "eyre",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest",
  "reth-era-downloader",
  "reth-ethereum-primitives",
@@ -8221,7 +8258,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-ecies",
  "reth-eth-wire-types",
@@ -8257,7 +8294,7 @@ dependencies = [
  "derive_more",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
@@ -8415,7 +8452,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
@@ -8506,7 +8543,7 @@ dependencies = [
  "arbitrary",
  "bincode 1.3.3",
  "derive_more",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
@@ -8528,7 +8565,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-config",
@@ -8599,7 +8636,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bincode 1.3.3",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-ethereum-primitives",
  "reth-execution-types",
@@ -8654,7 +8691,7 @@ dependencies = [
  "interprocess",
  "jsonrpsee",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-tracing",
  "serde",
  "serde_json",
@@ -8677,7 +8714,7 @@ dependencies = [
  "derive_more",
  "indexmap 2.10.0",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-mdbx-sys",
  "smallvec",
  "tempfile",
@@ -8746,7 +8783,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -8840,7 +8877,7 @@ dependencies = [
  "alloy-rlp",
  "enr",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "secp256k1 0.30.0",
  "serde_json",
  "serde_with",
@@ -8871,7 +8908,7 @@ dependencies = [
  "derive_more",
  "lz4_flex",
  "memmap2",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-fs-util",
  "serde",
  "tempfile",
@@ -8984,7 +9021,7 @@ dependencies = [
  "futures",
  "humantime",
  "proptest",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -9040,7 +9077,7 @@ dependencies = [
  "alloy-sol-types",
  "eyre",
  "futures",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chainspec",
  "reth-db",
  "reth-e2e-test-utils",
@@ -9137,7 +9174,7 @@ dependencies = [
  "reqwest",
  "reth-metrics",
  "reth-tasks",
- "socket2",
+ "socket2 0.5.10",
  "tikv-jemalloc-ctl",
  "tokio",
  "tower",
@@ -9450,7 +9487,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-zstd-compressors",
@@ -9654,7 +9691,7 @@ dependencies = [
  "gravity-storage",
  "metrics",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9730,7 +9767,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chainspec",
  "reth-codecs",
@@ -9760,7 +9797,7 @@ dependencies = [
  "metrics",
  "notify",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9946,7 +9983,7 @@ dependencies = [
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
@@ -10231,7 +10268,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -10307,7 +10344,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "paste",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reqwest",
  "reth-chainspec",
@@ -10342,8 +10379,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-testing-utils",
  "reth-tracing",
- "reth-trie",
- "reth-trie-db",
  "reth-trie-parallel",
  "serde",
  "tempfile",
@@ -10391,7 +10426,7 @@ dependencies = [
  "modular-bitfield",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-codecs",
  "reth-trie-common",
  "serde",
@@ -10482,6 +10517,7 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
+ "reth-tracing",
  "reth-trie-common",
  "reth-trie-db",
  "revm-bytecode",
@@ -10558,7 +10594,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "secp256k1 0.30.0",
@@ -10622,7 +10658,7 @@ dependencies = [
  "paste",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -10754,7 +10790,7 @@ dependencies = [
  "metrics",
  "proptest",
  "proptest-arbitrary-interop",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-db-api",
  "reth-execution-errors",
@@ -10788,7 +10824,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10817,7 +10853,7 @@ dependencies = [
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -11183,9 +11219,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -11201,7 +11237,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp",
  "ruint-macro",
  "serde",
@@ -11217,9 +11253,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -11288,9 +11324,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -11363,9 +11399,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -11490,7 +11526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.1",
+ "rand 0.9.2",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -11514,9 +11550,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation",
@@ -11605,9 +11641,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -11674,7 +11710,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -11792,9 +11828,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -11871,9 +11907,9 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -11918,6 +11954,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12111,13 +12157,12 @@ dependencies = [
 
 [[package]]
 name = "tar-no-std"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15574aa79d3c04a12f3cb53ff976d5571e53b9d8e0bdbe4021df0a06473dd1c9"
+checksum = "ac9ee8b664c9f1740cd813fea422116f8ba29997bb7c878d1940424889802897"
 dependencies = [
  "bitflags 2.9.1",
  "log",
- "memchr",
  "num-traits",
 ]
 
@@ -12169,9 +12214,9 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2f06b1ae65cbf4dc1f4975279cee7dbf70fcca269bdbdd8aabd20a79e6785c"
+checksum = "bb4eb3ad07d6df1b12c23bc2d034e35a80c25d2e1232d083b42c081fd01c1c63"
 dependencies = [
  "serde",
  "serde_combinators",
@@ -12182,9 +12227,9 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-internal"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6a1dc2074c20c6410ac75687be17808a22abfd449e28301a95d72974b91768"
+checksum = "53b853a8b27e0c335dd114f182fc808b917ced20dbc1bcdab79cc3e023b38762"
 dependencies = [
  "bincode 2.0.1",
  "cargo_metadata 0.19.2",
@@ -12193,11 +12238,11 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-macro"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190423aabaca6cec8392cf45e471777e036d424a14d979db8033f25cc417f1ad"
+checksum = "eb25760cf823885b202e5cc8ef8dc385e80ef913537656129ea8b34470280601"
 dependencies = [
- "darling",
+ "darling 0.21.1",
  "heck",
  "itertools 0.14.0",
  "prettyplease",
@@ -12208,9 +12253,9 @@ dependencies = [
 
 [[package]]
 name = "test-fuzz-runtime"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05723662ca81651b49dd87b50cae65a0a38523aa1c0cb6b049a8c4f5c2c7836"
+checksum = "c9b807e6d99cb6157a3f591ccf9f02187730a5774b9b1f066ff7dffba329495e"
 dependencies = [
  "hex",
  "num-traits",
@@ -12374,7 +12419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
- "zerovec 0.11.2",
+ "zerovec 0.11.4",
 ]
 
 [[package]]
@@ -12404,9 +12449,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -12417,9 +12462,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12474,9 +12519,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -12778,7 +12823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12800,7 +12845,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -12839,7 +12884,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -13324,7 +13369,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13594,7 +13639,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -13645,10 +13690,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -14071,9 +14117,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke 0.8.0",
  "zerofrom",

--- a/crates/gravity-primitives/src/config.rs
+++ b/crates/gravity-primitives/src/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
     pub disable_pipe_execution: bool,
     /// Whether to disable the Grevm executor. default true.
     pub disable_grevm: bool,
-    /// The gas limit for pipe block. default 1_000_000_000.
+    /// The gas limit for pipe block. default `1_000_000_000`.
     pub pipe_block_gas_limit: u64,
 }
 

--- a/crates/gravity-primitives/src/config.rs
+++ b/crates/gravity-primitives/src/config.rs
@@ -9,8 +9,6 @@ pub struct Config {
     pub disable_pipe_execution: bool,
     /// Whether to disable the Grevm executor. default true.
     pub disable_grevm: bool,
-    /// Whether compatible with trie output. default false.
-    pub compatible_trie_output: bool,
     /// The gas limit for pipe block. default 1_000_000_000.
     pub pipe_block_gas_limit: u64,
 }
@@ -20,10 +18,6 @@ pub static CONFIG: LazyLock<Config> = LazyLock::new(|| {
     let config = Config {
         disable_pipe_execution: std::env::var("GRETH_DISABLE_PIPE_EXECUTION").is_ok(),
         disable_grevm: std::env::var("GRETH_DISABLE_GREVM").is_ok(),
-        compatible_trie_output: std::env::var("GRETH_COMPATIBLE_TRIE_OUTPUT")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(false),
         pipe_block_gas_limit: std::env::var("GRETH_PIPE_BLOCK_GAS_LIMIT")
             .ok()
             .and_then(|v| v.parse().ok())

--- a/crates/gravity-storage/src/block_view_storage/mod.rs
+++ b/crates/gravity-storage/src/block_view_storage/mod.rs
@@ -10,10 +10,7 @@ use reth_revm::{
     state::AccountInfo, DatabaseRef,
 };
 use reth_storage_api::StateProviderFactory;
-use reth_trie::{
-    updates::{TrieUpdates, TrieUpdatesV2},
-    HashedPostState,
-};
+use reth_trie::{updates::TrieUpdatesV2, HashedPostState};
 use reth_trie_parallel::nested_hash::NestedStateRoot;
 use std::{collections::BTreeMap, sync::Mutex};
 
@@ -58,14 +55,10 @@ where
         Ok(BlockViewProvider::new(StateProviderDatabase::new(state), Some(self.cache.clone())))
     }
 
-    fn state_root(
-        &self,
-        hashed_state: &HashedPostState,
-        compatible: bool,
-    ) -> ProviderResult<(B256, TrieUpdatesV2, Option<TrieUpdates>)> {
+    fn state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<(B256, TrieUpdatesV2)> {
         let provider = || self.client.database_provider_ro().map(|db| db.into_tx());
         let nested_hash = NestedStateRoot::new(provider, Some(self.cache.clone()));
-        nested_hash.calculate(hashed_state, compatible)
+        nested_hash.calculate(hashed_state)
     }
 
     fn insert_block_id(&self, block_number: u64, block_id: B256) {

--- a/crates/gravity-storage/src/lib.rs
+++ b/crates/gravity-storage/src/lib.rs
@@ -6,10 +6,7 @@ pub mod block_view_storage;
 use alloy_primitives::B256;
 use reth_evm::ParallelDatabase;
 use reth_provider::ProviderResult;
-use reth_trie::{
-    updates::{TrieUpdates, TrieUpdatesV2},
-    HashedPostState,
-};
+use reth_trie::{updates::TrieUpdatesV2, HashedPostState};
 
 /// Gravity storage for pipeline execution
 pub trait GravityStorage: Send + Sync + 'static {
@@ -20,11 +17,7 @@ pub trait GravityStorage: Send + Sync + 'static {
     fn get_state_view(&self) -> ProviderResult<Self::StateView>;
 
     /// calculate state root
-    fn state_root(
-        &self,
-        hashed_state: &HashedPostState,
-        compatible: bool,
-    ) -> ProviderResult<(B256, TrieUpdatesV2, Option<TrieUpdates>)>;
+    fn state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<(B256, TrieUpdatesV2)>;
 
     /// Insert the mapping from `block_number` to `block_id`
     fn insert_block_id(&self, block_number: u64, block_id: B256);

--- a/crates/pipe-exec-layer-ext-v2/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/src/lib.rs
@@ -39,7 +39,6 @@ use tokio::sync::{
     oneshot, Mutex,
 };
 
-use gravity_primitives::CONFIG;
 use reth_revm::state::AccountInfo;
 use reth_trie::{HashedPostState, KeccakKeyHasher};
 use tracing::*;
@@ -267,8 +266,7 @@ impl<Storage: GravityStorage> Core<Storage> {
         // Merkling the state trie
         self.merklize_barrier.wait(block_number - 1).await.unwrap();
         let start_time = Instant::now();
-        let (state_root, trie_updates, compatible_trie_pudates) =
-            self.storage.state_root(&hashed_state, CONFIG.compatible_trie_output).unwrap();
+        let (state_root, trie_updates) = self.storage.state_root(&hashed_state).unwrap();
         let write_start = Instant::now();
         self.cache.write_trie_updates(&trie_updates, block_number);
         self.metrics.cache_trie_state.record(write_start.elapsed());
@@ -326,24 +324,14 @@ impl<Storage: GravityStorage> Core<Storage> {
         let prev_finish_commit_time =
             self.make_canonical_barrier.wait(block_number - 1).await.unwrap();
         let start_time = Instant::now();
-        let make_canonical = if let Some(compatible_trie_updates) = compatible_trie_pudates {
-            self.make_canonical(ExecutedBlockWithTrieUpdates::new(
-                Arc::new(RecoveredBlock::new_sealed(sealed_block, senders)),
-                Arc::new(execution_outcome),
-                Arc::new(hashed_state),
-                ExecutedTrieUpdates::Present(Arc::new(compatible_trie_updates)),
-                Arc::new(trie_updates),
-            ))
-        } else {
-            self.make_canonical(ExecutedBlockWithTrieUpdates::new(
-                Arc::new(RecoveredBlock::new_sealed(sealed_block, senders)),
-                Arc::new(execution_outcome),
-                Arc::new(hashed_state),
-                ExecutedTrieUpdates::empty(),
-                Arc::new(trie_updates),
-            ))
-        };
-        make_canonical.await;
+        self.make_canonical(ExecutedBlockWithTrieUpdates::new(
+            Arc::new(RecoveredBlock::new_sealed(sealed_block, senders)),
+            Arc::new(execution_outcome),
+            Arc::new(hashed_state),
+            ExecutedTrieUpdates::empty(),
+            Arc::new(trie_updates),
+        ))
+        .await;
         self.storage.update_canonical(block_number, block_hash);
         let elapsed = start_time.elapsed();
         info!(target: "PipeExecService.process",

--- a/crates/pipe-exec-layer-ext-v2/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/src/lib.rs
@@ -4,6 +4,7 @@ mod channel;
 mod metrics;
 
 use channel::Channel;
+use gravity_primitives::CONFIG;
 use metrics::PipeExecLayerMetrics;
 
 use alloy_consensus::{

--- a/crates/pipe-exec-layer-ext-v2/tests/pipe_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/tests/pipe_test.rs
@@ -141,7 +141,7 @@ async fn run_pipe(
     let nested_provider = || provider.database_provider_ro().map(|db| db.into_tx());
     let nested_hash = NestedStateRoot::new(nested_provider, None);
     let hashed_state = nested_hash.read_hashed_state(None).unwrap();
-    let (root_hash, trie_updates, _) = nested_hash.calculate(&hashed_state, false).unwrap();
+    let (root_hash, trie_updates) = nested_hash.calculate(&hashed_state).unwrap();
     let trie_write = provider.database_provider_rw().unwrap();
     trie_write.write_trie_updatesv2(&trie_updates).unwrap();
     UnifiedStorageWriter::commit_unwind(trie_write)?;

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -37,7 +37,6 @@ reth-storage-errors.workspace = true
 reth-revm.workspace = true
 reth-stages-api.workspace = true
 reth-static-file-types.workspace = true
-reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-parallel = { workspace = true, optional = true }
 
 reth-testing-utils = { workspace = true, optional = true }
@@ -80,11 +79,9 @@ reth-revm.workspace = true
 reth-static-file.workspace = true
 reth-stages-api = { workspace = true, features = ["test-utils"] }
 reth-testing-utils.workspace = true
-reth-trie = { workspace = true, features = ["test-utils"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-network-peers.workspace = true
 reth-tracing.workspace = true
-reth-trie-db.workspace = true
 
 alloy-primitives = { workspace = true, features = ["getrandom", "rand"] }
 alloy-rlp.workspace = true
@@ -117,9 +114,7 @@ test-utils = [
     "reth-revm/test-utils",
     "reth-codecs/test-utils",
     "reth-db-api/test-utils",
-    "reth-trie-db/test-utils",
     "reth-trie-parallel/test-utils",
-    "reth-trie/test-utils",
     "reth-prune-types/test-utils",
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",

--- a/crates/stages/stages/src/stages/execution.rs
+++ b/crates/stages/stages/src/stages/execution.rs
@@ -14,7 +14,6 @@ use reth_provider::{
     BlockHashReader, BlockReader, DBProvider, ExecutionOutcome, HeaderProvider,
     LatestStateProviderRef, OriginalValuesKnown, ProviderError, StateCommitmentProvider,
     StateWriter, StaticFileProviderFactory, StatsReader, StorageLocation, TransactionVariant,
-    EXECUTION_MERKLE_CHANNEL,
 };
 use reth_revm::database::StateProviderDatabase;
 use reth_stages_api::{
@@ -23,7 +22,6 @@ use reth_stages_api::{
     StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
-use reth_trie::{HashedPostState, KeccakKeyHasher};
 use std::{
     cmp::Ordering,
     ops::RangeInclusive,
@@ -458,9 +456,6 @@ where
 
         // write output
         provider.write_state(&state, OriginalValuesKnown::Yes, StorageLocation::StaticFiles)?;
-        let hashed_state =
-            HashedPostState::from_bundle_state::<KeccakKeyHasher>(&state.bundle.state);
-        EXECUTION_MERKLE_CHANNEL.send(start_block, hashed_state);
 
         let db_write_duration = time.elapsed();
         debug!(

--- a/crates/stages/stages/src/stages/merkle.rs
+++ b/crates/stages/stages/src/stages/merkle.rs
@@ -8,8 +8,8 @@ use reth_db_api::{
 };
 use reth_primitives_traits::{GotExpected, SealedHeader};
 use reth_provider::{
-    DBProvider, HeaderProvider, ProviderError, StageCheckpointReader, StageCheckpointWriter,
-    StatsReader, TrieWriter, TrieWriterV2, EXECUTION_MERKLE_CHANNEL,
+    DBProvider, HeaderProvider, PersistBlockCache, ProviderError, StageCheckpointReader,
+    StageCheckpointWriter, StatsReader, TrieWriter, TrieWriterV2, PERSIST_BLOCK_CACHE,
 };
 use reth_stages_api::{
     BlockErrorKind, BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput,
@@ -185,7 +185,7 @@ where
         }
 
         let range = input.next_block_range();
-        let (from_block, to_block) = range.clone().into_inner();
+        let (_from_block, to_block) = range.clone().into_inner();
         let current_block_number = input.checkpoint().block_number;
 
         let target_block = provider
@@ -197,16 +197,16 @@ where
             (target_block_root, input.checkpoint().entities_stage_checkpoint().unwrap_or_default())
         } else {
             debug!(target: "sync::stages::merkle::exec", current = ?current_block_number, target = ?to_block, "Updating trie in chunks");
+            let cache: PersistBlockCache = PERSIST_BLOCK_CACHE.clone();
             // Use optimized nested hash algorithm for state root calculation
-            let nested_state_root = NestedStateRoot::new(
-                || provider_ro().map(|db| db.into_tx()),
-                None, // No cache for history sync
-            );
+            let nested_state_root =
+                NestedStateRoot::new(|| provider_ro().map(|db| db.into_tx()), Some(cache.clone()));
             // Read the hashed state from database for the specified range
-            let hashed_state = EXECUTION_MERKLE_CHANNEL.consume(from_block);
-            let (final_root, trie_updates_v2, _compatible_updates) =
-                nested_state_root.calculate(&hashed_state, false)?;
+            let hashed_state = nested_state_root.read_hashed_state(Some(range))?;
+            let (final_root, trie_updates_v2) = nested_state_root.calculate(&hashed_state)?;
+            cache.write_trie_updates(&trie_updates_v2, to_block);
             provider.write_trie_updatesv2(&trie_updates_v2)?;
+            cache.persist_tip(to_block);
 
             let total_hashed_entries = (provider.count_entries::<tables::HashedAccounts>()? +
                 provider.count_entries::<tables::HashedStorages>()?)
@@ -278,8 +278,7 @@ where
             let nested_state_root =
                 NestedStateRoot::new(|| provider_ro().map(|db| db.into_tx()), None);
             let hashed_state = nested_state_root.read_hashed_state(Some(range))?;
-            let (block_root, trie_updates_v2, _compatible_updates) =
-                nested_state_root.calculate(&hashed_state, false)?;
+            let (block_root, trie_updates_v2) = nested_state_root.calculate(&hashed_state)?;
 
             // Validate the calculated state root
             let target = provider

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -329,7 +329,7 @@ where
     }
     let hashed_state = HashedPostState { accounts, storages };
     let nested_hash = NestedStateRoot::new(provider, None);
-    let (root_hash, trie_updates, _) = nested_hash.calculate(&hashed_state, false)?;
+    let (root_hash, trie_updates) = nested_hash.calculate(&hashed_state)?;
 
     writer.write_trie_updatesv2(&trie_updates)?;
     info!(target: "reth::cli",

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     providers::{StaticFileProvider, StaticFileWriter as SfWriter},
     BlockExecutionWriter, BlockWriter, HistoryWriter, StateWriter, StaticFileProviderFactory,
-    StorageLocation, TrieWriter, TrieWriterV2, PERSIST_BLOCK_CACHE,
+    StorageLocation, TrieWriter, TrieWriterV2,
 };
 use alloy_consensus::BlockHeader;
 use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
@@ -167,7 +167,6 @@ where
             triev2,
         } in blocks
         {
-            let block_number = recovered_block.number();
             let block_hash = recovered_block.hash();
 
             #[cfg(not(feature = "pipe_test"))]
@@ -188,7 +187,6 @@ where
                 trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(block_hash))?,
             )?;
             let _ = self.database().write_trie_updatesv2(triev2.as_ref())?;
-            PERSIST_BLOCK_CACHE.persist_tip(block_number);
         }
 
         // update history indices

--- a/crates/storage/storage-api/Cargo.toml
+++ b/crates/storage/storage-api/Cargo.toml
@@ -40,6 +40,7 @@ metrics.workspace = true
 metrics-derive.workspace = true
 once_cell.workspace = true
 rayon.workspace = true
+reth-tracing.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/storage/storage-api/src/cache.rs
+++ b/crates/storage/storage-api/src/cache.rs
@@ -10,9 +10,14 @@ use metrics_derive::Metrics;
 use once_cell::sync::Lazy;
 use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use reth_primitives_traits::Account;
-use reth_trie_common::{nested_trie::Node, updates::TrieUpdatesV2, HashedPostState, Nibbles};
+use reth_tracing::tracing::info;
+use reth_trie_common::{
+    nested_trie::{Node, StoredNode},
+    updates::TrieUpdatesV2,
+    Nibbles,
+};
 use revm_bytecode::Bytecode;
-use revm_database::{states::StorageSlot, BundleAccount, OriginalValuesKnown};
+use revm_database::{BundleAccount, OriginalValuesKnown};
 use std::{
     sync::{Arc, Condvar, Mutex},
     thread::{self, JoinHandle},
@@ -119,8 +124,8 @@ pub struct PersistBlockCacheInner {
     accounts: DashMap<Address, ValueWithTip<Account>>,
     storage: DashMap<Address, DashMap<U256, ValueWithTip<U256>>>,
     contracts: DashMap<B256, ValueWithTip<Bytecode>>,
-    account_trie: DashMap<Nibbles, ValueWithTip<Node>>,
-    storage_trie: DashMap<B256, DashMap<Nibbles, ValueWithTip<Node>>>,
+    account_trie: DashMap<Nibbles, ValueWithTip<StoredNode>>,
+    storage_trie: DashMap<B256, DashMap<Nibbles, ValueWithTip<StoredNode>>>,
     merged_block_number: Mutex<Option<u64>>,
     persist_block_number: Mutex<Option<u64>>,
     metrics: CacheMetricsReporter,
@@ -198,6 +203,7 @@ impl PersistBlockCache {
                         let persist_height =
                             inner.persist_block_number.lock().unwrap().unwrap_or(0);
                         let mut max_height = 512;
+                        info!("Start to clean contrancts in cache");
                         while inner.contracts.len() > CACHE_CONTRACTS_THRESHOLD {
                             let eviction_height = persist_height.saturating_sub(max_height);
                             if eviction_height == 0 || eviction_height == persist_height {
@@ -206,6 +212,10 @@ impl PersistBlockCache {
                             inner.contracts.retain(|_, v| v.block_number > eviction_height);
                             max_height /= 2;
                         }
+                        info!(
+                            "Cleaned contracts in cache, current size: {}",
+                            inner.contracts.len()
+                        );
                         last_eviction_contract = Instant::now();
                     }
                     // check and eviction account and trie state
@@ -213,6 +223,7 @@ impl PersistBlockCache {
                         let persist_height =
                             inner.persist_block_number.lock().unwrap().unwrap_or(0);
                         if last_eviction_time.elapsed() >= eviction_interval && persist_height > 0 {
+                            info!("Start to clean states in cache");
                             overflow = true;
                             let eviction_height = if last_eviction_height == 0 {
                                 persist_height.saturating_sub(512).max(persist_height / 2)
@@ -234,6 +245,7 @@ impl PersistBlockCache {
                                 .metrics
                                 .eviction_block_number
                                 .store(eviction_height, Ordering::Relaxed);
+                            info!("Cleaned states in cache, eviction_height: {}", eviction_height);
                         }
                     } else if overflow {
                         overflow = false;
@@ -356,7 +368,7 @@ impl PersistBlockCache {
     pub fn trie_account(&self, nibbles: &Nibbles) -> Option<Node> {
         if let Some(value) = self.account_trie.get(nibbles) {
             self.metrics.trie_cache_hit_record.hit();
-            Some(value.value.clone())
+            Some(value.value.clone().into())
         } else {
             self.metrics.trie_cache_hit_record.not_hit();
             None
@@ -368,7 +380,7 @@ impl PersistBlockCache {
         if let Some(storage) = self.storage_trie.get(hash_address) {
             if let Some(value) = storage.get(nibbles) {
                 self.metrics.trie_cache_hit_record.hit();
-                Some(value.value.clone())
+                Some(value.value.clone().into())
             } else {
                 self.metrics.trie_cache_hit_record.not_hit();
                 None
@@ -384,13 +396,7 @@ impl PersistBlockCache {
         self.metrics.persist_block_number.store(block_number, Ordering::Relaxed);
         let mut guard = self.persist_block_number.lock().unwrap();
         if let Some(ref mut persist_block_number) = *guard {
-            assert_eq!(
-                block_number,
-                *persist_block_number + 1,
-                "Persist uncontinuous block, expect: {}, actual: {}",
-                *persist_block_number + 1,
-                block_number
-            );
+            assert!(block_number > *persist_block_number);
             *persist_block_number = block_number;
         } else {
             *guard = Some(block_number);
@@ -452,8 +458,11 @@ impl PersistBlockCache {
             if was_destroyed {
                 self.storage.remove(address);
             }
-            let write_slot = |kv: (U256, StorageSlot)| {
-                let (slot, slot_value) = kv;
+
+            // Append storage changes
+            // Note: Assumption is that revert is going to remove whole plain storage from
+            // database so we can check if plain state was wiped or not.
+            for (slot, slot_value) in account.storage.iter().map(|(k, v)| (*k, *v)) {
                 // If storage was destroyed that means that storage was wiped.
                 // In that case we need to check if present storage value is different then ZERO.
                 let destroyed_and_not_zero = was_destroyed && !slot_value.present_value.is_zero();
@@ -487,17 +496,6 @@ impl PersistBlockCache {
                         }
                     }
                 }
-            };
-
-            // Append storage changes
-            // Note: Assumption is that revert is going to remove whole plain storage from
-            // database so we can check if plain state was wiped or not.
-            if account.storage.len() > 256 {
-                account.storage.par_iter().map(|(k, v)| (*k, *v)).for_each(write_slot);
-            } else {
-                for kv in account.storage.iter().map(|(k, v)| (*k, *v)) {
-                    write_slot(kv);
-                }
             }
         })
     }
@@ -508,61 +506,46 @@ impl PersistBlockCache {
             self.account_trie.remove(path);
         });
         input.account_nodes.par_iter().for_each(|(path, node)| {
-            self.account_trie.insert(*path, ValueWithTip::new(node.clone().reset(), block_number));
+            self.account_trie.insert(*path, ValueWithTip::new(node.clone().into(), block_number));
         });
 
-        let write_slot = |data: &DashMap<Nibbles, ValueWithTip<Node>>, kv: (&Nibbles, &Node)| {
-            data.insert(*kv.0, ValueWithTip::new(kv.1.clone().reset(), block_number));
-        };
         input.storage_tries.par_iter().for_each(|(hashed_address, storage_trie_update)| {
             if storage_trie_update.is_deleted {
                 self.storage_trie.remove(hashed_address);
             } else {
+                let mut remove_storage_trie = false;
                 if let Some(storage) = self.storage_trie.get(hashed_address) {
-                    if storage_trie_update.removed_nodes.len() > 256 {
-                        storage_trie_update.removed_nodes.par_iter().for_each(|path| {
-                            storage.remove(path);
-                        });
-                    } else {
-                        for path in &storage_trie_update.removed_nodes {
-                            storage.remove(path);
-                        }
+                    for path in &storage_trie_update.removed_nodes {
+                        storage.remove(path);
                     }
+                    remove_storage_trie = storage.is_empty();
+                }
+                if remove_storage_trie {
+                    self.storage_trie.remove(hashed_address);
                 }
 
                 if let Some(storage) = self.storage_trie.get(hashed_address) {
-                    if storage_trie_update.storage_nodes.len() > 256 {
-                        storage_trie_update.storage_nodes.par_iter().for_each(|kv| {
-                            write_slot(storage.value(), kv);
-                        });
-                    } else {
-                        for kv in &storage_trie_update.storage_nodes {
-                            write_slot(storage.value(), kv);
-                        }
+                    for (nibbles, node) in &storage_trie_update.storage_nodes {
+                        storage
+                            .insert(*nibbles, ValueWithTip::new(node.clone().into(), block_number));
                     }
                 } else {
                     match self.storage_trie.entry(*hashed_address) {
                         dashmap::Entry::Occupied(entry) => {
-                            if storage_trie_update.storage_nodes.len() > 256 {
-                                storage_trie_update.storage_nodes.par_iter().for_each(|kv| {
-                                    write_slot(entry.get(), kv);
-                                });
-                            } else {
-                                for kv in &storage_trie_update.storage_nodes {
-                                    write_slot(entry.get(), kv);
-                                }
+                            for (nibbles, node) in &storage_trie_update.storage_nodes {
+                                entry.get().insert(
+                                    *nibbles,
+                                    ValueWithTip::new(node.clone().into(), block_number),
+                                );
                             }
                         }
                         dashmap::Entry::Vacant(entry) => {
                             let data = DashMap::new();
-                            if storage_trie_update.storage_nodes.len() > 256 {
-                                storage_trie_update.storage_nodes.par_iter().for_each(|kv| {
-                                    write_slot(&data, kv);
-                                });
-                            } else {
-                                for kv in &storage_trie_update.storage_nodes {
-                                    write_slot(&data, kv);
-                                }
+                            for (nibbles, node) in &storage_trie_update.storage_nodes {
+                                data.insert(
+                                    *nibbles,
+                                    ValueWithTip::new(node.clone().into(), block_number),
+                                );
                             }
                             entry.insert(data);
                         }
@@ -572,29 +555,3 @@ impl PersistBlockCache {
         });
     }
 }
-
-/// Stage Data channel that from execution to merkle stage
-#[derive(Clone, Debug, Default)]
-pub struct ExecutionMerkleChannel {
-    data: Arc<Mutex<Option<(u64, HashedPostState)>>>,
-}
-
-impl ExecutionMerkleChannel {
-    /// send data to merkle stage
-    pub fn send(&self, block_number: u64, hashed_state: HashedPostState) {
-        let mut data = self.data.lock().unwrap();
-        assert!(data.is_none());
-        *data = Some((block_number, hashed_state));
-    }
-
-    /// consume data in merkle stage
-    pub fn consume(&self, block_number: u64) -> HashedPostState {
-        let data = self.data.lock().unwrap().take().unwrap();
-        assert_eq!(data.0, block_number);
-        data.1
-    }
-}
-
-/// Single instance of `ExecutionMerkleChannel`
-pub static EXECUTION_MERKLE_CHANNEL: Lazy<ExecutionMerkleChannel> =
-    Lazy::new(ExecutionMerkleChannel::default);

--- a/crates/storage/storage-api/src/cache.rs
+++ b/crates/storage/storage-api/src/cache.rs
@@ -513,13 +513,15 @@ impl PersistBlockCache {
             if storage_trie_update.is_deleted {
                 self.storage_trie.remove(hashed_address);
             } else {
-                let mut remove_storage_trie = false;
-                if let Some(storage) = self.storage_trie.get(hashed_address) {
-                    for path in &storage_trie_update.removed_nodes {
-                        storage.remove(path);
-                    }
-                    remove_storage_trie = storage.is_empty();
-                }
+                let remove_storage_trie =
+                    if let Some(storage) = self.storage_trie.get(hashed_address) {
+                        for path in &storage_trie_update.removed_nodes {
+                            storage.remove(path);
+                        }
+                        storage.is_empty()
+                    } else {
+                        false
+                    };
                 if remove_storage_trie {
                     self.storage_trie.remove(hashed_address);
                 }

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -101,7 +101,7 @@ serde = [
     "revm-database/serde",
     "revm-state/serde",
 ]
-reth-codec = ["dep:reth-codecs", "dep:bytes"]
+reth-codec = ["dep:reth-codecs", "dep:bytes", "bytes/std"]
 serde-bincode-compat = [
     "serde",
     "reth-primitives-traits/serde-bincode-compat",

--- a/crates/trie/common/src/nested_trie/mod.rs
+++ b/crates/trie/common/src/nested_trie/mod.rs
@@ -2,4 +2,4 @@ mod node;
 mod trie;
 
 pub use node::{Node, NodeFlag, StorageNodeEntry, StoredNode};
-pub use trie::{CompatibleTrieOutput, Trie, TrieOutput, TrieReader};
+pub use trie::{Trie, TrieOutput, TrieReader};

--- a/crates/trie/common/src/nested_trie/node.rs
+++ b/crates/trie/common/src/nested_trie/node.rs
@@ -242,7 +242,7 @@ impl From<Node> for StoredNode {
             }
             _ => unreachable!(),
         }
-        Bytes::from(buf.freeze())
+        Self::from(buf.freeze())
     }
 }
 
@@ -260,7 +260,7 @@ impl From<StoredNode> for Node {
                 for i in 0..16 {
                     if mask.is_bit_set(i) {
                         let s = 1 + 32 * cnt;
-                        children[i as usize] = Some(Box::new(Node::HashNode(RlpNode::word_rlp(
+                        children[i as usize] = Some(Box::new(Self::HashNode(RlpNode::word_rlp(
                             &B256::from_slice(&value[s..s + 32]),
                         ))));
                         cnt += 1;
@@ -270,7 +270,7 @@ impl From<StoredNode> for Node {
             }
             Some(NodeType::ExtensionNode) => {
                 // ShortNode
-                let next = Node::HashNode(RlpNode::word_rlp(&B256::from_slice(&value[1..33])));
+                let next = Self::HashNode(RlpNode::word_rlp(&B256::from_slice(&value[1..33])));
                 let odd = value[33];
                 let mut shared_nibbles = Nibbles::unpack(&value[34..]);
                 if odd == 1 {
@@ -294,7 +294,7 @@ impl From<StoredNode> for Node {
                 let value = value[2 + pack_len..].to_vec();
                 Self::ShortNode {
                     key: key_end,
-                    value: Box::new(Node::ValueNode(value)),
+                    value: Box::new(Self::ValueNode(value)),
                     flags: NodeFlag::new(None),
                 }
             }

--- a/crates/trie/parallel/src/nested_hash.rs
+++ b/crates/trie/parallel/src/nested_hash.rs
@@ -20,11 +20,10 @@ use reth_provider::{PersistBlockCache, ProviderResult};
 use reth_storage_errors::db::DatabaseError;
 use reth_trie::{
     nested_trie::{Node, Trie, TrieReader},
-    updates::StorageTrieUpdates,
     HashedPostState, HashedStorage, Nibbles, StorageTrieUpdatesV2, StoredNibbles,
     StoredNibblesSubKey, EMPTY_ROOT_HASH,
 };
-use reth_trie_common::updates::{TrieUpdates, TrieUpdatesV2};
+use reth_trie_common::updates::TrieUpdatesV2;
 
 /// Storage trie node reader
 #[allow(missing_debug_implementations)]
@@ -176,10 +175,8 @@ where
     pub fn calculate(
         &self,
         hashed_state: &HashedPostState,
-        compatible: bool,
-    ) -> ProviderResult<(B256, TrieUpdatesV2, Option<TrieUpdates>)> {
+    ) -> ProviderResult<(B256, TrieUpdatesV2)> {
         let trie_update = Mutex::new(TrieUpdatesV2::default());
-        let compatible_trie_update = compatible.then_some(Mutex::new(TrieUpdates::default()));
         let updated_account_nodes: [Mutex<Vec<(Nibbles, Option<Node>)>>; 16] = Default::default();
         let mut partitioned_accounts: [Vec<(&B256, &Option<Account>)>; 16] = Default::default();
         let HashedPostState { accounts: hashed_accounts, storages: hashed_storages } = hashed_state;
@@ -208,13 +205,6 @@ where
                                 .unwrap()
                                 .storage_tries
                                 .insert(hashed_address, StorageTrieUpdatesV2::deleted());
-                            if let Some(compatible) = compatible_trie_update.as_ref() {
-                                compatible
-                                    .lock()
-                                    .unwrap()
-                                    .storage_tries
-                                    .insert(hashed_address, StorageTrieUpdates::deleted());
-                            }
                         };
                         if let Some(account) = account {
                             let storage = hashed_storages.get(&hashed_address).cloned();
@@ -246,7 +236,7 @@ where
                             // only make the large storage trie parallel
                             let parallel =
                                 storage.as_ref().map(|s| s.storage.len() > 256).unwrap_or(false);
-                            let mut storage_trie = Trie::new(trie_reader, parallel, compatible)?;
+                            let mut storage_trie = Trie::new(trie_reader, parallel)?;
                             if let Some(storage) = storage {
                                 for (hashed_slot, value) in storage.storage {
                                     let nibbles = Nibbles::unpack(hashed_slot);
@@ -265,7 +255,7 @@ where
                             updated_account_nodes
                                 .push((path, Some(Node::ValueNode(alloy_rlp::encode(account)))));
 
-                            let (trie_output, compatible_output) = storage_trie.take_output();
+                            let trie_output = storage_trie.take_output();
                             if !trie_output.is_empty() {
                                 assert!(trie_update
                                     .lock()
@@ -280,24 +270,6 @@ where
                                         }
                                     )
                                     .is_none());
-                            }
-                            if let Some(compatible) = compatible_trie_update.as_ref() {
-                                let compatible_output = compatible_output.unwrap();
-                                if !compatible_output.is_empty() {
-                                    assert!(compatible
-                                        .lock()
-                                        .unwrap()
-                                        .storage_tries
-                                        .insert(
-                                            hashed_address,
-                                            StorageTrieUpdates {
-                                                is_deleted: false,
-                                                storage_nodes: compatible_output.update_nodes,
-                                                removed_nodes: compatible_output.removed_nodes,
-                                            }
-                                        )
-                                        .is_none());
-                                }
                             }
                         } else {
                             updated_account_nodes.push((path, None));
@@ -315,27 +287,20 @@ where
 
         let updated_account_nodes = updated_account_nodes.map(|u| u.into_inner().unwrap());
         let mut trie_update = trie_update.into_inner().unwrap();
-        let mut compatible_trie_update = compatible_trie_update.map(|c| c.into_inner().unwrap());
         let create_reader = || {
             let cursor = (self.provider)()?.cursor_read::<tables::AccountsTrieV2>()?;
             Ok(AccountTrieReader(cursor, self.cache.clone()))
         };
         let cursor = (self.provider)()?.cursor_read::<tables::AccountsTrieV2>()?;
-        let mut account_trie =
-            Trie::new(AccountTrieReader(cursor, self.cache.clone()), true, compatible)?;
+        let mut account_trie = Trie::new(AccountTrieReader(cursor, self.cache.clone()), true)?;
         account_trie.parallel_update(updated_account_nodes, create_reader)?;
 
         let root_hash = account_trie.hash();
-        let (output, compatible_output) = account_trie.take_output();
+        let output = account_trie.take_output();
         trie_update.account_nodes = output.update_nodes;
         trie_update.removed_nodes = output.removed_nodes;
-        if let Some(compatible) = &mut compatible_trie_update {
-            let compatible_output = compatible_output.unwrap();
-            compatible.account_nodes = compatible_output.update_nodes;
-            compatible.removed_nodes = compatible_output.removed_nodes;
-        }
 
-        Ok((root_hash, trie_update, compatible_trie_update))
+        Ok((root_hash, trie_update))
     }
 }
 
@@ -347,7 +312,7 @@ mod tests {
     };
 
     use super::*;
-    use alloy_primitives::{keccak256, map::HashMap, Address, U256};
+    use alloy_primitives::{keccak256, map::HashMap, Address, Bytes, U256};
     use alloy_rlp::encode_fixed_size;
     use rand::Rng;
     use reth_primitives_traits::Account;
@@ -361,8 +326,8 @@ mod tests {
 
     #[derive(Default)]
     struct InmemoryTrieDB {
-        account_trie: Arc<Mutex<HashMap<Nibbles, Vec<u8>>>>,
-        storage_trie: Arc<Mutex<HashMap<B256, HashMap<Nibbles, Vec<u8>>>>>,
+        account_trie: Arc<Mutex<HashMap<Nibbles, Bytes>>>,
+        storage_trie: Arc<Mutex<HashMap<B256, HashMap<Nibbles, Bytes>>>>,
     }
     struct InmemoryAccountTrieReader(Arc<InmemoryTrieDB>);
     struct InmemoryStorageTrieReader(Arc<InmemoryTrieDB>, B256);
@@ -408,17 +373,24 @@ mod tests {
                         num_update += destruct_account.len();
                     }
                 } else {
+                    let mut remove_storage = false;
                     if let Some(storage) = storage_trie.get_mut(hashed_address) {
                         for path in &storage_trie_update.removed_nodes {
                             if storage.remove(path).is_some() {
                                 num_update += 1;
                             }
                         }
+                        remove_storage = storage.is_empty();
                     }
-                    let storage = storage_trie.entry(*hashed_address).or_default();
-                    for (path, node) in storage_trie_update.storage_nodes.clone() {
-                        storage.insert(path.clone(), node.into());
-                        num_update += 1;
+                    if remove_storage {
+                        storage_trie.remove(hashed_address);
+                    }
+                    if !storage_trie_update.storage_nodes.is_empty() {
+                        let storage = storage_trie.entry(*hashed_address).or_default();
+                        for (path, node) in storage_trie_update.storage_nodes.clone() {
+                            storage.insert(path, node.into());
+                            num_update += 1;
+                        }
                     }
                 }
             }
@@ -434,7 +406,6 @@ mod tests {
     ) -> (B256, TrieUpdatesV2) {
         let (tx, rx) = mpsc::channel();
         let num_task = state.len();
-        let is_compatible = false;
         for (address, (account, storage)) in state {
             let db = db.clone();
             let tx = tx.clone();
@@ -442,7 +413,7 @@ mod tests {
                 let hashed_address = keccak256(address);
                 let create_reader = || Ok(InmemoryStorageTrieReader(db.clone(), hashed_address));
                 let storage_reader = InmemoryStorageTrieReader(db.clone(), hashed_address);
-                let mut storage_trie = Trie::new(storage_reader, true, is_compatible).unwrap();
+                let mut storage_trie = Trie::new(storage_reader, true).unwrap();
                 let mut batches: [Vec<(Nibbles, Option<Node>)>; 16] = Default::default();
                 for (hashed_slot, value) in
                     storage.into_iter().map(|(k, v)| (keccak256(k), encode_fixed_size(&v)))
@@ -469,16 +440,12 @@ mod tests {
         let mut batches: [Vec<(Nibbles, Option<Node>)>; 16] = Default::default();
         let create_reader = || Ok(InmemoryAccountTrieReader(db.clone()));
         for _ in 0..num_task {
-            let (hashed_address, rlp_account, (trie_output, _)) =
+            let (hashed_address, rlp_account, trie_output) =
                 rx.recv().expect("Failed to receive storage trie");
-            let storage_trie_update = if is_insert {
-                StorageTrieUpdatesV2 {
-                    is_deleted: false,
-                    storage_nodes: trie_output.update_nodes,
-                    removed_nodes: trie_output.removed_nodes,
-                }
-            } else {
-                StorageTrieUpdatesV2::deleted()
+            let storage_trie_update = StorageTrieUpdatesV2 {
+                is_deleted: false,
+                storage_nodes: trie_output.update_nodes,
+                removed_nodes: trie_output.removed_nodes,
             };
             let nibbles = Nibbles::unpack(hashed_address);
             let index = nibbles.get_unchecked(0) as usize;
@@ -489,13 +456,13 @@ mod tests {
                 .is_none());
         }
         let account_reader = InmemoryAccountTrieReader(db.clone());
-        let mut account_trie = Trie::new(account_reader, true, is_compatible).unwrap();
+        let mut account_trie = Trie::new(account_reader, true).unwrap();
 
         // parallel update
         account_trie.parallel_update(batches, create_reader).unwrap();
 
         let root_hash = account_trie.hash();
-        let (output, _) = account_trie.take_output();
+        let output = account_trie.take_output();
         trie_updates.account_nodes = output.update_nodes;
         trie_updates.removed_nodes = output.removed_nodes;
         (root_hash, trie_updates)
@@ -597,7 +564,7 @@ mod tests {
         }
 
         let (parallel_root_hash, ..) =
-            NestedStateRoot::new(provider, None).calculate(&hashed_state, true).unwrap();
+            NestedStateRoot::new(provider, None).calculate(&hashed_state).unwrap();
         assert_eq!(parallel_root_hash, test_utils::state_root(state))
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,10 @@ ignore = [
     "RUSTSEC-2024-0384",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2024-0320 yaml-rust is unmaintained
+    # Pulled transitively via `api-types` (gravity-aptos) -> `serde_yaml` -> `yaml-rust`.
+    # Upstream has no safe upgrade as of now; will revisit when serde_yaml migrates to yaml-rust2.
+    "RUSTSEC-2024-0320",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -89,5 +93,8 @@ allow-git = [
     "https://github.com/alloy-rs/evm",
     "https://github.com/alloy-rs/hardforks",
     "https://github.com/paradigmxyz/jsonrpsee",
+    # Allowed for gravity exec layer extension dependencies
+    "https://github.com/aptos-labs/bcs",
+    "https://github.com/Galxe/gravity-aptos",
 ]
 allow-org = { github = ["Galxe"] }


### PR DESCRIPTION
Fix Issue: https://github.com/Galxe/gravity-reth/issues/151

Optimize the serialization size of trie nodes, and in the testing of the first 2000K blocks of the Ethereum mainnet, the size of StoresTrieV2 was reduced from 1002M to 285M