### PR TITLE
feat: add hardfork testing framework (trait + generic helpers)

### DIFF
--- a/crates/ethereum/evm/src/hardfork/common.rs
+++ b/crates/ethereum/evm/src/hardfork/common.rs
@@ -1,0 +1,40 @@
+//! Common types and traits for Gravity hardfork state changes.
+//!
+//! Each hardfork module (alpha, beta, gamma, ...) defines a set of
+//! system contract bytecode upgrades. This module provides a trait
+//! that standardizes how upgrade tables are exposed, enabling generic
+//! verification logic in tests.
+
+use alloy_primitives::{Address, B256, U256};
+
+/// A single bytecode replacement: target address → new runtime bytecode.
+pub type BytecodeUpgrade = (Address, &'static [u8]);
+
+/// A single storage patch: target address, slot, value.
+pub type StoragePatch = (Address, B256, U256);
+
+/// Trait implemented by each hardfork module to describe its upgrades.
+///
+/// This enables generic test helpers that work across any hardfork:
+/// ```ignore
+/// fn verify_hardfork_applied<H: HardforkUpgrades>(provider: &P, block: u64) { ... }
+/// ```
+pub trait HardforkUpgrades {
+    /// The human-readable name of this hardfork (e.g. "Gamma").
+    fn name(&self) -> &'static str;
+
+    /// System contract bytecode upgrades: `(address, new_bytecode)` pairs.
+    fn system_upgrades(&self) -> &'static [BytecodeUpgrade];
+
+    /// Additional non-system contract bytecode upgrades (e.g. `StakePool` instances).
+    /// Returns `(address, new_bytecode)` pairs.
+    fn extra_upgrades(&self) -> &'static [BytecodeUpgrade] {
+        &[]
+    }
+
+    /// Storage patches to apply alongside bytecode replacements
+    /// (e.g. `ReentrancyGuard` initialization).
+    fn storage_patches(&self) -> &'static [StoragePatch] {
+        &[]
+    }
+}

--- a/crates/ethereum/evm/src/hardfork/mod.rs
+++ b/crates/ethereum/evm/src/hardfork/mod.rs
@@ -1,0 +1,7 @@
+//! Gravity-specific hardfork state changes.
+//!
+//! Each hardfork (alpha, beta, gamma, ...) should be added as a submodule
+//! on the corresponding release branch. The `common` module provides shared
+//! traits and types that all hardfork modules implement.
+
+pub mod common;

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -70,6 +70,7 @@ pub mod execute {
     pub type EthExecutorProvider = EthEvmConfig;
 }
 
+pub mod hardfork;
 pub mod parallel_execute;
 
 mod build;

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/HARDFORK_TESTING.md
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/HARDFORK_TESTING.md
@@ -1,0 +1,128 @@
+# Gravity Hardfork Integration Testing
+
+## Overview
+
+`gravity_hardfork_test.rs` is a **single-node integration test** that verifies reth correctly performs system contract bytecode replacements (hardfork) at a specified block number.
+
+## How It Works
+
+```
+Genesis (v1.0.0 old contracts) → run N blocks → gammaBlock triggers apply_gamma() → run M blocks → verify
+```
+
+1. **Build an old-version Genesis**: Check out a historical tag (e.g. `gravity-testnet-v1.0.0`) from the contracts repo, then run `scripts/generate_genesis_single.sh` to produce a `genesis.json` containing legacy contract bytecodes.
+2. **Inject hardfork config**: Add `gravityHardforks.gammaBlock` to the genesis JSON's `config` object.
+3. **Boot a reth node**: Start a single-node reth instance using the modified genesis.
+4. **Push blocks via MockConsensus**: Use `PipeExecLayerApi` to push empty blocks across the `gammaBlock` boundary.
+5. **Verify bytecode replacement**:
+   - Before hardfork (`gammaBlock - 1`): contract bytecodes must still be the old version.
+   - At hardfork (`gammaBlock`): contract bytecodes must match the new version.
+   - After hardfork: the node must continue producing blocks normally.
+
+## File Reference
+
+| File | Description |
+|------|-------------|
+| `gravity_hardfork_test.rs` | Integration test code |
+| `gravity_hardfork.json` | Legacy genesis with `gammaBlock` injected |
+| `HARDFORK_TESTING.md` | This document |
+
+Core code paths:
+
+| File | Description |
+|------|-------------|
+| `crates/chainspec/src/gravity.rs` | `GravityHardfork` enum (Alpha/Beta/Gamma) |
+| `crates/chainspec/src/spec.rs` | Parses `gravityHardforks.gammaBlock` from genesis JSON |
+| `crates/chainspec/src/api.rs` | `gamma_transitions_at_block()` trait method |
+| `crates/ethereum/evm/src/hardfork/gamma.rs` | Gamma bytecode constants and addresses |
+| `crates/ethereum/evm/src/parallel_execute.rs` | `apply_gamma()` bytecode replacement logic |
+
+## Generating the Test Genesis
+
+```bash
+# 1. Create a worktree at the old tag in the contracts repo
+cd gravity_chain_core_contracts
+git worktree add /tmp/gcc-v1.0.0 gravity-testnet-v1.0.0
+
+# 2. Install dependencies (forge-std, openzeppelin, etc.)
+cd /tmp/gcc-v1.0.0 && npm install
+
+# 3. Generate genesis
+bash scripts/generate_genesis_single.sh
+
+# 4. Inject gammaBlock
+python3 -c "
+import json
+with open('genesis.json') as f: g = json.load(f)
+g['config']['gravityHardforks'] = {'gammaBlock': 20}
+with open('gravity_hardfork.json', 'w') as f: json.dump(g, f, indent=2)
+"
+
+# 5. Copy to test directory
+cp gravity_hardfork.json <reth>/crates/pipe-exec-layer-ext-v2/execute/
+
+# 6. Clean up worktree
+cd gravity_chain_core_contracts && git worktree remove /tmp/gcc-v1.0.0
+```
+
+## Running the Test
+
+```bash
+cd crates/pipe-exec-layer-ext-v2/execute
+rm -rf data/gravity_hardfork_test   # Must clear stale data before each run
+RUSTFLAGS="--cfg tokio_unstable" cargo test --test gravity_hardfork_test -- --nocapture
+```
+
+## Pitfalls and Lessons Learned
+
+### 1. Genesis build requires node_modules
+`generate_genesis_single.sh` depends on `node_modules` (forge-std, openzeppelin). After checking out an old tag, you **must** run `npm install` first — otherwise Forge compilation will fail.
+
+### 2. `gravityHardforks` must be a top-level config key
+reth's `alloy_genesis` handles unknown config fields via `#[serde(flatten)]` into `extra_fields`. This means `gravityHardforks` must be a top-level key inside the `config` object — it cannot be nested under any other field.
+
+### 3. Contracts that didn't exist in the old genesis
+Contracts added after v1.0.0 (e.g. `OracleRequestQueue` at 0x1625F4002) won't be present in the legacy genesis. `apply_gamma()` already handles this by checking `if let Some(ref info)` and skipping missing accounts. The test must tolerate this as well.
+
+### 4. StakePool addresses are dynamically created
+StakePool is **not** a pre-deployed system contract at a fixed address. It is dynamically created via `CREATE` during `Genesis.initialize` in the genesis-tool. The address is deterministic but not in the `0x1625f` system range. To find it, look for accounts in the genesis `alloc` that have `code` but are outside the system address range.
+
+### 5. ReentrancyGuard storage must be initialized
+The new StakePool introduces OpenZeppelin v5's `ReentrancyGuardUpgradeable`, which uses ERC-7201 namespaced storage. When replacing the bytecode at hardfork time, the ReentrancyGuard storage slot **must** be initialized to `NOT_ENTERED` (1). Without this, the very first call to any guarded function will revert with `ReentrancyGuardReentrantCall`.
+
+### 6. StateProvider::storage() returns Option
+`StateProvider::storage()` returns `Result<Option<U256>>`, not `Result<U256>`. When asserting storage values, wrap the expected value in `Some(...)`.
+
+### 7. Data directory must be cleaned between runs
+reth persists its RocksDB state under `data/gravity_hardfork_test/`. Leftover data from a previous run will cause genesis initialization conflicts. Always `rm -rf data/gravity_hardfork_test` before each test run.
+
+## Guide: Adding a New Hardfork Test
+
+Using a hypothetical "Delta" hardfork as an example:
+
+### 1. Code Changes
+
+```
+crates/chainspec/src/gravity.rs             → Add Delta variant to GravityHardfork enum
+crates/chainspec/src/spec.rs                → Parse gravityHardforks.deltaBlock
+crates/chainspec/src/api.rs                 → Add delta_transitions_at_block()
+crates/ethereum/evm/src/hardfork/delta.rs   → New file with updated bytecode constants
+crates/ethereum/evm/src/parallel_execute.rs → Add apply_delta() call
+```
+
+### 2. Test Data
+
+- Pick a tag **after** Gamma as the "old version" and regenerate the genesis.
+- Alternatively, reuse `gravity_hardfork.json` and append `"deltaBlock": N` to the config.
+- To test both hardforks in sequence, set both `gammaBlock` and `deltaBlock` in the same genesis.
+
+### 3. Test Code
+
+- Either extend `gravity_hardfork_test.rs` with Delta verification logic, or create a separate `gravity_delta_hardfork_test.rs` for isolation.
+- The verification pattern is identical: old bytecodes before → new bytecodes at hardfork block → normal block execution after.
+
+### 4. Things to Watch For
+
+- If new contracts are being **deployed** (not just upgraded), `apply_delta()` needs to insert a new account rather than just replacing bytecode on an existing one.
+- If storage layout changes are involved (e.g. new storage slots), the initial values must be written in `apply_delta()`.
+- StakePool and other dynamically-created contract addresses must be enumerated from on-chain data and hardcoded into constants before deployment.

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/hardfork_test_helpers.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/hardfork_test_helpers.rs
@@ -1,0 +1,133 @@
+//! Reusable test helpers for Gravity hardfork integration tests.
+//!
+//! These helpers verify that contract bytecodes were correctly replaced
+//! during a hardfork. They work with any hardfork by accepting
+//! `(address, expected_bytecode)` slices as parameters.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use reth_evm_ethereum::hardfork::gamma::{GAMMA_SYSTEM_UPGRADES, STAKEPOOL_ADDRESSES, STAKEPOOL_BYTECODE};
+//!
+//! // Verify system contracts were upgraded at the hardfork block
+//! verify_bytecodes_at_block(&provider, hardfork_block, GAMMA_SYSTEM_UPGRADES, "Gamma system");
+//!
+//! // Verify they were NOT upgraded before the hardfork block
+//! verify_bytecodes_old_before_block(&provider, hardfork_block, GAMMA_SYSTEM_UPGRADES, "Gamma system");
+//! ```
+
+use alloy_primitives::{Address, B256, U256};
+use reth_provider::StateProviderFactory;
+
+/// Verify that all contracts in `upgrades` have the expected new bytecodes
+/// at the given `block_number`.
+///
+/// Panics if any mismatch is found. Contracts that don't exist on-chain
+/// are logged as warnings but not treated as failures (they may not have
+/// existed in the old genesis).
+pub fn verify_bytecodes_at_block<P: StateProviderFactory>(
+    provider: &P,
+    block_number: u64,
+    upgrades: &[(Address, &[u8])],
+    label: &str,
+) {
+    println!("[hardfork_test] Verifying {label} bytecodes at block {block_number}...");
+
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(block_number))
+        .expect("Failed to get state provider");
+
+    let mut all_ok = true;
+    for (addr, expected_bytecode) in upgrades {
+        match state.account_code(addr) {
+            Ok(Some(code)) => {
+                let code_bytes = code.original_bytes();
+                if code_bytes.as_ref() == *expected_bytecode {
+                    println!("[hardfork_test] ✅ {addr}: bytecode matches ({}B)", code_bytes.len());
+                } else {
+                    println!(
+                        "[hardfork_test] ❌ {addr}: MISMATCH got={}B expected={}B",
+                        code_bytes.len(),
+                        expected_bytecode.len()
+                    );
+                    all_ok = false;
+                }
+            }
+            Ok(None) => {
+                // Contract may not have existed in old genesis — skip
+                println!("[hardfork_test] ⚠ {addr}: no code found (not in old genesis, skip)");
+            }
+            Err(e) => {
+                println!("[hardfork_test] ❌ {addr}: error: {e:?}");
+                all_ok = false;
+            }
+        }
+    }
+
+    assert!(all_ok, "Not all {label} contracts were upgraded at block {block_number}!");
+    println!("[hardfork_test] ✅ All {} {label} bytecodes verified!", upgrades.len());
+}
+
+/// Verify that contracts in `upgrades` do NOT yet have the new bytecodes
+/// before the hardfork block (i.e. at `hardfork_block - 1`).
+///
+/// Checks only the first contract as a smoke test to avoid excessive slowness.
+pub fn verify_bytecodes_old_before_block<P: StateProviderFactory>(
+    provider: &P,
+    hardfork_block: u64,
+    upgrades: &[(Address, &[u8])],
+    label: &str,
+) {
+    let pre_block = hardfork_block - 1;
+    println!("[hardfork_test] Verifying {label} bytecodes are OLD before block {pre_block}...");
+
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(pre_block))
+        .expect("Failed to get state provider for pre-hardfork block");
+
+    // Smoke test: check the first contract
+    let (addr, expected_new) = &upgrades[0];
+    match state.account_code(addr) {
+        Ok(Some(code)) => {
+            let code_bytes = code.original_bytes();
+            assert_ne!(
+                code_bytes.as_ref(),
+                *expected_new,
+                "Bytecode at {addr} should be OLD before hardfork but was already upgraded!"
+            );
+            println!(
+                "[hardfork_test] ✅ {addr} at block {pre_block}: old bytecode ({}B), new would be {}B",
+                code_bytes.len(),
+                expected_new.len()
+            );
+        }
+        Ok(None) => {
+            println!("[hardfork_test] ⚠ {addr} at block {pre_block}: no code (may be expected)");
+        }
+        Err(e) => {
+            panic!("[hardfork_test] Failed to fetch code before hardfork: {e:?}");
+        }
+    }
+}
+
+/// Verify that specific storage slots have expected values at a given block.
+///
+/// Useful for checking ReentrancyGuard initialization, new storage slots, etc.
+pub fn verify_storage_patches<P: StateProviderFactory>(
+    provider: &P,
+    block_number: u64,
+    patches: &[(Address, B256, U256)],
+    label: &str,
+) {
+    println!("[hardfork_test] Verifying {label} storage patches at block {block_number}...");
+
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(block_number))
+        .expect("Failed to get state provider");
+
+    for (addr, slot, expected_value) in patches {
+        let actual = state.storage(*addr, *slot).expect("Failed to read storage");
+        assert_eq!(actual, Some(*expected_value), "{label}: {addr} slot {slot} mismatch");
+        println!("[hardfork_test] ✅ {addr}: storage {slot} = {actual:?}");
+    }
+}


### PR DESCRIPTION
Add the hardfork testing framework to main without any hardfork-specific code (alpha/beta/gamma modules live on release branches only):

- hardfork/common.rs: HardforkUpgrades trait defining system_upgrades(), extra_upgrades(), and storage_patches() interface
- hardfork/mod.rs: Module root (only pub mod common)
- hardfork_test_helpers.rs: Generic verification functions for any hardfork:
  - verify_bytecodes_at_block()
  - verify_bytecodes_old_before_block()
  - verify_storage_patches()
- HARDFORK_TESTING.md: Guide for adding new hardfork tests

Release branches should add their hardfork-specific modules (e.g. gamma.rs with GammaHardfork implementing HardforkUpgrades) and use the generic helpers from this framework.