### PR TITLE
chore(deps): update gaptos deps to include peer_id consistency fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos?rev=d0add73ccce05df649f51715dedc36f0710dd331#d0add73ccce05df649f51715dedc36f0710dd331"
+source = "git+https://github.com/Galxe/gravity-aptos?rev=977f5b9388183c8a14c0ddcb4e2ac9f265d45184#977f5b9388183c8a14c0ddcb4e2ac9f265d45184"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 # reth
-gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "d0add73ccce05df649f51715dedc36f0710dd331" }
+gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "977f5b9388183c8a14c0ddcb4e2ac9f265d45184" }
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }


### PR DESCRIPTION
This PR updates the gaptos dependency to incorporate a change regarding how VFN peer id is validated during the Noise handshake.