### PR TITLE
fix(onchain_config): use JWK semantic version as oracle record nonce

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
@@ -208,7 +208,7 @@ fn construct_jwk_record_transaction(
     let call = recordCall {
         sourceType: SOURCE_TYPE_JWK,
         sourceId: source_id,
-        nonce: nonce as u128,
+        nonce: version as u128,
         blockNumber: U256::ZERO, // JWK records don't have a source block number
         payload: payload.into(),
         callbackGasLimit: U256::from(CALLBACK_GAS_LIMIT),


### PR DESCRIPTION
## Summary

- **Fix**: `construct_jwk_record_transaction` was incorrectly using the SYSTEM_CALLER's EVM transaction nonce (a global counter shared across metadata/DKG/JWK transactions) as the `nonce` parameter in the `NativeOracle.record()` call. This should be the JWK provider's semantic `version` field instead.
- **Root cause**: The `nonce` parameter in `recordCall` serves as a per-source freshness signal in the NativeOracle contract, which enforces `nonce == currentNonce + 1` per `(sourceType, sourceId)`. The EVM tx nonce is unrelated to this semantic.
- **Impact**: Cross-source nonce pollution between JWK issuers, and permanent oracle stall after any SYSTEM_CALLER state reset (all subsequent JWK updates silently rejected as `NonceNotSequential`).

## Why `provider_jwks.version` is correct

The JWK consensus protocol in gravity-aptos guarantees `version` is strictly sequential (+1) per issuer, enforced at three layers:
1. Proposal: `version = on_chain_version() + 1`
2. Consensus: all validators must agree on the same version
3. Execution: `on_chain.version + 1 != observed.version` → reject

This matches the NativeOracle contract's requirement that `nonce == currentNonce + 1`.

## Test plan

- [ ] Verify JWK oracle record transactions use the correct semantic version as nonce
- [ ] Confirm no regression in JWK update flow across blocks with mixed system transactions (metadata + DKG + JWK)

Closes Galxe/gravity-audit#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)