### PR TITLE
fix(precompiles): execute system transactions as normal transactions

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -18,15 +18,16 @@
 extern crate alloc;
 
 use crate::parallel_execute::GrevmExecutor;
-use alloc::{borrow::Cow, boxed::Box, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{BlockHeader, Header};
 use alloy_eips::Decodable2718;
 pub use alloy_evm::EthEvm;
 use alloy_evm::{
     eth::{EthBlockExecutionCtx, EthBlockExecutorFactory},
+    precompiles::DynPrecompile,
     EthEvmFactory,
 };
-use alloy_primitives::{Bytes, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_types_engine::ExecutionData;
 use core::{convert::Infallible, fmt::Debug};
 use gravity_primitives::get_gravity_config;
@@ -43,17 +44,21 @@ use reth_primitives_traits::{
 };
 use reth_storage_errors::any::AnyError;
 use revm::{
-    context::{BlockEnv, CfgEnv},
+    context::{
+        result::{ExecutionResult, HaltReason},
+        BlockEnv, CfgEnv,
+    },
     context_interface::block::BlobExcessGasAndPrice,
-    database::WrapDatabaseRef,
+    database::{State, WrapDatabaseRef},
     primitives::hardfork::SpecId,
 };
 
 mod config;
 use alloy_eips::{eip1559::INITIAL_BASE_FEE, eip7840::BlobParams};
-use alloy_evm::eth::spec::EthExecutorSpec;
+use alloy_evm::{eth::spec::EthExecutorSpec, Database, Evm};
 pub use config::{revm_spec, revm_spec_by_timestamp_and_block_number};
 use reth_ethereum_forks::{EthereumHardfork, Hardforks};
+use revm::{context::TxEnv, DatabaseCommit};
 
 /// Helper type with backwards compatible methods to obtain Ethereum executor
 /// providers.
@@ -295,6 +300,27 @@ where
         } else {
             Box::new(GrevmExecutor::new(self.chain_spec().clone(), self, db))
         }
+    }
+
+    fn transact_system_txn<DB: Database>(
+        &self,
+        db: &mut State<DB>,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, BlockExecutionError> {
+        let (execution_result, evm_state) = {
+            let mut evm = self.evm_with_env(&mut *db, evm_env);
+            for (addr, precompile) in precompiles {
+                Evm::precompiles_mut(&mut evm).apply_precompile(&addr, move |_| Some(precompile));
+            }
+            let result = Evm::transact_raw(&mut evm, tx_env).map_err(|e| {
+                BlockExecutionError::msg(alloc::format!("system txn execution failed: {e:?}"))
+            })?;
+            (result.result, result.state)
+        };
+        db.commit(evm_state);
+        Ok(execution_result)
     }
 }
 

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -20,11 +20,15 @@ use reth_evm::{
         BlockExecutionError, BlockValidationError, ExecuteOutput, InternalBlockExecutionError,
     },
     parallel_execute::ParallelExecutor,
-    ConfigureEvm, ParallelDatabase,
+    ConfigureEvm, Evm, ParallelDatabase,
 };
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{BlockBody, NodePrimitives, RecoveredBlock, SignedTransaction};
 use revm::{
+    context::{
+        result::{ExecutionResult, HaltReason},
+        TxEnv,
+    },
     database::{
         states::bundle_state::BundleRetention, BundleState, TransitionState, WrapDatabaseRef,
     },
@@ -229,8 +233,11 @@ where
             self.execute_transactions(block)?
         };
         let requests = self.apply_post_execution_changes(block, &receipts)?;
-        let state_mut =
-            self.state.as_mut().expect("state should be set before calling merge_transitions");
+        Ok(BlockExecutionResult { receipts, gas_used, requests })
+    }
+
+    fn take_bundle(&mut self) -> BundleState {
+        let state_mut = self.state.as_mut().unwrap();
         if let Some(transition_state) =
             state_mut.transition_state.as_mut().map(TransitionState::take)
         {
@@ -239,27 +246,36 @@ where
                 BundleRetention::Reverts,
             );
         }
-        Ok(BlockExecutionResult { receipts, gas_used, requests })
-    }
-
-    fn take_bundle(&mut self) -> BundleState {
-        self.state.as_mut().expect("state should be set before calling take_bundle").take_bundle()
+        state_mut.take_bundle()
     }
 
     fn size_hint(&self) -> usize {
-        self.state
-            .as_ref()
-            .expect("state should be set before calling size_hint")
-            .bundle_size_hint()
+        self.state.as_ref().unwrap().bundle_size_hint()
     }
 
-    fn commit_changes(&mut self, changes: EvmState) {
-        // Load all accounts in the changes map to ensure they are cached before committing.
-        let state = self.state.as_mut().expect("state should be set before calling commit_changes");
-        for address in changes.keys() {
-            state.load_mut_cache_account(*address).unwrap();
-        }
-        state.commit(changes);
+    fn transact_system_txn(
+        &mut self,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, Self::Error> {
+        let state = self.state.as_mut().unwrap();
+        // Phase 1: execute with WrapDatabaseRef(state).
+        let (execution_result, evm_state) = {
+            let mut evm = self.evm_config.evm_with_env(&mut *state, evm_env);
+            // Inject per-transaction system precompiles (mint, BLS, etc.)
+            for (addr, precompile) in precompiles {
+                evm.precompiles_mut().apply_precompile(&addr, move |_| Some(precompile));
+            }
+            let result = evm.transact_raw(tx_env).map_err(|e| {
+                BlockExecutionError::msg(alloc::format!("system txn execution failed: {e:?}"))
+            })?;
+            (result.result, result.state)
+        };
+
+        // Phase 2: commit the state changes directly into the executor's ParallelState.
+        state.commit(evm_state);
+        Ok(execution_result)
     }
 
     fn apply_custom_precompiles(&mut self, custom_precompiles: Arc<Vec<(Address, DynPrecompile)>>) {

--- a/crates/evm/evm/src/either.rs
+++ b/crates/evm/evm/src/either.rs
@@ -2,11 +2,18 @@
 
 use crate::{execute::Executor, Database, OnStateHook};
 
-// re-export Either
+use alloy_evm::{precompiles::DynPrecompile, EvmEnv};
+use alloy_primitives::Address;
 pub use futures_util::future::Either;
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
-use revm::{database::BundleState, state::EvmState};
+use revm::{
+    context::{
+        result::{ExecutionResult, HaltReason},
+        TxEnv,
+    },
+    database::BundleState,
+};
 
 impl<A, B, DB> Executor<DB> for Either<A, B>
 where
@@ -88,10 +95,15 @@ where
         }
     }
 
-    fn commit_changes(&mut self, changes: EvmState) {
+    fn transact_system_txn(
+        &mut self,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, Self::Error> {
         match self {
-            Self::Left(a) => a.commit_changes(changes),
-            Self::Right(b) => b.commit_changes(changes),
+            Self::Left(a) => a.transact_system_txn(evm_env, precompiles, tx_env),
+            Self::Right(b) => b.transact_system_txn(evm_env, precompiles, tx_env),
         }
     }
 }

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -7,6 +7,7 @@ use alloy_eips::eip2718::WithEncoded;
 pub use alloy_evm::block::{BlockExecutor, BlockExecutorFactory};
 use alloy_evm::{
     block::{CommitChanges, ExecutableTx},
+    precompiles::DynPrecompile,
     Evm, EvmEnv, EvmFactory, RecoveredTx, ToTxEnv,
 };
 use alloy_primitives::{Address, B256};
@@ -22,10 +23,11 @@ use reth_storage_api::StateProvider;
 pub use reth_storage_errors::provider::ProviderError;
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
 use revm::{
-    context::result::ExecutionResult,
+    context::{
+        result::{ExecutionResult, HaltReason},
+        TxEnv,
+    },
     database::{states::bundle_state::BundleRetention, BundleState, State},
-    state::EvmState,
-    DatabaseCommit,
 };
 
 /// A type that knows how to execute a block. It is assumed to operate on a
@@ -135,8 +137,14 @@ pub trait Executor<DB: Database>: Sized {
     /// This is used to optimize DB commits depending on the size of the state.
     fn size_hint(&self) -> usize;
 
-    /// Commits the changes to the executor state.
-    fn commit_changes(&mut self, changes: EvmState);
+    /// Executes a single system transaction on the executor's own internal state and commits
+    /// the resulting state changes immediately.
+    fn transact_system_txn(
+        &mut self,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, Self::Error>;
 }
 
 /// Helper type for the output of executing a block.
@@ -590,8 +598,6 @@ where
             .with_state_hook(Some(Box::new(state_hook)))
             .execute_block(block.transactions_recovered())?;
 
-        self.db.merge_transitions(BundleRetention::Reverts);
-
         Ok(result)
     }
 
@@ -600,19 +606,21 @@ where
     }
 
     fn take_bundle(&mut self) -> BundleState {
+        self.db.merge_transitions(BundleRetention::Reverts);
         self.db.take_bundle()
-    }
-
-    fn commit_changes(&mut self, changes: EvmState) {
-        // Load all accounts in the changes map to ensure they are cached before committing.
-        for address in changes.keys() {
-            self.db.load_cache_account(*address).unwrap();
-        }
-        self.db.commit(changes);
     }
 
     fn size_hint(&self) -> usize {
         self.db.bundle_state.size_hint()
+    }
+
+    fn transact_system_txn(
+        &mut self,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, Self::Error> {
+        self.strategy_factory.transact_system_txn(&mut self.db, evm_env, precompiles, tx_env)
     }
 }
 
@@ -712,12 +720,17 @@ mod tests {
             unreachable!()
         }
 
-        fn commit_changes(&mut self, _changes: EvmState) {
-            unreachable!()
-        }
-
         fn size_hint(&self) -> usize {
             0
+        }
+
+        fn transact_system_txn(
+            &mut self,
+            _evm_env: EvmEnv,
+            _precompiles: Vec<(Address, DynPrecompile)>,
+            _tx_env: TxEnv,
+        ) -> Result<ExecutionResult<HaltReason>, Self::Error> {
+            unreachable!()
         }
     }
 

--- a/crates/evm/evm/src/lib.rs
+++ b/crates/evm/evm/src/lib.rs
@@ -26,7 +26,7 @@ use alloy_eips::{
 };
 use alloy_evm::{
     block::{BlockExecutorFactory, BlockExecutorFor},
-    precompiles::PrecompilesMap,
+    precompiles::{DynPrecompile, PrecompilesMap},
 };
 use alloy_primitives::{Address, B256};
 use core::{error::Error, fmt::Debug};
@@ -35,7 +35,11 @@ use reth_execution_errors::BlockExecutionError;
 use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, ReceiptTy, SealedBlock, SealedHeader, TxTy,
 };
-use revm::{context::TxEnv, database::State};
+use revm::{
+    context::{result::ExecutionResult, TxEnv},
+    context_interface::result::HaltReason,
+    database::State,
+};
 
 pub mod either;
 /// EVM environment configuration.
@@ -458,6 +462,21 @@ pub trait ConfigureEvm: Clone + Debug + Send + Sync + Unpin {
         db: DB,
     ) -> impl Executor<DB, Primitives = Self::Primitives, Error = BlockExecutionError> {
         BasicBlockExecutor::new(self, db)
+    }
+
+    /// Executes a single system transaction directly against the given database state and commits
+    /// the resulting state changes immediately.
+    ///
+    /// Default: `unimplemented!()` — override in every `ConfigureEvm` impl that supports system
+    /// transactions.
+    fn transact_system_txn<DB: Database>(
+        &self,
+        _db: &mut State<DB>,
+        _evm_env: EvmEnv,
+        _precompiles: Vec<(Address, DynPrecompile)>,
+        _tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, BlockExecutionError> {
+        unimplemented!("transact_system_txn not implemented for this ConfigureEvm")
     }
 
     /// Returns a new [`ParallelExecutor`].

--- a/crates/evm/evm/src/parallel_execute.rs
+++ b/crates/evm/evm/src/parallel_execute.rs
@@ -4,11 +4,15 @@ use core::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::execute::Executor;
-use alloy_evm::{precompiles::DynPrecompile, Database};
+use alloy_evm::{precompiles::DynPrecompile, Database, EvmEnv};
 use alloy_primitives::Address;
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
-use revm::{database::BundleState, state::EvmState};
+use revm::{
+    context::TxEnv,
+    context_interface::result::{ExecutionResult, HaltReason},
+    database::BundleState,
+};
 
 /// The `ParallelExecutor` trait defines the interface for executing EVM blocks in parallel.
 pub trait ParallelExecutor {
@@ -47,18 +51,28 @@ pub trait ParallelExecutor {
         Ok(BlockExecutionOutput { state: self.take_bundle(), result })
     }
 
-    /// Commits the changes to the executor state.
-    fn commit_changes(&mut self, changes: EvmState);
+    /// Executes a single system transaction on the executor's own internal state and commits
+    /// the resulting state changes immediately.
+    ///
+    /// The EVM is constructed internally using the executor's `ParallelState` as the DB,
+    /// so there is only ONE source of truth. State changes are committed immediately after
+    /// execution. The next call will see updated nonces, balances, and storage without any
+    /// external bridging.
+    ///
+    /// `precompiles` allows callers to inject custom precompiles (e.g. mint, BLS) for this
+    /// specific transaction, in addition to any executor-level custom precompiles.
+    fn transact_system_txn(
+        &mut self,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, Self::Error>;
 
     /// Applies custom precompiled contracts to the executor.
     ///
     /// These precompiles will be available during transaction execution alongside
     /// the standard Ethereum precompiles. This is a no-op by default.
-    fn apply_custom_precompiles(
-        &mut self,
-        _custom_precompiles: Arc<Vec<(Address, DynPrecompile)>>,
-    ) {
-    }
+    fn apply_custom_precompiles(&mut self, custom_precompiles: Arc<Vec<(Address, DynPrecompile)>>);
 }
 
 /// Wraps a [`Executor`] to provide a [`ParallelExecutor`] implementation.
@@ -96,7 +110,20 @@ impl<DB: Database, T: Executor<DB>> ParallelExecutor for WrapExecutor<DB, T> {
     }
 
     #[inline]
-    fn commit_changes(&mut self, changes: EvmState) {
-        self.0.commit_changes(changes);
+    fn transact_system_txn(
+        &mut self,
+        evm_env: EvmEnv,
+        precompiles: Vec<(Address, DynPrecompile)>,
+        tx_env: TxEnv,
+    ) -> Result<ExecutionResult<HaltReason>, Self::Error> {
+        self.0.transact_system_txn(evm_env, precompiles, tx_env)
+    }
+
+    #[inline]
+    fn apply_custom_precompiles(
+        &mut self,
+        _custom_precompiles: Arc<Vec<(Address, DynPrecompile)>>,
+    ) {
+        // TODO(Ashin Gau): How does basic executor handle custom precompiles
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -25,13 +25,13 @@ use alloy_primitives::{
 };
 use alloy_rpc_types_eth::TransactionRequest;
 use gravity_primitives::get_gravity_config;
-use grevm::ParallelState;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_chain_state::{ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates};
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_ethereum_primitives::{Block, BlockBody, Receipt, TransactionSigned};
 use reth_evm::{
-    precompiles::DynPrecompile, ConfigureEvm, Evm, NextBlockEnvAttributes, ParallelDatabase,
+    execute::BlockExecutionError, precompiles::DynPrecompile, ConfigureEvm, IntoTxEnv,
+    NextBlockEnvAttributes, ParallelDatabase,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
@@ -39,18 +39,14 @@ use reth_pipe_exec_layer_event_bus::{
     MakeCanonicalEvent, PipeExecLayerEvent, PipeExecLayerEventBus, WaitForPersistenceEvent,
     PIPE_EXEC_LAYER_EVENT_BUS,
 };
-use reth_primitives::EthPrimitives;
+use reth_primitives::{EthPrimitives, Recovered};
 use reth_primitives_traits::{
     proofs::{self},
     Block as _, RecoveredBlock,
 };
 use reth_provider::{OriginalValuesKnown, PersistBlockCache, PERSIST_BLOCK_CACHE};
 use reth_rpc_eth_api::RpcTypes;
-use revm::{
-    database::{states::bundle_state::BundleRetention, State},
-    state::AccountInfo,
-    Database, DatabaseCommit,
-};
+use revm::{state::AccountInfo, DatabaseRef};
 use std::{
     collections::BTreeMap,
     sync::{
@@ -62,6 +58,7 @@ use std::{
 
 use gravity_storage::GravityStorage;
 use onchain_config::OnchainConfigFetcher;
+use reth_evm::parallel_execute::ParallelExecutor;
 use reth_rpc_eth_api::helpers::EthCall;
 use reth_trie::{HashedPostState, KeccakKeyHasher};
 use tokio::sync::{
@@ -76,7 +73,6 @@ use crate::{
     onchain_config::{
         construct_metadata_txn, construct_validator_txn_from_extra_data,
         dkg::{convert_dkg_start_event_to_api, DKGStartEvent},
-        transact_system_txn,
         types::DataRecorded,
         SystemTxnResult, BLS_PRECOMPILE_ADDR, NATIVE_MINT_PRECOMPILE_ADDR, SYSTEM_CALLER,
     },
@@ -307,11 +303,7 @@ struct ExecuteOrderedBlockResult {
 /// This enum represents both outcomes.
 enum SystemTxnExecutionOutcome {
     /// Normal execution completed, continue with block processing
-    Continue {
-        metadata_result: SystemTxnResult,
-        accumulated_state_changes: revm::state::EvmState,
-        validator_results: Vec<SystemTxnResult>,
-    },
+    Continue { metadata_result: SystemTxnResult, validator_results: Vec<SystemTxnResult> },
     /// Epoch changed, return early with the result
     EpochChanged(ExecuteOrderedBlockResult),
 }
@@ -664,9 +656,11 @@ impl<Storage: GravityStorage> Core<Storage> {
     /// Returns `SystemTxnExecutionOutcome::EpochChanged` if a new epoch was triggered,
     /// otherwise returns `SystemTxnExecutionOutcome::Continue` with the results.
     fn execute_system_transactions(
-        evm_config: &EthEvmConfig,
+        executor: &mut dyn ParallelExecutor<
+            Primitives = EthPrimitives,
+            Error = BlockExecutionError,
+        >,
         chain_spec: &ChainSpec,
-        state: &Arc<Storage::StateView>,
         evm_env: reth_evm::EvmEnv,
         ordered_block: &OrderedBlock,
         base_fee: u64,
@@ -674,52 +668,38 @@ impl<Storage: GravityStorage> Core<Storage> {
         block_id: B256,
         parent_id: B256,
         block_number: u64,
+        initial_nonce: u64,
     ) -> SystemTxnExecutionOutcome {
-        let mut inner_state =
-            State::builder().with_database_ref(state).with_bundle_update().build();
-        let mut evm = evm_config.evm_with_env(&mut inner_state, evm_env);
-
-        // Create shared state for precompile - keep a reference so we can extract changes later
-        let state_for_precompile = {
-            let report_db_metrics = get_gravity_config().report_db_metrics;
-            let parallel_state = ParallelState::new(state.clone(), true, report_db_metrics);
-            Arc::new(parking_lot::Mutex::new(parallel_state))
-        };
-        let state_for_precompile_ref = state_for_precompile.clone();
-        let precompile = create_mint_token_precompile(state_for_precompile);
-        evm.precompiles_mut()
-            .apply_precompile(&NATIVE_MINT_PRECOMPILE_ADDR, move |_| Some(precompile));
-
-        // Register BLS12-381 PoP verification precompile (stateless)
+        let mint_precompile = create_mint_token_precompile();
         let bls_precompile = create_bls_pop_verify_precompile();
-        evm.precompiles_mut().apply_precompile(&BLS_PRECOMPILE_ADDR, move |_| Some(bls_precompile));
+        let system_precompiles: Vec<(Address, DynPrecompile)> = vec![
+            (NATIVE_MINT_PRECOMPILE_ADDR, mint_precompile),
+            (BLS_PRECOMPILE_ADDR, bls_precompile),
+        ];
 
-        // Get system caller nonce and gas price for constructing all system transactions
-        let system_call_account =
-            evm.db_mut().basic(SYSTEM_CALLER).unwrap().expect("SYSTEM_CALLER not exists");
-        let gas_price = evm.block().basefee as u128;
-        let mut current_nonce = system_call_account.nonce;
-        // Construct and execute metadata transaction using unified entry point
+        let mut current_nonce = initial_nonce;
+        // -----------------------------------------------------------------------
+        // Metadata transaction (onBlockStart)
+        // -----------------------------------------------------------------------
         let metadata_txn = construct_metadata_txn(
             current_nonce,
-            gas_price,
+            base_fee as u128,
             ordered_block.timestamp_us,
             ordered_block.proposer_index,
         );
         current_nonce = metadata_txn.nonce() + 1;
 
-        let (metadata_txn_result, metadata_state_changes) =
-            transact_system_txn(&mut evm, metadata_txn);
+        let metadata_tx_env =
+            Recovered::new_unchecked(metadata_txn.clone(), SYSTEM_CALLER).into_tx_env();
+        let metadata_execution_result = executor
+            .transact_system_txn(evm_env.clone(), system_precompiles.clone(), metadata_tx_env)
+            .unwrap_or_else(|e| panic!("metadata txn execution failed: {e:?}"));
 
-        // Commit metadata state changes immediately so subsequent txns see nonce update
-        evm.db_mut().commit(metadata_state_changes.clone());
+        let metadata_txn_result =
+            SystemTxnResult { result: metadata_execution_result, txn: metadata_txn };
 
-        // Accumulate state changes for returning to executor
-        let mut accumulated_state_changes = metadata_state_changes;
-
-        // Check for epoch change
+        // Check for epoch change from metadata txn
         if let Some((new_epoch, validators)) = metadata_txn_result.emit_new_epoch() {
-            drop(evm);
             assert_eq!(new_epoch, epoch + 1);
             info!(target: "execute_ordered_block",
                 id=?block_id,
@@ -728,13 +708,15 @@ impl<Storage: GravityStorage> Core<Storage> {
                 new_epoch=?new_epoch,
                 "emit new epoch, discard the block"
             );
-            inner_state.merge_transitions(BundleRetention::Reverts);
+            // merge_transitions was already called inside transact_system_txn,
+            // so take_bundle() returns the complete bundle with all system-txn changes.
+            let bundle = executor.take_bundle();
             return SystemTxnExecutionOutcome::EpochChanged(
                 metadata_txn_result.into_executed_ordered_block_result(
                     chain_spec,
                     ordered_block,
                     base_fee,
-                    inner_state.take_bundle(),
+                    bundle,
                     validators,
                 ),
             );
@@ -745,35 +727,36 @@ impl<Storage: GravityStorage> Core<Storage> {
             "metadata transaction result"
         );
 
-        // Execute validator transactions (DKG and JWK) one by one
-        // DKG transactions are executed first since they may trigger epoch changes
+        // -----------------------------------------------------------------------
+        // Validator transactions (DKG and JWK) — sorted: DKG first, JWK second
+        // -----------------------------------------------------------------------
         let mut validator_txn_results: Vec<SystemTxnResult> = Vec::new();
 
-        // Sort extra_data: DKG first, then JWK
         let mut sorted_extra_data: Vec<_> = ordered_block.extra_data.iter().collect();
         sorted_extra_data.sort_by_key(|data| match data {
-            ExtraDataType::DKG(_) => 0, // DKG comes first
-            ExtraDataType::JWK(_) => 1, // JWK comes second
+            ExtraDataType::DKG(_) => 0,
+            ExtraDataType::JWK(_) => 1,
         });
 
         for (index, extra_data) in sorted_extra_data.iter().enumerate() {
             let is_dkg = matches!(extra_data, ExtraDataType::DKG(_));
-            // Try to construct validator transaction, skip if failed
-            let txn =
-                match construct_validator_txn_from_extra_data(extra_data, current_nonce, gas_price)
-                {
-                    Ok(txn) => txn,
-                    Err(e) => {
-                        error!(target: "execute_ordered_block",
-                            index=?index,
-                            is_dkg=?is_dkg,
-                            block_number=?block_number,
-                            error=?e,
-                            "Failed to construct validator transaction, skipping"
-                        );
-                        continue;
-                    }
-                };
+            let txn = match construct_validator_txn_from_extra_data(
+                extra_data,
+                current_nonce,
+                base_fee as u128,
+            ) {
+                Ok(txn) => txn,
+                Err(e) => {
+                    error!(target: "execute_ordered_block",
+                        index=?index,
+                        is_dkg=?is_dkg,
+                        block_number=?block_number,
+                        error=?e,
+                        "Failed to construct validator transaction, skipping"
+                    );
+                    continue;
+                }
+            };
             current_nonce += 1;
 
             debug!(target: "execute_ordered_block",
@@ -784,20 +767,16 @@ impl<Storage: GravityStorage> Core<Storage> {
                 "executing validator transaction one by one"
             );
 
-            let (validator_result, validator_state_changes) = transact_system_txn(&mut evm, txn);
+            let tx_env = Recovered::new_unchecked(txn.clone(), SYSTEM_CALLER).into_tx_env();
+            let execution_result = executor
+                .transact_system_txn(evm_env.clone(), system_precompiles.clone(), tx_env)
+                .unwrap_or_else(|e| panic!("validator txn execution failed: {e:?}"));
 
-            // Commit state changes immediately so subsequent txns see nonce update
-            evm.db_mut().commit(validator_state_changes.clone());
-
-            // Merge state changes into accumulated changes
-            for (addr, account) in validator_state_changes {
-                accumulated_state_changes.insert(addr, account);
-            }
+            let validator_result = SystemTxnResult { result: execution_result, txn };
 
             // DKG transactions may trigger epoch change
             if is_dkg {
                 if let Some((new_epoch, validators)) = validator_result.emit_new_epoch() {
-                    drop(evm);
                     assert_eq!(new_epoch, epoch + 1);
                     info!(target: "execute_ordered_block",
                         id=?block_id,
@@ -806,13 +785,13 @@ impl<Storage: GravityStorage> Core<Storage> {
                         new_epoch=?new_epoch,
                         "DKG triggered new epoch, discard the block"
                     );
-                    inner_state.merge_transitions(BundleRetention::Reverts);
+                    let bundle = executor.take_bundle();
                     return SystemTxnExecutionOutcome::EpochChanged(
                         validator_result.into_executed_ordered_block_result(
                             chain_spec,
                             ordered_block,
                             base_fee,
-                            inner_state.take_bundle(),
+                            bundle,
                             validators,
                         ),
                     );
@@ -830,43 +809,8 @@ impl<Storage: GravityStorage> Core<Storage> {
             validator_txn_results.push(validator_result);
         }
 
-        drop(evm);
-
-        // Extract changes from precompile state and merge into accumulated_state_changes
-        {
-            let mut precompile_state = state_for_precompile_ref.lock();
-            precompile_state.merge_transitions(BundleRetention::Reverts);
-            let precompile_bundle = precompile_state.take_bundle();
-
-            // DESIGN: Using `insert` (shallow merge) is intentional here.
-            // The mint precompile only modifies regular user accounts (mint recipients),
-            // which are disjoint from accounts touched by system transactions
-            // (SYSTEM_CALLER, on-chain config contracts). The two state domains are
-            // architecturally separated: precompiles use `ParallelState` while system
-            // txns use the EVM's `inner_state`, so address overlap does not occur.
-            for (address, account) in precompile_bundle.state {
-                if let Some(info) = account.info {
-                    use revm::state::{Account, AccountStatus, EvmStorageSlot};
-                    accumulated_state_changes.insert(
-                        address,
-                        Account {
-                            info,
-                            storage: account
-                                .storage
-                                .into_iter()
-                                .map(|(k, v)| (k, EvmStorageSlot::new(v.present_value, 0)))
-                                .collect(),
-                            status: AccountStatus::Touched,
-                            transaction_id: 0,
-                        },
-                    );
-                }
-            }
-        }
-
         SystemTxnExecutionOutcome::Continue {
             metadata_result: metadata_txn_result,
-            accumulated_state_changes,
             validator_results: validator_txn_results,
         }
     }
@@ -968,7 +912,7 @@ impl<Storage: GravityStorage> Core<Storage> {
         assert_eq!(block_number, parent_header.number + 1);
         let epoch = ordered_block.epoch;
 
-        let state = Arc::new(self.storage.get_state_view().unwrap());
+        let state = self.storage.get_state_view().unwrap();
 
         let evm_env = self
             .evm_config
@@ -989,37 +933,46 @@ impl<Storage: GravityStorage> Core<Storage> {
             block_number=?block_number,
         );
         let base_fee = evm_env.block_env.basefee;
-        //             let mut evm = self.evm_config.evm_with_env(&mut state, evm_env);
-        //  evm apply precompile
-        // for xx in xx {  evm.execute_transaction(tx) }
-        // cases
 
-        // Execute system transactions (metadata, DKG, JWK) sequentially
-        let (metadata_txn_result, accumulated_state_changes, validator_txn_results) =
-            match Self::execute_system_transactions(
-                &self.evm_config,
-                &self.chain_spec,
-                &state,
-                evm_env,
-                &ordered_block,
-                base_fee,
-                epoch,
-                block_id,
-                parent_id,
-                block_number,
-            ) {
-                SystemTxnExecutionOutcome::EpochChanged(result) => return result,
-                SystemTxnExecutionOutcome::Continue {
-                    metadata_result,
-                    accumulated_state_changes,
-                    validator_results,
-                } => (metadata_result, accumulated_state_changes, validator_results),
-            };
+        // Read SYSTEM_CALLER nonce and gas price from state BEFORE moving state into executor.
+        // ParallelDatabase (Storage::StateView) implements DatabaseRef, so we can read directly.
+        let initial_nonce = state
+            .basic_ref(SYSTEM_CALLER)
+            .expect("failed to read SYSTEM_CALLER account from state")
+            .map(|a| a.nonce)
+            .unwrap_or(0);
 
-        // No longer pass validator_txns to create_block_for_executor since they are executed
-        // separately
+        // Create executor with state. System transactions will commit directly to its
+        // ParallelState, so there is a single source of truth for both system and user txns.
+        let mut executor = self.evm_config.parallel_executor(state);
+        executor.apply_custom_precompiles(self.custom_precompiles.clone());
+
+        // Execute system transactions (metadata, DKG, JWK) sequentially.
+        // State changes are committed directly into executor's ParallelState.
+        let (metadata_txn_result, validator_txn_results) = match Self::execute_system_transactions(
+            &mut *executor,
+            &self.chain_spec,
+            evm_env,
+            &ordered_block,
+            base_fee,
+            epoch,
+            block_id,
+            parent_id,
+            block_number,
+            initial_nonce,
+        ) {
+            SystemTxnExecutionOutcome::EpochChanged(result) => return result,
+            SystemTxnExecutionOutcome::Continue { metadata_result, validator_results } => {
+                (metadata_result, validator_results)
+            }
+        };
+
+        // State was moved into executor above. Get a fresh snapshot view for block construction.
+        // filter_invalid_txs only reads from storage (not the in-memory ParallelState cache),
+        // so both views see the same committed on-chain data.
+        let state_for_block = self.storage.get_state_view().unwrap();
         let (block, txs_info) =
-            self.create_block_for_executor(ordered_block, base_fee, &state, vec![]);
+            self.create_block_for_executor(ordered_block, base_fee, &state_for_block, vec![]);
 
         info!(target: "execute_ordered_block",
             id=?block_id,
@@ -1030,11 +983,6 @@ impl<Storage: GravityStorage> Core<Storage> {
             "ready to execute block"
         );
 
-        let mut executor = self.evm_config.parallel_executor(state);
-        executor.apply_custom_precompiles(self.custom_precompiles.clone());
-        // Apply all pre-executed transaction state changes (metadata + validator txns) to executor
-        // state
-        executor.commit_changes(accumulated_state_changes);
         let outcome = executor.execute(&block).unwrap_or_else(|err| {
             serde_json::to_writer_pretty(
                 std::io::BufWriter::new(std::fs::File::create(format!("{block_id}.json")).unwrap()),

--- a/crates/pipe-exec-layer-ext-v2/execute/src/mint_precompile.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/mint_precompile.rs
@@ -1,17 +1,12 @@
 //! Mint Token Precompile Contract
 //!
 //! This precompile allows authorized callers (JWK Manager) to mint tokens
-//! directly to specified recipient addresses.
+//! directly to specified recipient addresses by modifying the EVM journal state
+//! in-place via `EvmInternals`.
 
-use alloy_primitives::{address, map::HashMap, Address, Bytes, U256};
-use grevm::ParallelState;
-use parking_lot::Mutex;
-use reth_evm::{
-    precompiles::{DynPrecompile, PrecompileInput},
-    ParallelDatabase,
-};
+use alloy_primitives::{address, Address, Bytes, U256};
+use reth_evm::precompiles::{DynPrecompile, PrecompileInput};
 use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
-use std::sync::Arc;
 use tracing::{info, warn};
 
 /// Authorized caller address (JWK Manager at 0x2018)
@@ -25,34 +20,32 @@ const FUNC_MINT: u8 = 0x01;
 /// Base gas cost for mint operation
 const MINT_BASE_GAS: u64 = 21000;
 
-/// Creates a mint token precompile contract instance with state access.
+/// Creates a mint token precompile contract instance.
 ///
-/// The precompile contract allows authorized callers to submit mint requests
-/// and directly modifies the recipient's balance in the state.
-///
-/// # Arguments
-///
-/// * `state` - Shared ParallelState wrapped in `Arc<Mutex<>>` for thread-safe access
+/// The precompile directly modifies the recipient account's balance inside the
+/// EVM journal (via [`EvmInternals::load_account`]) during execution.
 ///
 /// # Returns
 ///
-/// A dynamic precompile that can be registered with the EVM
-pub fn create_mint_token_precompile<DB: ParallelDatabase + Send + Sync + 'static>(
-    state: Arc<Mutex<ParallelState<DB>>>,
-) -> DynPrecompile {
+/// A dynamic precompile that can be registered with the EVM.
+pub fn create_mint_token_precompile() -> DynPrecompile {
     let precompile_id = PrecompileId::custom("mint_token");
 
     (precompile_id, move |input: PrecompileInput<'_>| -> PrecompileResult {
-        mint_token_handler(input, state.clone())
+        mint_token_handler(input)
     })
         .into()
 }
 
 /// Mint Token handler function
 ///
+/// Directly modifies the recipient's balance in the EVM journal state, ensuring
+/// the change is visible to subsequent opcodes within the same block and is
+/// committed atomically with the rest of the transaction's state changes.
+///
 /// # Security
 ///
-/// - Only JWK Manager (0x2018) is allowed to call this precompile
+/// - Only JWK Manager (AUTHORIZED_CALLER) is allowed to call this precompile
 /// - Calls from other addresses will be rejected with an error
 ///
 /// # Parameter format (53 bytes)
@@ -69,10 +62,9 @@ pub fn create_mint_token_precompile<DB: ParallelDatabase + Send + Sync + 'static
 /// - `Invalid input length` - Input data is less than 53 bytes
 /// - `Invalid function ID` - Function ID is not 0x01
 /// - `Invalid or zero amount` - Amount is zero or exceeds u128::MAX
-fn mint_token_handler<DB: ParallelDatabase + Send + Sync>(
-    input: PrecompileInput<'_>,
-    state: Arc<Mutex<ParallelState<DB>>>,
-) -> PrecompileResult {
+/// - `Balance overflow` - Adding amount would overflow the recipient's balance
+/// - `Failed to load account` - Journal failed to load the recipient account
+fn mint_token_handler(mut input: PrecompileInput<'_>) -> PrecompileResult {
     // 1. Validate caller address
     if input.caller != AUTHORIZED_CALLER {
         warn!(
@@ -131,25 +123,28 @@ fn mint_token_handler<DB: ParallelDatabase + Send + Sync>(
         return Err(PrecompileError::Other("Zero amount not allowed".into()));
     }
 
-    // 6. Execute mint operation
-    let mut state_guard = state.lock();
-    if let Err(e) = state_guard.increment_balances(HashMap::from([(recipient, amount)])) {
-        warn!(
-            target: "evm::precompile::mint_token",
-            ?recipient,
-            amount,
-            error = ?e,
-            "Failed to increment balance"
-        );
-        return Err(PrecompileError::Other("Failed to mint tokens".into()));
-    }
-    drop(state_guard);
+    // 6. Load recipient account from EVM journal and directly increment its balance. `load_account`
+    //    either returns the cached journal entry or fetches from the underlying DB and inserts it
+    //    into the journal cache, always returning a `&mut Account`.
+    let state_load = input.internals_mut().load_account(recipient).map_err(|e| {
+        PrecompileError::Other(format!("Failed to load account {recipient}: {e}").into())
+    })?;
+    let account = state_load.data;
+    let new_balance = account
+        .info
+        .balance
+        .checked_add(U256::from(amount))
+        .ok_or_else(|| PrecompileError::Other("Balance overflow".into()))?;
+    account.info.balance = new_balance;
+    // Mark the account as touched so revm commits it to state on transaction end.
+    account.mark_touch();
 
     info!(
         target: "evm::precompile::mint_token",
         ?recipient,
         amount,
-        "Minted tokens successfully"
+        new_balance = ?new_balance,
+        "Minted tokens directly into journal state"
     );
 
     Ok(PrecompileOutput { gas_used: MINT_BASE_GAS, bytes: Bytes::new(), reverted: false })

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{onchain_config::BLOCK_ADDR, ExecuteOrderedBlockResult, OrderedBlock};
 use alloy_consensus::{constants::EMPTY_WITHDRAWALS, Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{eip4895::Withdrawals, merge::BEACON_NONCE};
-use alloy_primitives::{Bytes, U256};
+use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolEvent};
 use gravity_api_types::events::contract_event::GravityEvent;
 use gravity_primitives::get_gravity_config;


### PR DESCRIPTION
## Problem

Previously, system transactions (mint, BLS PoP, metadata, validator) were executed against a **temporary in-memory database** that was separate from the executor's own state. After execution, state changes had to be manually bridged back, which introduced two classes of bugs:

1. **State overwrite bug**: The temporary DB was initialized from a snapshot of the current state, but the executor's state could diverge between snapshots. Any changes made by one system transaction were invisible to the next, and the final `commit_changes` call could silently overwrite state already written by parallel user transactions.
2. **Lossy type conversion**: Balance increments were accumulated in a separate `PendingMints` structure and applied via `increment_balances` after EVM execution, bypassing the EVM journal entirely. This meant mint operations were not subject to EVM revert semantics.

Additionally, the mint precompile used a two-step design — recording intent into `PendingMints` and applying it externally — making the execution model inconsistent with how normal transactions work.

## Solution

### Direct state modification in the executor

[ParallelExecutor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/evm/evm/src/parallel_execute.rs:17:0-75:1) and [Executor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/evm/evm/src/execute.rs:35:0-148:1) traits gain a new [transact_system_txn(evm_env, precompiles, tx_env)](cci:1://file:///Users/gx/ws/git/block/gravity-reth/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs:188:0-211:1) method. Both [GrevmExecutor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/ethereum/evm/src/parallel_execute.rs:40:0-51:1) and [BasicBlockExecutor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/evm/evm/src/execute.rs:546:0-551:1) implement it by building the EVM **directly on top of the executor's own internal state** (`ParallelState` / `State<DB>`), not a temporary copy, then immediately committing the resulting `EvmState` back via `DatabaseCommit::commit`. Every subsequent transaction — system or user — sees the updated nonces, balances and storage without any manual bridging.

### Mint precompile rewired to modify EVM journal directly

`mint_precompile` no longer writes to `PendingMints`. It now calls `EvmInternals::load_account` to load the recipient account from the EVM journal and increments its balance in-place. The change participates correctly in checkpoint/revert semantics and is committed atomically with the rest of the system transaction.

### Unified system-transaction execution path

All system transactions (metadata, BLS PoP, mint, DKG, validator set updates) now go through the same [transact_system_txn](cci:1://file:///Users/gx/ws/git/block/gravity-reth/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs:188:0-211:1) code path, identical in structure to user-transaction execution. The special-cased `increment_balances` / `commit_changes` methods, the `PendingMints` accumulator, and the temporary database have all been removed.

## Interface changes

| Symbol | Change |
|---|---|
| `ParallelExecutor::transact_system_txn` | **New** — executes and commits one system tx on the executor's own state |
| `Executor::transact_system_txn` | **New** — same for sequential ([WrapExecutor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/evm/evm/src/parallel_execute.rs:79:0-79:79) / [BasicBlockExecutor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/evm/evm/src/execute.rs:546:0-551:1)) |
| `ParallelExecutor::increment_balances` | **Removed** |
| `ParallelExecutor::commit_changes` | **Removed** |
| `PendingMints` | **Removed** |

## Known limitation

[BasicBlockExecutor](cci:2://file:///Users/gx/ws/git/block/gravity-reth/crates/evm/evm/src/execute.rs:546:0-551:1) does not yet implement `ParallelExecutor::apply_custom_precompiles`. The sequential (`disable_grevm`) path therefore ignores executor-level custom precompiles; per-call precompiles injected via [transact_system_txn](cci:1://file:///Users/gx/ws/git/block/gravity-reth/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs:188:0-211:1) still work correctly.
