### PR TITLE
feat(pipe-exec-layer-ext-v2): fetch pending validators in validator set

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/types.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/types.rs
@@ -39,6 +39,13 @@ sol! {
     // Function from ValidatorManagement contract
     function getActiveValidators() external view returns (ValidatorConsensusInfo[] memory);
 
+    // Functions to get pending validators (now return full ValidatorConsensusInfo[])
+    function getPendingActiveValidators() external view returns (ValidatorConsensusInfo[] memory);
+    function getPendingInactiveValidators() external view returns (ValidatorConsensusInfo[] memory);
+
+    // Function to get total voting power directly from contract
+    function getTotalVotingPower() external view returns (uint256);
+
     /// NewEpochEvent from Reconfiguration.sol
     /// Emitted when epoch transition completes with full validator set
     event NewEpochEvent(
@@ -106,20 +113,40 @@ pub fn convert_validator_consensus_info(
     )
 }
 
-/// Convert array of ValidatorConsensusInfo to BCS-encoded ValidatorSet
+/// Convert arrays of ValidatorConsensusInfo to BCS-encoded ValidatorSet
 /// Used by ValidatorSetFetcher to convert getActiveValidators() response
-pub fn convert_active_validators_to_bcs(validators: &[ValidatorConsensusInfo]) -> Bytes {
+///
+/// # Arguments
+/// * `active_validators` - Active validators from getActiveValidators()
+/// * `pending_active` - Validators pending activation (optional, from getCurValidatorConsensusInfos style query)
+/// * `pending_inactive` - Validators pending deactivation (still in active set for this epoch)
+pub fn convert_validators_to_bcs(
+    active_validators: &[ValidatorConsensusInfo],
+    pending_active: &[ValidatorConsensusInfo],
+    pending_inactive: &[ValidatorConsensusInfo],
+) -> Bytes {
+    // Calculate total voting power from active validators (in Ether units)
     let total_voting_power: u128 =
-        validators.iter().map(|v| wei_to_ether(v.votingPower).to::<u128>()).sum();
+        active_validators.iter().map(|v| wei_to_ether(v.votingPower).to::<u128>()).sum();
+
+    // Calculate total joining power from pending_active validators
+    let total_joining_power: u128 =
+        pending_active.iter().map(|v| wei_to_ether(v.votingPower).to::<u128>()).sum();
 
     let gravity_validator_set = GravityValidatorSet {
-        active_validators: validators.iter().map(convert_validator_consensus_info).collect(),
-        pending_inactive: vec![], // Not returned by getActiveValidators()
-        pending_active: vec![],   // Not returned by getActiveValidators()
+        active_validators: active_validators.iter().map(convert_validator_consensus_info).collect(),
+        pending_inactive: pending_inactive.iter().map(convert_validator_consensus_info).collect(),
+        pending_active: pending_active.iter().map(convert_validator_consensus_info).collect(),
         total_voting_power,
-        total_joining_power: 0, // Not returned by getActiveValidators()
+        total_joining_power,
     };
 
     // Serialize to BCS format (gravity-aptos standard)
     bcs::to_bytes(&gravity_validator_set).expect("Failed to serialize validator set").into()
+}
+
+/// Legacy function for backward compatibility - only active validators
+/// Used when we don't have pending validator info available
+pub fn convert_active_validators_to_bcs(validators: &[ValidatorConsensusInfo]) -> Bytes {
+    convert_validators_to_bcs(validators, &[], &[])
 }


### PR DESCRIPTION
Extend ValidatorSetFetcher to fetch and include pending active and pending inactive validators when building the validator set. This fixes the issue where total_joining_power was hardcoded to 0 and ensures complete validator state information during epoch transitions.