### PR TITLE
fix: map ConfigVariant::Off to Off instead of V1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos?rev=5919060148c7bd9e995d6945c7aabaca97c0e4d6#5919060148c7bd9e995d6945c7aabaca97c0e4d6"
+source = "git+https://github.com/Galxe/gravity-aptos?rev=1d1153b6fdfbc14960d433c3949c781bb1739c64#1d1153b6fdfbc14960d433c3949c781bb1739c64"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 # reth
-gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "5919060148c7bd9e995d6945c7aabaca97c0e4d6" }
+gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "1d1153b6fdfbc14960d433c3949c781bb1739c64" }
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/dkg.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/dkg.rs
@@ -229,9 +229,8 @@ fn convert_config_v2_data(
 fn convert_randomness_config(
     config: &RandomnessConfigData,
 ) -> gravity_api_types::on_chain_config::dkg::RandomnessConfigData {
-    // Convert enum variant (Off -> V1, V2 -> V2 in API types)
     let variant = match config.variant {
-        ConfigVariant::Off => gravity_api_types::on_chain_config::dkg::ConfigVariant::V1,
+        ConfigVariant::Off => gravity_api_types::on_chain_config::dkg::ConfigVariant::Off,
         ConfigVariant::V2 => gravity_api_types::on_chain_config::dkg::ConfigVariant::V2,
         ConfigVariant::__Invalid => panic!("Invalid ConfigVariant"),
     };


### PR DESCRIPTION
Previously the EL→CL conversion mapped Solidity's ConfigVariant.Off to api-types ConfigVariant::V1, causing the consensus layer to treat disabled randomness as enabled. Now maps Off→Off correctly.