### PR TITLE
fix(pipe): use checked_add to prevent overflow in gas limit

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -1243,21 +1243,24 @@ fn filter_invalid_txs<DB: ParallelDatabase>(
     gas_limit: u64,
 ) -> HashSet<usize> {
     let mut gas_limit_exceeded_tx_idx = txs.len();
-    let mut tx_gas_limit_sum = 0;
+    let mut tx_gas_limit_sum: u64 = 0;
     for (idx, tx) in txs.iter().enumerate() {
         let tx_gas_limit = tx.gas_limit();
-        if tx_gas_limit_sum + tx_gas_limit > gas_limit {
-            warn!(target: "filter_invalid_txs",
-                tx_hash=?txs[idx].hash(),
-                sender=?senders[idx],
-                block_gas_limit=?gas_limit,
-                "gas limit exceeded, truncated to {}",
-                idx,
-            );
-            gas_limit_exceeded_tx_idx = idx;
-            break;
-        } else {
-            tx_gas_limit_sum += tx_gas_limit;
+        match tx_gas_limit_sum.checked_add(tx_gas_limit) {
+            Some(new_sum) if new_sum <= gas_limit => {
+                tx_gas_limit_sum = new_sum;
+            }
+            _ => {
+                warn!(target: "filter_invalid_txs",
+                    tx_hash=?txs[idx].hash(),
+                    sender=?senders[idx],
+                    block_gas_limit=?gas_limit,
+                    "gas limit exceeded, truncated to {}",
+                    idx,
+                );
+                gas_limit_exceeded_tx_idx = idx;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes [gravity-audit#584](https://github.com/Galxe/gravity-audit/issues/584) — integer overflow in `filter_invalid_txs` gas-limit accumulator.

## Problem

`tx_gas_limit_sum + tx_gas_limit > gas_limit` at `crates/pipe-exec-layer-ext-v2/execute/src/lib.rs:1249` is plain `u64 +` with no overflow check. Release builds wrap silently (no `overflow-checks`), so a byzantine proposer packing:
- `tx₀.gas_limit = block.gas_limit` (e.g. `1e9`)
- `tx₁.gas_limit = u64::MAX - tx₀.gas_limit + 1`

makes `sum + tx₁.gas_limit` wrap to `0`, the `> gas_limit` check returns false, and `tx₁` slips past the filter. Downstream revm rejects `tx₁` with `CallerGasLimitMoreThanBlock`, `executor.execute(&block).unwrap_or_else(\|err\| panic!(...))` fires, and every honest validator panics at the same block → network-wide liveness halt.

## Fix

Replace `+` with `checked_add`; treat both overflow and "sum exceeds `gas_limit`" as the same truncation case (same `break` path):

```rust
match tx_gas_limit_sum.checked_add(tx_gas_limit) {
    Some(new_sum) if new_sum <= gas_limit => {
        tx_gas_limit_sum = new_sum;
    }
    _ => { warn!(...); gas_limit_exceeded_tx_idx = idx; break; }
}
```

Semantics unchanged on all non-overflow inputs. Overflow now produces the same truncation result as a legitimately-too-large tx instead of being silently admitted.