### PR TITLE
docs: add round 2 security audit design documents for 9 findings

### DIFF
--- a/docs/plans/2026-02-27-greth-high-fixes-design.md
+++ b/docs/plans/2026-02-27-greth-high-fixes-design.md
@@ -1,0 +1,19 @@
+# GRETH HIGH Fixes Design (Round 2)
+
+Date: 2026-02-27
+
+## GRETH-021: validate_execution_output Only Runs in Debug Builds
+
+**Problem:** Critical block validation logic in `execute/src/lib.rs` (L304–L336) and its call site (L420–L423) are gated behind `#[cfg(debug_assertions)]`. In production (`--release`) builds, none of these sanity checks run: (1) `gas_limit < gas_used` — block claims more gas than allowed, (2) `gas_used != last receipt cumulative_gas_used` — inconsistent gas accounting, (3) `timestamp > now_secs * 2` — timestamp in microseconds instead of seconds. This is the same class of issue as GRETH-004 (block validation bypassed in production) but in the execution layer rather than the engine tree.
+
+**Fix:** Remove the `#[cfg(debug_assertions)]` guard. Replace `panic!` with `error!` logging + metric counter so the node signals the anomaly without crashing in production. Alternatively, keep `unwrap_or_else` panic in debug and `error!` log in release using a runtime check.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/execute/src/lib.rs`
+
+## GRETH-025: System Transaction Failure Silently Continues Block Execution
+
+**Problem:** In `transact_system_txn` (`metadata_txn.rs:L198–L203`), when a system transaction execution fails (reverts), only `log_execution_error()` is called — execution continues normally. The caller in `lib.rs:L692–L696` proceeds to commit state changes from the failed transaction via `evm.db_mut().commit(metadata_state_changes.clone())` and checks its logs for epoch-change events. A reverted metadata transaction would have empty/invalid logs, causing the epoch-change check to silently skip. Additionally, `into_executed_ordered_block_result` (`metadata_txn.rs:L123–L128`) hardcodes `success: true` in the receipt regardless of actual execution outcome, making failed system transactions indistinguishable from successful ones on-chain.
+
+**Fix:** Either (a) assert that system transactions always succeed — `assert!(result.result.is_success(), "system txn must succeed: {result:?}")` — or (b) propagate the failure as an `Err` and halt block processing. Set `receipt.success` from `result.is_success()` instead of hardcoding `true`.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs`, `crates/pipe-exec-layer-ext-v2/execute/src/lib.rs`

--- a/docs/plans/2026-02-27-greth-low-fixes-design.md
+++ b/docs/plans/2026-02-27-greth-low-fixes-design.md
@@ -1,0 +1,35 @@
+# GRETH LOW Fixes Design (Round 2)
+
+Date: 2026-02-27
+
+## GRETH-024: Nonce Truncation u128→u64 in OracleRelayerManager
+
+**Problem:** In `oracle_manager.rs:L270`, `BlockchainEventSource::last_nonce()` returns `Option<u128>`, but `PollResult::nonce` is typed as `Option<u64>`. The implicit `as u64` cast at L270 silently truncates nonce values exceeding `u64::MAX`. At L303, the truncated `u64` is cast back to `u128` for `update_and_save_state`, potentially persisting a wrong value. While the Solidity `MessageSent` event uses `uint128` for nonce, current deployments are unlikely to reach u64::MAX, but the type mismatch may hide bugs.
+
+**Fix:** Either (a) ensure the oracle nonce domain is guaranteed ≤ u64::MAX and document this invariant with a compile-time or runtime assertion, or (b) widen `PollResult::nonce` to `Option<u128>` throughout the API.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/relayer/src/oracle_manager.rs`
+
+## GRETH-026: Precompile State Merge Overwrites Instead of Deep Merging
+
+**Problem:** In `execute/src/lib.rs:L823–L840`, precompile state changes are merged into `accumulated_state_changes` using `HashMap::insert`. If both a prior system transaction (e.g., metadata) and the mint precompile modify the same account address, `insert` replaces the entire `Account` entry. This means changes from the earlier transaction (nonce increments, storage writes) are lost for overlapping addresses. In practice, the mint precompile operates on `ParallelState` which is a separate DB snapshot, so overlapping addresses are unlikely but not impossible (e.g., if a mint targets `SYSTEM_CALLER` or a validator address that also had system txn changes).
+
+**Fix:** Use `entry(...).and_modify(|existing| { /* merge storage slots + update info */ }).or_insert(...)` to properly deep-merge account state. Alternatively, document that the mint precompile must not modify accounts that are also touched by system transactions.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/execute/src/lib.rs`
+
+## GRETH-027: GRETH-011 Cross-Verification Uses Same RPC Endpoint (Informational)
+
+**Problem:** This is a reiteration of reviewer neko's existing rejection on GRETH-011. Both `eth_getLogs` and `eth_getBlockReceipts` calls in `blockchain_source.rs` go through the same `self.rpc_client` (same RPC endpoint). A fully compromised RPC can forge both responses to be mutually consistent, making the cross-verification ineffective against a compromised-RPC threat model.
+
+**Recommendation:** Use a separate, independent RPC endpoint for receipt verification, or implement Merkle proof verification against a locally-validated block header. This is an architectural limitation, not a code bug.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/relayer/src/blockchain_source.rs`
+
+## GRETH-028: Block Timestamp Sanity Check Debug-Only (Subset of GRETH-021)
+
+**Problem:** The timestamp sanity check at `lib.rs:L327–L334` detects when a block timestamp is in milliseconds or microseconds instead of seconds (by checking `timestamp > now_secs * 2`). This is critical for catching bugs in the `timestamp_us / 1_000_000` conversion (L579, L958), but is compiled out in release builds as part of the `#[cfg(debug_assertions)]` block described in GRETH-021.
+
+**Fix:** Addressed as part of GRETH-021. When the `#[cfg(debug_assertions)]` guard is removed, this check will automatically run in production.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/execute/src/lib.rs`

--- a/docs/plans/2026-02-27-greth-medium-fixes-design.md
+++ b/docs/plans/2026-02-27-greth-medium-fixes-design.md
@@ -1,0 +1,27 @@
+# GRETH MEDIUM Fixes Design (Round 2)
+
+Date: 2026-02-27
+
+## GRETH-020: Mint Precompile Accepts Trailing Bytes
+
+**Problem:** `mint_precompile.rs:L91` uses `input.data.len() < EXPECTED_LEN` instead of strict equality `!=`. This allows extra trailing bytes to be silently ignored. Inconsistent with the BLS precompile which was fixed to use strict equality in GRETH-015. Trailing bytes could serve as a covert data channel or cause confusion during forensic analysis of on-chain transactions.
+
+**Fix:** Change the length check from `<` to `!=`, matching the BLS precompile fix pattern: `if input.data.len() != EXPECTED_LEN { return Err(...) }`. Update the error message to include both expected and actual lengths.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/execute/src/mint_precompile.rs`
+
+## GRETH-022: Unsafe `Send` Impl on MutexGuard Wrapper in Channel
+
+**Problem:** `channel.rs:L57–L58` defines `struct SendMutexGuard<'a, T>(MutexGuard<'a, T>)` with `unsafe impl<'a, T> Send for SendMutexGuard<'a, T> {}`. The safety comment claims `.await` will not occur within the critical zone, but this invariant is not compiler-enforced. `MutexGuard` is deliberately `!Send` because holding a lock across `.await` points can cause deadlocks (the tokio runtime may resume the task on a different thread). A future refactor that adds `.await` while the guard is held would silently compile but introduce undefined behavior or deadlocks.
+
+**Fix:** Replace `std::sync::Mutex` with `tokio::sync::Mutex` for `Channel.inner`, which yields a `Send`-safe guard natively. Alternatively, restructure the code so the `MutexGuard` is always dropped before any `.await` point without needing the unsafe workaround — the current code already does this, but the unsafe shim is fragile against future changes.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/execute/src/channel.rs`
+
+## GRETH-023: OracleRelayerManager::new Panics on None Datadir
+
+**Problem:** `oracle_manager.rs:L134` calls `datadir.unwrap()` on an `Option<PathBuf>` parameter. The function signature `fn new(datadir: Option<PathBuf>) -> Self` advertises that `datadir` is optional, but the implementation panics if `None` is passed. This can crash the node at startup if the relayer is configured without a data directory. The `Default` impl at L122–L126 calls `Self::new(None)`, guaranteeing a panic.
+
+**Fix:** Either (a) change the parameter type to `PathBuf` (removing the `Option`) and fix all call sites including `Default`, or (b) handle `None` gracefully by defaulting to a temporary directory or disabling persistence.
+
+**Files:** `crates/pipe-exec-layer-ext-v2/relayer/src/oracle_manager.rs`


### PR DESCRIPTION
Security audit round 2 covering GRETH-020 through GRETH-028:
- 2 HIGH (debug-only validation, silent system txn failure)
- 3 MEDIUM (mint precompile trailing bytes, unsafe Send impl, unwrap panic)
- 4 LOW/INFO (nonce truncation, state merge overwrite, same-RPC verification, timestamp check)

Design documents detail the problem and fix approach for each severity level.