### PR TITLE
chore: datadir for relayer state must be set when launching chain node

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/relayer/src/oracle_manager.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/oracle_manager.rs
@@ -119,19 +119,12 @@ pub struct OracleRelayerManager {
     state: RwLock<RelayerState>,
 }
 
-impl Default for OracleRelayerManager {
-    fn default() -> Self {
-        Self::new(None)
-    }
-}
-
 impl OracleRelayerManager {
     /// Create a new OracleRelayerManager with optional persistence
     ///
     /// # Arguments
     /// * `datadir` - Optional path to data directory for state persistence
-    pub fn new(datadir: Option<PathBuf>) -> Self {
-        let datadir = datadir.unwrap();
+    pub fn new(datadir: PathBuf) -> Self {
         let state = load_state_if_exists(&datadir).unwrap_or_else(RelayerState::new);
 
         Self { sources: RwLock::new(HashMap::new()), datadir, state: RwLock::new(state) }


### PR DESCRIPTION
Since now we use the datadir for chain data so it must be set. No need for option.