### PR TITLE
chore: update gravity-aptos dep for EpochBlockInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos?rev=6c778c7#6c778c77dfbdc73bac1eeaeb9f8202eab3da7ceb"
+source = "git+https://github.com/Galxe/gravity-aptos?branch=feat%2Fadd-epoch-block-info#758601339070da82968a466cba66eb1f040699a5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 # reth
-gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "6c778c7" }
+gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", branch = "feat/add-epoch-block-info" }
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }


### PR DESCRIPTION
## Summary

Update `gravity-api-types` dependency to track the `feat/add-epoch-block-info` branch of `gravity-aptos`, which adds `EpochBlockInfo` to `BlockInfo`.

### Related PRs
- gravity-aptos: https://github.com/Galxe/gravity-aptos/pull/57