### PR TITLE
fix(pipe): Set gas-free for system transactions

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
+++ b/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
@@ -40,7 +40,9 @@ tokio.workspace = true
 rayon.workspace = true
 
 # ethereum
-revm.workspace = true
+# `optional_no_base_fee` enables `CfgEnv::disable_base_fee`, which is set for system-tx
+# execution so gas_price = 0 passes the EIP-1559 base-fee check.
+revm = { workspace = true, features = ["optional_no_base_fee"] }
 
 # misc
 tracing.workspace = true

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -697,9 +697,11 @@ impl<Storage: GravityStorage> Core<Storage> {
         // -----------------------------------------------------------------------
         // Metadata transaction (onBlockStart)
         // -----------------------------------------------------------------------
+        // System transactions are gas-free: pass gas_price = 0. Passes the base-fee check because
+        // `cfg_env.disable_base_fee` was set upstream in `execute_ordered_block`.
         let metadata_txn = construct_metadata_txn(
             current_nonce,
-            base_fee as u128,
+            0,
             ordered_block.timestamp_us,
             ordered_block.proposer_index,
             &ordered_block.failed_proposer_indices,
@@ -766,11 +768,8 @@ impl<Storage: GravityStorage> Core<Storage> {
 
         for (index, extra_data) in sorted_extra_data.iter().enumerate() {
             let is_dkg = matches!(extra_data, ExtraDataType::DKG(_));
-            let txn = match construct_validator_txn_from_extra_data(
-                extra_data,
-                current_nonce,
-                base_fee as u128,
-            ) {
+            // gas_price = 0 — see comment on metadata_txn construction above.
+            let txn = match construct_validator_txn_from_extra_data(extra_data, current_nonce, 0) {
                 Ok(txn) => txn,
                 Err(e) => {
                     error!(target: "execute_ordered_block",
@@ -951,7 +950,7 @@ impl<Storage: GravityStorage> Core<Storage> {
 
         let state = self.storage.get_state_view().unwrap();
 
-        let evm_env = self
+        let mut evm_env = self
             .evm_config
             .next_evm_env(
                 parent_header,
@@ -970,6 +969,12 @@ impl<Storage: GravityStorage> Core<Storage> {
             block_number=?block_number,
         );
         let base_fee = evm_env.block_env.basefee;
+
+        // System transactions run with `gas_price = 0` so SYSTEM_CALLER pays no wei and no
+        // base_fee is burned. Disabling the base-fee check on this env only allows that; user
+        // transactions execute in a fresh env built from the block header inside
+        // `executor.execute`, so they remain subject to EIP-1559 as usual.
+        evm_env.cfg_env.disable_base_fee = true;
 
         // Read SYSTEM_CALLER nonce and gas price from state BEFORE moving state into executor.
         // ParallelDatabase (Storage::StateView) implements DatabaseRef, so we can read directly.


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                               
                  
  Make system transactions (`metadata`, `DKG`, `JWK`) gas-free by:                                                                                                                                                                                                                                                         
   
  1. Constructing them with `gas_price = 0` (instead of `base_fee as u128`).                                                                                                                                                                                                                                               
  2. Setting `CfgEnv::disable_base_fee = true` on a dedicated `EvmEnv` used **only** for system-tx execution, so `gas_price = 0` passes the EIP-1559 base-fee check.
  3. Enabling `revm/optional_no_base_fee` in the crate's `Cargo.toml` so the flag is effective regardless of workspace-level feature unification.                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                           
  The modified `EvmEnv` is consumed only by `execute_system_transactions`. The user-tx path (`executor.execute(&block)` → `execute_transactions` in `parallel_execute.rs`) builds a fresh `EvmEnv` from the block header, so **user transactions are unaffected** and continue to follow standard EIP-1559.                
                                                                                                                                                                                                                                                                                                                           
  ## Scope Notes                                                                                                                                                                                                                                                                                                           
                  
  ### 1. The `mint_token_handler` halt/revert state-leak is **NOT** fixed in this PR                                                                                                                                                                                                                                       
   
  `mint_precompile.rs` mutates `account.info.balance` directly via `load_account(...).data` without emitting a journal entry. If the enclosing call later halts (`assert` → `InvalidFEOpcode`, OOG, etc.) or reverts, the mint persists — `checkpoint_revert` only rewinds journal entries, not raw state mutations.       
                  
  The proper fix is `EvmInternals::balance_incr`, which exists in `alloy-evm >= 0.25` but not in our pinned `v0.21.3-gravity`. Back-porting the API or bumping `alloy-evm` in isolation cascades into many downstream bumps that would destabilize the current release line.                                               
                  
  **Good news**: upstream reth 2.0 already ships `alloy-evm 0.33`. This issue will be resolved naturally when we rebase onto reth 2.0.                                                                                                                                                                                     
                  
  **Interim process**: if a user-originated mint is silently dropped because of a halt-after-mint path, users can contact the team and we will resolve it manually. Exploit surface is narrow because (a) the precompile enforces `AUTHORIZED_CALLER`, and (b) validator `extra_data` only reaches hard-coded              
  system-contract targets, none of which equal `AUTHORIZED_CALLER`.
                                                                                                                                                                                                                                                                                                                           
  ### 2. Why "gas-free system txs" is the right direction                                                                                                                                                                                                                                                                  
   
  The alternative is to keep charging system txs and fund `SYSTEM_CALLER` with a pre-allocated balance. Back-of-envelope with a legitimate L2-staked 100k G and testnet-observed per-block system-call cost `< 10⁻¹² G`:                                                                                                   
                  
  runway ≈ 100_000 / 10⁻¹² = 10¹⁷ blocks                                                                                                                                                                                                                                                                                   
                  
  Astronomically sufficient in practice, but it still leaves `SYSTEM_CALLER` as a draining account with an operational dependency on top-ups. The approach in this PR removes that dependency by making the cost zero by construction.                                                                                     
                                                                                                                                                                                                                                                                                                                           
  ### 3. `base_fee` floors at **8 wei**, not 0 — so user txs still pay a minuscule fee                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                           
  Starting from `INITIAL_BASE_FEE = 1 gwei`, EIP-1559 decay rounds toward zero, but never reaches it under gravity's parameters (`BaseFeeParams::ethereum()`: `max_change_denominator = 8`, `elasticity_multiplier = 2`):                                                                                                  
                  
  - The decrement is `delta = base_fee × (gas_target - gas_used) / (gas_target × 8)`.                                                                                                                                                                                                                                      
  - At `base_fee = 8`, this simplifies to `(gas_target - gas_used) / gas_target`.
  - Every block runs at least `metadata_txn`, so `gas_used > 0` always holds, and the integer division rounds to `0` → **`base_fee` stays at 8 wei**.                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                           
  Testnet confirms: https://explorer-testnet.gravity.xyz/block/20751707                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                           
  User transactions continue to burn `gas_used × 8 wei` as normal EIP-1559 base fee. System transactions no longer contribute to this burn because of (1)/(2) above.                                                                                                                                                       
                  
  ### 4. This is still a hard fork                                                                                                                                                                                                                                                                                         
                  
  `genesis` allocations are untouched in this PR, but the execution semantics change: pre-PR nodes would compute a non-zero `gas_used × base_fee` deduction from `SYSTEM_CALLER` for every system tx; post-PR nodes deduct zero. Any replay across the upgrade boundary diverges on `SYSTEM_CALLER`'s balance and therefore
   on state root. Nodes must upgrade in coordination.
                                                                                                                                                                                                                                                                                                                           