### PR TITLE
refactor(parallel): remove the read provider factory that supports parallel reading

### DIFF
--- a/crates/cli/commands/src/stage/dump/execution.rs
+++ b/crates/cli/commands/src/stage/dump/execution.rs
@@ -147,10 +147,6 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
 
     exec_stage.unwind(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         UnwindInput {
             unwind_to: from,
             checkpoint: StageCheckpoint::new(tip_block_number),
@@ -189,7 +185,6 @@ where
         reth_stages::ExecInput { target: Some(to), checkpoint: Some(StageCheckpoint::new(from)) };
     exec_stage.execute(
         &output_provider_factory.database_provider_rw()?,
-        Box::new(move || output_provider_factory.database_provider_ro()),
         input,
     )?;
 

--- a/crates/cli/commands/src/stage/dump/hashing_account.rs
+++ b/crates/cli/commands/src/stage/dump/hashing_account.rs
@@ -60,10 +60,6 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
 
     exec_stage.unwind(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         UnwindInput {
             unwind_to: from,
             checkpoint: StageCheckpoint::new(tip_block_number),
@@ -99,10 +95,6 @@ fn dry_run<N: ProviderNodeTypes>(
         if stage
             .execute(
                 &provider,
-                Box::new({
-                    let provider_factory = output_provider_factory.clone();
-                    move || provider_factory.database_provider_ro()
-                }),
                 input,
             )?
             .done

--- a/crates/cli/commands/src/stage/dump/hashing_storage.rs
+++ b/crates/cli/commands/src/stage/dump/hashing_storage.rs
@@ -51,10 +51,6 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
 
     exec_stage.unwind(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         UnwindInput {
             unwind_to: from,
             checkpoint: StageCheckpoint::new(tip_block_number),
@@ -94,10 +90,6 @@ fn dry_run<N: ProviderNodeTypes>(
         if stage
             .execute(
                 &provider,
-                Box::new({
-                    let provider_factory = output_provider_factory.clone();
-                    move || provider_factory.database_provider_ro()
-                }),
                 input,
             )?
             .done

--- a/crates/cli/commands/src/stage/dump/merkle.rs
+++ b/crates/cli/commands/src/stage/dump/merkle.rs
@@ -96,30 +96,18 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
     StorageHashingStage::default()
         .unwind(
             &provider,
-            Box::new({
-                let provider_factory = db_tool.provider_factory.clone();
-                move || provider_factory.database_provider_ro()
-            }),
             unwind,
         )
         .unwrap();
     AccountHashingStage::default()
         .unwind(
             &provider,
-            Box::new({
-                let provider_factory = db_tool.provider_factory.clone();
-                move || provider_factory.database_provider_ro()
-            }),
             unwind,
         )
         .unwrap();
 
     MerkleStage::default_unwind().unwind(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         unwind,
     )?;
 
@@ -139,10 +127,6 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
 
     exec_stage.unwind(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         UnwindInput {
             unwind_to: to,
             checkpoint: StageCheckpoint::new(tip_block_number),
@@ -158,10 +142,6 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
     }
     .execute(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         execute_input,
     )
     .unwrap();
@@ -172,10 +152,6 @@ fn unwind_and_copy<N: ProviderNodeTypes>(
     }
     .execute(
         &provider,
-        Box::new({
-            let provider_factory = db_tool.provider_factory.clone();
-            move || provider_factory.database_provider_ro()
-        }),
         execute_input,
     )
     .unwrap();
@@ -216,10 +192,6 @@ where
         if stage
             .execute(
                 &provider,
-                Box::new({
-                    let provider_factory = output_provider_factory.clone();
-                    move || provider_factory.database_provider_ro()
-                }),
                 input,
             )?
             .done

--- a/crates/cli/commands/src/stage/run.rs
+++ b/crates/cli/commands/src/stage/run.rs
@@ -154,8 +154,8 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
         let prune_modes = config.prune.clone().map(|prune| prune.segments).unwrap_or_default();
 
         let (mut exec_stage, mut unwind_stage): (
-            Box<dyn Stage<_, _>>,
-            Option<Box<dyn Stage<_, _>>>,
+            Box<dyn Stage<_>>,
+            Option<Box<dyn Stage<_>>>,
         ) = match self.stage {
             StageEnum::Headers => {
                 let consensus = Arc::new(components.consensus().clone());
@@ -332,10 +332,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             while unwind.checkpoint.block_number > self.from {
                 let UnwindOutput { checkpoint } = unwind_stage.unwind(
                     &provider_rw,
-                    Box::new({
-                        let provider_factory = provider_factory.clone();
-                        move || provider_factory.database_provider_ro()
-                    }),
                     unwind,
                 )?;
                 unwind.checkpoint = checkpoint;
@@ -362,10 +358,6 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
             exec_stage.execute_ready(input).await?;
             let ExecOutput { checkpoint, done } = exec_stage.execute(
                 &provider_rw,
-                Box::new({
-                    let provider_factory = provider_factory.clone();
-                    move || provider_factory.database_provider_ro()
-                }),
                 input,
             )?;
 

--- a/crates/gravity-storage/src/block_view_storage/mod.rs
+++ b/crates/gravity-storage/src/block_view_storage/mod.rs
@@ -57,8 +57,8 @@ where
     }
 
     fn state_root(&self, hashed_state: &HashedPostState) -> ProviderResult<(B256, TrieUpdatesV2)> {
-        let provider = || self.client.database_provider_ro().map(|db| db.into_tx());
-        let nested_hash = NestedStateRoot::new(provider, Some(self.cache.clone()));
+        let tx = self.client.database_provider_ro()?.into_tx();
+        let nested_hash = NestedStateRoot::new(&tx, Some(self.cache.clone()));
         nested_hash.calculate(hashed_state)
     }
 

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/pipe_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/pipe_test.rs
@@ -142,8 +142,8 @@ async fn run_pipe(
     drop(db_provider);
 
     // write new state root
-    let nested_provider = || provider.database_provider_ro().map(|db| db.into_tx());
-    let nested_hash = NestedStateRoot::new(nested_provider, None);
+    let tx = provider.database_provider_ro().unwrap().into_tx();
+    let nested_hash = NestedStateRoot::new(&tx, None);
     let hashed_state = nested_hash.read_hashed_state(None).unwrap();
     let (root_hash, trie_updates) = nested_hash.calculate(&hashed_state).unwrap();
     let trie_write = provider.database_provider_rw().unwrap();

--- a/crates/stages/api/src/pipeline/builder.rs
+++ b/crates/stages/api/src/pipeline/builder.rs
@@ -6,9 +6,9 @@ use tokio::sync::watch;
 
 /// Builds a [`Pipeline`].
 #[must_use = "call `build` to construct the pipeline"]
-pub struct PipelineBuilder<ProviderRW, ProviderRO> {
+pub struct PipelineBuilder<ProviderRW> {
     /// All configured stages in the order they will be executed.
-    stages: Vec<BoxedStage<ProviderRW, ProviderRO>>,
+    stages: Vec<BoxedStage<ProviderRW>>,
     /// The maximum block number to sync to.
     max_block: Option<BlockNumber>,
     /// A receiver for the current chain tip to sync to.
@@ -17,11 +17,11 @@ pub struct PipelineBuilder<ProviderRW, ProviderRO> {
     fail_on_unwind: bool,
 }
 
-impl<ProviderRW, ProviderRO> PipelineBuilder<ProviderRW, ProviderRO> {
+impl<ProviderRW> PipelineBuilder<ProviderRW> {
     /// Add a stage to the pipeline.
     pub fn add_stage<S>(mut self, stage: S) -> Self
     where
-        S: Stage<ProviderRW, ProviderRO> + 'static,
+        S: Stage<ProviderRW> + 'static,
     {
         self.stages.push(Box::new(stage));
         self
@@ -34,7 +34,7 @@ impl<ProviderRW, ProviderRO> PipelineBuilder<ProviderRW, ProviderRO> {
     /// To customize the stages in the set (reorder, disable, insert a stage) call
     /// [`builder`][StageSet::builder] on the set which will convert it to a
     /// [`StageSetBuilder`][crate::StageSetBuilder].
-    pub fn add_stages<Set: StageSet<ProviderRW, ProviderRO>>(mut self, set: Set) -> Self {
+    pub fn add_stages<Set: StageSet<ProviderRW>>(mut self, set: Set) -> Self {
         let states = set.builder().build();
         self.stages.reserve_exact(states.len());
         for stage in states {
@@ -77,7 +77,7 @@ impl<ProviderRW, ProviderRO> PipelineBuilder<ProviderRW, ProviderRO> {
     ) -> Pipeline<N>
     where
         N: ProviderNodeTypes,
-        ProviderFactory<N>: DatabaseProviderFactory<ProviderRW = ProviderRW, Provider = ProviderRO>,
+        ProviderFactory<N>: DatabaseProviderFactory<ProviderRW = ProviderRW>,
     {
         let Self { stages, max_block, tip_tx, metrics_tx, fail_on_unwind } = self;
         Pipeline {
@@ -96,7 +96,7 @@ impl<ProviderRW, ProviderRO> PipelineBuilder<ProviderRW, ProviderRO> {
     }
 }
 
-impl<ProviderRW, ProviderRO> Default for PipelineBuilder<ProviderRW, ProviderRO> {
+impl<ProviderRW> Default for PipelineBuilder<ProviderRW> {
     fn default() -> Self {
         Self {
             stages: Vec::new(),
@@ -108,7 +108,7 @@ impl<ProviderRW, ProviderRO> Default for PipelineBuilder<ProviderRW, ProviderRO>
     }
 }
 
-impl<ProviderRW, ProviderRO> std::fmt::Debug for PipelineBuilder<ProviderRW, ProviderRO> {
+impl<ProviderRW> std::fmt::Debug for PipelineBuilder<ProviderRW> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PipelineBuilder")
             .field("stages", &self.stages.iter().map(|stage| stage.id()).collect::<Vec<StageId>>())

--- a/crates/stages/stages/src/stages/bodies.rs
+++ b/crates/stages/stages/src/stages/bodies.rs
@@ -11,7 +11,7 @@ use reth_provider::{
     StaticFileProviderFactory, StatsReader, StorageLocation,
 };
 use reth_stages_api::{
-    BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
+    EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
     StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
@@ -142,7 +142,7 @@ where
     Ok(())
 }
 
-impl<Provider, ProviderRO, D> Stage<Provider, ProviderRO> for BodyStage<D>
+impl<Provider, D> Stage<Provider> for BodyStage<D>
 where
     Provider: DBProvider<Tx: DbTxMut>
         + StaticFileProviderFactory
@@ -189,7 +189,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -230,7 +229,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.buffer.take();

--- a/crates/stages/stages/src/stages/era.rs
+++ b/crates/stages/stages/src/stages/era.rs
@@ -14,7 +14,7 @@ use reth_provider::{
     StaticFileProviderFactory, StaticFileWriter,
 };
 use reth_stages_api::{
-    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
+    ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_errors::ProviderError;
@@ -129,7 +129,7 @@ impl<Header, Body, F> EraStage<Header, Body, F> {
     }
 }
 
-impl<Provider, ProviderRO, N, F> Stage<Provider, ProviderRO>
+impl<Provider, N, F> Stage<Provider>
     for EraStage<N::BlockHeader, N::BlockBody, F>
 where
     Provider: DBProvider<Tx: DbTxMut>
@@ -172,7 +172,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let height = if let Some(era) = self.item.take() {
@@ -228,7 +227,6 @@ where
     fn unwind(
         &mut self,
         _provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         Ok(UnwindOutput { checkpoint: input.checkpoint.with_block_number(input.unwind_to) })

--- a/crates/stages/stages/src/stages/finish.rs
+++ b/crates/stages/stages/src/stages/finish.rs
@@ -1,5 +1,5 @@
 use reth_stages_api::{
-    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
+    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
     UnwindInput, UnwindOutput,
 };
 
@@ -11,7 +11,7 @@ use reth_stages_api::{
 #[non_exhaustive]
 pub struct FinishStage;
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for FinishStage {
+impl<Provider> Stage<Provider> for FinishStage {
     fn id(&self) -> StageId {
         StageId::Finish
     }
@@ -19,7 +19,6 @@ impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for FinishStage {
     fn execute(
         &mut self,
         _provider: &Provider,
-        _provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         Ok(ExecOutput { checkpoint: StageCheckpoint::new(input.target()), done: true })
@@ -28,7 +27,6 @@ impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for FinishStage {
     fn unwind(
         &mut self,
         _provider: &Provider,
-        _provider_ro: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         Ok(UnwindOutput { checkpoint: StageCheckpoint::new(input.unwind_to) })

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -11,7 +11,7 @@ use reth_etl::Collector;
 use reth_primitives_traits::Account;
 use reth_provider::{AccountExtReader, DBProvider, HashingWriter, StatsReader};
 use reth_stages_api::{
-    AccountHashingCheckpoint, BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput,
+    AccountHashingCheckpoint, EntitiesCheckpoint, ExecInput, ExecOutput,
     Stage, StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderResult;
@@ -132,7 +132,7 @@ impl Default for AccountHashingStage {
     }
 }
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for AccountHashingStage
+impl<Provider> Stage<Provider> for AccountHashingStage
 where
     Provider: DBProvider<Tx: DbTxMut> + HashingWriter + AccountExtReader + StatsReader,
 {
@@ -145,7 +145,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -237,7 +236,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -12,7 +12,7 @@ use reth_etl::Collector;
 use reth_primitives_traits::StorageEntry;
 use reth_provider::{DBProvider, HashingWriter, StatsReader, StorageReader};
 use reth_stages_api::{
-    BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
+    EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
     StageError, StageId, StorageHashingCheckpoint, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderResult;
@@ -62,7 +62,7 @@ impl Default for StorageHashingStage {
     }
 }
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for StorageHashingStage
+impl<Provider> Stage<Provider> for StorageHashingStage
 where
     Provider: DBProvider<Tx: DbTxMut> + StorageReader + HashingWriter + StatsReader,
 {
@@ -75,7 +75,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let tx = provider.tx_ref();
@@ -169,7 +168,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -27,7 +27,6 @@ use reth_static_file_types::StaticFileSegment;
 use reth_storage_errors::provider::ProviderError;
 use std::task::{ready, Context, Poll};
 
-use reth_stages_api::BoxedConcurrentProvider;
 use tokio::sync::watch;
 use tracing::*;
 
@@ -185,7 +184,7 @@ where
     }
 }
 
-impl<Provider, ProviderRO, P, D> Stage<Provider, ProviderRO> for HeaderStage<P, D>
+impl<Provider, P, D> Stage<Provider> for HeaderStage<P, D>
 where
     Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
     P: HeaderSyncGapProvider<Header = <Provider::Primitives as NodePrimitives>::BlockHeader>,
@@ -286,7 +285,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         let current_checkpoint = input.checkpoint();
@@ -335,7 +333,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         self.sync_gap.take();

--- a/crates/stages/stages/src/stages/index_account_history.rs
+++ b/crates/stages/stages/src/stages/index_account_history.rs
@@ -5,7 +5,7 @@ use reth_db_api::{models::ShardedKey, table::Decode, tables, transaction::DbTxMu
 use reth_provider::{DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter};
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
-    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
+    ExecInput, ExecOutput, Stage, StageCheckpoint, StageError, StageId,
     UnwindInput, UnwindOutput,
 };
 use std::fmt::Debug;
@@ -42,7 +42,7 @@ impl Default for IndexAccountHistoryStage {
     }
 }
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for IndexAccountHistoryStage
+impl<Provider> Stage<Provider> for IndexAccountHistoryStage
 where
     Provider:
         DBProvider<Tx: DbTxMut> + HistoryWriter + PruneCheckpointReader + PruneCheckpointWriter,
@@ -56,7 +56,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -129,7 +128,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/index_storage_history.rs
+++ b/crates/stages/stages/src/stages/index_storage_history.rs
@@ -10,7 +10,7 @@ use reth_db_api::{
 use reth_provider::{DBProvider, HistoryWriter, PruneCheckpointReader, PruneCheckpointWriter};
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
-    BoxedConcurrentProvider, ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
+    ExecInput, ExecOutput, Stage, StageError, UnwindInput, UnwindOutput,
 };
 use std::fmt::Debug;
 use tracing::info;
@@ -46,7 +46,7 @@ impl Default for IndexStorageHistoryStage {
     }
 }
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for IndexStorageHistoryStage
+impl<Provider> Stage<Provider> for IndexStorageHistoryStage
 where
     Provider:
         DBProvider<Tx: DbTxMut> + PruneCheckpointWriter + HistoryWriter + PruneCheckpointReader,
@@ -60,7 +60,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -137,7 +136,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (range, unwind_progress, _) =

--- a/crates/stages/stages/src/stages/sender_recovery.rs
+++ b/crates/stages/stages/src/stages/sender_recovery.rs
@@ -16,7 +16,7 @@ use reth_provider::{
 };
 use reth_prune_types::PruneSegment;
 use reth_stages_api::{
-    BlockErrorKind, BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage,
+    BlockErrorKind, EntitiesCheckpoint, ExecInput, ExecOutput, Stage,
     StageCheckpoint, StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
@@ -58,7 +58,7 @@ impl Default for SenderRecoveryStage {
     }
 }
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for SenderRecoveryStage
+impl<Provider> Stage<Provider> for SenderRecoveryStage
 where
     Provider: DBProvider<Tx: DbTxMut>
         + BlockReader
@@ -78,7 +78,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if input.target_reached() {
@@ -128,7 +127,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let (_, unwind_to, _) = input.unwind_block_range_with_threshold(self.commit_threshold);

--- a/crates/stages/stages/src/stages/tx_lookup.rs
+++ b/crates/stages/stages/src/stages/tx_lookup.rs
@@ -17,7 +17,7 @@ use reth_provider::{
 };
 use reth_prune_types::{PruneCheckpoint, PruneMode, PrunePurpose, PruneSegment};
 use reth_stages_api::{
-    BoxedConcurrentProvider, EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
+    EntitiesCheckpoint, ExecInput, ExecOutput, Stage, StageCheckpoint,
     StageError, StageId, UnwindInput, UnwindOutput,
 };
 use reth_storage_errors::provider::ProviderError;
@@ -57,7 +57,7 @@ impl TransactionLookupStage {
     }
 }
 
-impl<Provider, ProviderRO> Stage<Provider, ProviderRO> for TransactionLookupStage
+impl<Provider> Stage<Provider> for TransactionLookupStage
 where
     Provider: DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
@@ -76,7 +76,6 @@ where
     fn execute(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         mut input: ExecInput,
     ) -> Result<ExecOutput, StageError> {
         if let Some((target_prunable_block, prune_mode)) = self
@@ -191,7 +190,6 @@ where
     fn unwind(
         &mut self,
         provider: &Provider,
-        _: BoxedConcurrentProvider<ProviderRO>,
         input: UnwindInput,
     ) -> Result<UnwindOutput, StageError> {
         let tx = provider.tx_ref();


### PR DESCRIPTION
## Remove read provider factory
The `Tx` can support parallel reading, so no need to produce provider factory.