### PR TITLE
fix(evm/p2): Reject over-length BLS precompile input with strict equality check

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/bls_precompile.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/bls_precompile.rs
@@ -59,7 +59,7 @@ fn bls_pop_verify_handler(input: PrecompileInput<'_>) -> PrecompileResult {
 /// Separated from the `PrecompileInput` wrapper to facilitate unit testing.
 fn bls_pop_verify_handler_raw(data: &[u8]) -> PrecompileResult {
     // 1. Validate input length
-    if data.len() < EXPECTED_INPUT_LEN {
+    if data.len() != EXPECTED_INPUT_LEN {
         warn!(
             target: "evm::precompile::bls_pop_verify",
             input_len = data.len(),
@@ -67,7 +67,7 @@ fn bls_pop_verify_handler_raw(data: &[u8]) -> PrecompileResult {
             "Invalid input length"
         );
         return Err(PrecompileError::Other(
-            format!("Invalid input length: {}, expected {}", data.len(), EXPECTED_INPUT_LEN).into(),
+            format!("expected exactly {} bytes, got {}", EXPECTED_INPUT_LEN, data.len()).into(),
         ));
     }
 


### PR DESCRIPTION
See https://github.com/Galxe/gravity-reth/pull/256
Fix GRETH-015: BLS PoP verification precompile now rejects over-length input.

**Problem:** The input length check used `data.len() < EXPECTED_INPUT_LEN`, which allowed arbitrarily long input with extra trailing bytes silently ignored.

**Fix:** Changed to strict equality `data.len() != EXPECTED_INPUT_LEN`. Returns `PrecompileError::Other` with descriptive message including expected and actual lengths.