### PR TITLE
chore(onchain_config): assert RSA JWK oracle path is unreachable

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
@@ -17,7 +17,7 @@ use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use gravity_api_types::on_chain_config::jwks::{JWKStruct, ProviderJWKs};
 use reth_ethereum_primitives::TransactionSigned;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Default callback gas limit for oracle updates
 const CALLBACK_GAS_LIMIT: u64 = 500_000;
@@ -167,8 +167,20 @@ pub fn construct_oracle_record_transaction(
         .ok_or_else(|| format!("No JWKs found for issuer: {}", issuer_str))?;
 
     if is_rsa_jwk(first_jwk) {
-        // RSA JWK update
-        construct_jwk_record_transaction(provider_jwks, nonce, gas_price)
+        // RSA JWK path is not currently used in production. All JWK data flows through
+        // the UnsupportedJWK (blockchain event) path. If this is reached, something
+        // unexpected has changed in the consensus layer.
+        error!(
+            target: "gravity::onchain_config::jwk_oracle",
+            issuer = %issuer_str,
+            jwk_count = provider_jwks.jwks.len(),
+            "RSA JWK path entered unexpectedly — this code path should be unreachable"
+        );
+        panic!(
+            "RSA JWK oracle record path is unreachable: issuer={}, jwk_count={}",
+            issuer_str,
+            provider_jwks.jwks.len()
+        );
     } else if is_unsupported_jwk(first_jwk) {
         // Blockchain/oracle events - use recordBatch for ALL logs
         construct_blockchain_batch_transaction(provider_jwks, nonce, gas_price)


### PR DESCRIPTION
## Summary

- Add panic + error log to the RSA JWK branch in `construct_oracle_record_transaction`
- This code path is not used in production — all JWK data flows through the UnsupportedJWK (blockchain event / bridge) path via `construct_blockchain_batch_transaction`
- If this path is ever entered unexpectedly, the node will fail fast with a clear error message instead of silently producing incorrect state

## Context

Follow-up to #323. During investigation we confirmed that:
1. The RSA JWK path has never been executed on-chain (zero `DataRecorded` events for sourceType=1)
2. Bridge data reuses JWK consensus via `UnsupportedJWK`, which correctly handles nonces from event payloads
3. The RSA JWK path should remain dead code until explicitly needed

## Test plan

- [ ] Verify node starts and processes blocks normally (RSA JWK path not triggered)
- [ ] Verify e2e bridge tests still pass (UnsupportedJWK path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)