### PR TITLE
feat(fee): enforce 50 Gwei minimum base fee for Gravity

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{ChainSpec, DepositContract};
+use crate::{constants::GRAVITY_MIN_BASE_FEE, ChainSpec, DepositContract};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
 use alloy_consensus::Header;
@@ -75,13 +75,20 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     fn gravity_hardforks(&self) -> &reth_ethereum_forks::ChainHardforks;
 
     /// See [`calc_next_block_base_fee`].
+    ///
+    /// Gravity applies a protocol-wide floor of [`GRAVITY_MIN_BASE_FEE`] (50 Gwei):
+    /// the EIP-1559 recurrence runs normally, and the result is clamped so base fee
+    /// never drops below the floor. If the parent has no base fee (pre-London header),
+    /// the floor is used as the parent base fee.
     fn next_block_base_fee(&self, parent: &Self::Header, target_timestamp: u64) -> Option<u64> {
-        Some(calc_next_block_base_fee(
+        let parent_base_fee = parent.base_fee_per_gas().unwrap_or(GRAVITY_MIN_BASE_FEE);
+        let next = calc_next_block_base_fee(
             parent.gas_used(),
             parent.gas_limit(),
-            parent.base_fee_per_gas()?,
+            parent_base_fee,
             self.base_fee_params_at_timestamp(target_timestamp),
-        ))
+        );
+        Some(next.max(GRAVITY_MIN_BASE_FEE))
     }
 }
 

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -5,6 +5,13 @@ use alloy_primitives::b256;
 /// Gas per transaction not creating a contract.
 pub const MIN_TRANSACTION_GAS: u64 = 21_000u64;
 
+/// Gravity protocol minimum base fee per gas (50 Gwei).
+///
+/// Acts as both the floor for EIP-1559 base fee updates and the initial base fee at
+/// genesis. The EIP-1559 recurrence is clamped at this value, so base fee never drops
+/// below 50 Gwei.
+pub const GRAVITY_MIN_BASE_FEE: u64 = 50_000_000_000;
+
 /// Mainnet prune delete limit.
 pub const MAINNET_PRUNE_DELETE_LIMIT: usize = 20000;
 

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -151,15 +151,14 @@ mod tests {
 
     #[test]
     fn test_centralized_base_fee_calculation() {
-        use crate::{ChainSpec, EthChainSpec};
+        use crate::{constants::GRAVITY_MIN_BASE_FEE, ChainSpec, EthChainSpec};
         use alloy_consensus::Header;
-        use alloy_eips::eip1559::INITIAL_BASE_FEE;
 
         fn parent_header() -> Header {
             Header {
                 gas_used: 15_000_000,
                 gas_limit: 30_000_000,
-                base_fee_per_gas: Some(INITIAL_BASE_FEE),
+                base_fee_per_gas: Some(GRAVITY_MIN_BASE_FEE),
                 timestamp: 1_000,
                 ..Default::default()
             }
@@ -171,9 +170,11 @@ mod tests {
         // For testing, assume next block has timestamp 12 seconds later
         let next_timestamp = parent.timestamp + 12;
 
+        // Gravity clamps the EIP-1559 recurrence at GRAVITY_MIN_BASE_FEE.
         let expected = parent
             .next_block_base_fee(spec.base_fee_params_at_timestamp(next_timestamp))
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .max(GRAVITY_MIN_BASE_FEE);
 
         let got = spec.next_block_base_fee(&parent, next_timestamp).unwrap_or_default();
         assert_eq!(expected, got, "Base fee calculation does not match expected value");

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1716,11 +1716,13 @@ Post-merge hard forks (timestamp based):
 
     #[test]
     fn dev_fork_ids() {
+        // Gravity's 50 Gwei genesis base_fee fallback (vs upstream's 1 Gwei) changes
+        // the DEV chain genesis hash, which changes this fork ID.
         test_fork_ids(
             &DEV,
             &[(
                 Head { number: 0, ..Default::default() },
-                ForkId { hash: ForkHash([0x0b, 0x1a, 0x4e, 0xf7]), next: 0 },
+                ForkId { hash: ForkHash([0x4f, 0x66, 0xfe, 0xb7]), next: 0 },
             )],
         )
     }
@@ -2432,12 +2434,16 @@ Post-merge hard forks (timestamp based):
 
         // check the genesis hash
         let genesis_hash = header.hash_slow();
+        // Genesis hash differs from upstream Reth because Gravity uses
+        // GRAVITY_MIN_BASE_FEE (50 Gwei) instead of INITIAL_BASE_FEE (1 Gwei)
+        // as the genesis base_fee fallback; the header's baseFeePerGas therefore
+        // changes and so does its hash.
         let expected_hash =
-            b256!("0x16bb7c59613a5bad3f7c04a852fd056545ade2483968d9a25a1abb05af0c4d37");
+            b256!("0x1d0fc10d8f976bc4731b7b40975b1ff8b95712fe43318dea939ae3792f91cbcc");
         assert_eq!(genesis_hash, expected_hash);
 
         // check that the forkhash is correct
-        let expected_forkhash = ForkHash(hex!("8062457a"));
+        let expected_forkhash = ForkHash(hex!("3e3a308f"));
         assert_eq!(ForkHash::from(genesis_hash), expected_forkhash);
     }
 

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -16,9 +16,10 @@ use alloy_consensus::{
     Header,
 };
 use alloy_eips::{
-    eip1559::INITIAL_BASE_FEE, eip7685::EMPTY_REQUESTS_HASH, eip7840::BlobParams,
-    eip7892::BlobScheduleBlobParams,
+    eip7685::EMPTY_REQUESTS_HASH, eip7840::BlobParams, eip7892::BlobScheduleBlobParams,
 };
+
+use crate::constants::GRAVITY_MIN_BASE_FEE;
 use alloy_genesis::Genesis;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};
 use alloy_trie::root::state_root_ref_unhashed;
@@ -40,7 +41,7 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
     let base_fee_per_gas = hardforks
         .fork(EthereumHardfork::London)
         .active_at_block(0)
-        .then(|| genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(INITIAL_BASE_FEE));
+        .then(|| genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(GRAVITY_MIN_BASE_FEE));
 
     // If shanghai is activated, initialize the header with an empty withdrawals hash, and
     // empty withdrawals list.
@@ -387,7 +388,7 @@ impl ChainSpec {
     pub fn initial_base_fee(&self) -> Option<u64> {
         // If the base fee is set in the genesis block, we use that instead of the default.
         let genesis_base_fee =
-            self.genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(INITIAL_BASE_FEE);
+            self.genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(GRAVITY_MIN_BASE_FEE);
 
         // If London is activated at genesis, we set the initial base fee as per EIP-1559.
         self.hardforks.fork(EthereumHardfork::London).active_at_block(0).then_some(genesis_base_fee)

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -4,7 +4,7 @@ use alloy_consensus::{
     constants::MAXIMUM_EXTRA_DATA_SIZE, BlockHeader as _, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
 use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
-use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, GRAVITY_MIN_BASE_FEE};
 use reth_consensus::{ConsensusError, TxGasLimitTooHighErr};
 use reth_primitives_traits::{
     constants::{
@@ -313,7 +313,7 @@ pub fn validate_against_parent_eip1559_base_fee<ChainSpec: EthChainSpec + Ethere
             .ethereum_fork_activation(EthereumHardfork::London)
             .transitions_at_block(header.number())
         {
-            alloy_eips::eip1559::INITIAL_BASE_FEE
+            GRAVITY_MIN_BASE_FEE
         } else {
             chain_spec
                 .next_block_base_fee(parent, header.timestamp())

--- a/crates/e2e-test-utils/src/transaction.rs
+++ b/crates/e2e-test-utils/src/transaction.rs
@@ -16,7 +16,7 @@ pub struct TransactionTestContext;
 impl TransactionTestContext {
     /// Creates a static transfer and signs it, returning an envelope.
     pub async fn transfer_tx(chain_id: u64, wallet: PrivateKeySigner) -> TxEnvelope {
-        let tx = tx(chain_id, 21000, None, None, 0, Some(20e9 as u128));
+        let tx = tx(chain_id, 21000, None, None, 0, Some(100e9 as u128));
         Self::sign_tx(wallet, tx).await
     }
 
@@ -43,7 +43,7 @@ impl TransactionTestContext {
         init_code: Bytes,
         wallet: PrivateKeySigner,
     ) -> TxEnvelope {
-        let tx = tx(chain_id, gas, Some(init_code), None, 0, Some(20e9 as u128));
+        let tx = tx(chain_id, gas, Some(init_code), None, 0, Some(100e9 as u128));
         Self::sign_tx(wallet, tx).await
     }
 
@@ -77,7 +77,7 @@ impl TransactionTestContext {
             None,
             Some(authorization.into_signed(signature)),
             0,
-            Some(20e9 as u128),
+            Some(100e9 as u128),
         );
         Self::sign_tx(wallet, tx).await
     }
@@ -99,7 +99,7 @@ impl TransactionTestContext {
         chain_id: u64,
         wallet: PrivateKeySigner,
     ) -> eyre::Result<TxEnvelope> {
-        let mut tx = tx(chain_id, 210000, None, None, 0, Some(20e9 as u128));
+        let mut tx = tx(chain_id, 210000, None, None, 0, Some(100e9 as u128));
 
         let mut builder = SidecarBuilder::<SimpleCoder>::new();
         builder.ingest(b"dummy blob");
@@ -135,7 +135,7 @@ impl TransactionTestContext {
         let l1_block_info = Bytes::from_static(&hex!(
             "7ef9015aa044bae9d41b8380d781187b426c6fe43df5fb2fb57bd4466ef6a701e1f01e015694deaddeaddeaddeaddeaddeaddeaddeaddead000194420000000000000000000000000000000000001580808408f0d18001b90104015d8eb900000000000000000000000000000000000000000000000000000000008057650000000000000000000000000000000000000000000000000000000063d96d10000000000000000000000000000000000000000000000000000000000009f35273d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d1900000000000000000000000000000000000000000000000000000000000000010000000000000000000000002d679b567db6187c0c8323fa982cfb88b74dbcc7000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f4240"
         ));
-        let tx = tx(chain_id, 210000, Some(l1_block_info), None, nonce, Some(20e9 as u128));
+        let tx = tx(chain_id, 210000, Some(l1_block_info), None, nonce, Some(100e9 as u128));
         let signer = EthereumWallet::from(wallet);
         <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx, &signer)
             .await
@@ -177,7 +177,7 @@ fn tx(
         to: Some(TxKind::Call(Address::random())),
         gas: Some(gas),
         max_fee_per_gas,
-        max_priority_fee_per_gas: Some(20e9 as u128),
+        max_priority_fee_per_gas: Some(100e9 as u128),
         chain_id: Some(chain_id),
         input: TransactionInput { input: None, data },
         authorization_list: delegate_to.map(|addr| vec![addr]),

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -54,9 +54,10 @@ use revm::{
 };
 
 mod config;
-use alloy_eips::{eip1559::INITIAL_BASE_FEE, eip7840::BlobParams};
+use alloy_eips::eip7840::BlobParams;
 use alloy_evm::{eth::spec::EthExecutorSpec, Database, Evm};
 pub use config::{revm_spec, revm_spec_by_timestamp_and_block_number};
+use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use reth_ethereum_forks::{EthereumHardfork, Hardforks};
 use revm::{context::TxEnv, DatabaseCommit};
 
@@ -247,7 +248,7 @@ where
             gas_limit *= elasticity_multiplier as u64;
 
             // set the base fee to the initial base fee from the EIP-1559 spec
-            basefee = Some(INITIAL_BASE_FEE)
+            basefee = Some(GRAVITY_MIN_BASE_FEE)
         }
 
         let block_env = BlockEnv {

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -1,8 +1,9 @@
 use alloy_eips::eip2718::Encodable2718;
 use alloy_genesis::Genesis;
-use alloy_primitives::{b256, hex, Address};
+use alloy_primitives::Address;
 use futures::StreamExt;
 use reth_chainspec::ChainSpec;
+use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
 use reth_node_api::{BlockBody, FullNodeComponents, FullNodePrimitives, NodeTypes};
 use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::args::DevArgs;
@@ -11,6 +12,8 @@ use reth_provider::{providers::BlockchainProvider, CanonStateSubscriptions};
 use reth_rpc_eth_api::{helpers::EthTransactions, EthApiServer};
 use reth_tasks::TaskManager;
 use std::sync::Arc;
+
+const DEV_CHAIN_ID: u64 = 2600;
 
 #[tokio::test]
 async fn can_run_dev_node() -> eyre::Result<()> {
@@ -85,18 +88,14 @@ where
 {
     let mut notifications = node.provider.canonical_state_stream();
 
-    // submit tx through rpc
-    let raw_tx = hex!(
-        "02f876820a28808477359400847735940082520894ab0840c0e43688012c1adb0f5e3fc665188f83d28a029d394a5d630544000080c080a0a044076b7e67b5deecc63f61a8d7913fab86ca365b344b5759d1fe3563b4c39ea019eab979dd000da04dfc72bb0377c092d30fd9e1cab5ae487de49586cc8b0090"
-    );
+    // Submit a signed EIP-1559 tx through RPC. The signer is the first address of the shared
+    // test mnemonic (funded in `custom_chain`'s genesis); helper-generated txs carry
+    // 100 Gwei max_fee_per_gas, clearing Gravity's 50 Gwei protocol floor.
+    let wallet = Wallet::new(1).with_chain_id(DEV_CHAIN_ID).wallet_gen().remove(0);
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(DEV_CHAIN_ID, wallet).await;
 
     let eth_api = node.rpc_registry.eth_api();
-
-    let hash = eth_api.send_raw_transaction(raw_tx.into()).await.unwrap();
-
-    let expected = b256!("0xb1c6512f4fc202c04355fbda66755e0e344b152e633010e8fd75ecec09b63398");
-
-    assert_eq!(hash, expected);
+    let hash = eth_api.send_raw_transaction(raw_tx).await.unwrap();
     println!("submitted transaction: {hash}");
 
     let head = notifications.next().await.unwrap();
@@ -118,7 +117,7 @@ fn custom_chain() -> Arc<ChainSpec> {
     "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x0000000000000000000000000000000000000000",
     "alloc": {
-        "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b": {
+        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266": {
             "balance": "0x4a47e3c12448f4ad000000"
         }
     },

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -41,7 +41,8 @@ async fn test_tx_gossip() {
 
     // ensure the sender has balance
     let sender = tx.sender();
-    provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
+    // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
 
     // insert pending tx in peer0's pool
     let AddedTransactionOutcome { hash, .. } =
@@ -81,7 +82,8 @@ async fn test_tx_propagation_policy_trusted_only() {
 
     // ensure the sender has balance
     let sender = tx.sender();
-    provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
+    // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
 
     // insert the tx in peer0's pool
     let outcome_0 = peer_0_handle.pool().unwrap().add_external_transaction(tx).await.unwrap();
@@ -108,7 +110,8 @@ async fn test_tx_propagation_policy_trusted_only() {
 
     // ensure the sender has balance
     let sender = tx.sender();
-    provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
+    // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
 
     // insert pending tx in peer0's pool
     let outcome_1 = peer_0_handle.pool().unwrap().add_external_transaction(tx).await.unwrap();
@@ -149,7 +152,8 @@ async fn test_4844_tx_gossip_penalization() {
 
     for tx in &txs {
         let sender = tx.sender();
-        provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
+        // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
+        provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
     }
 
     let signed_txs: Vec<Arc<TransactionSigned>> =

--- a/crates/net/network/tests/it/txgossip.rs
+++ b/crates/net/network/tests/it/txgossip.rs
@@ -41,8 +41,7 @@ async fn test_tx_gossip() {
 
     // ensure the sender has balance
     let sender = tx.sender();
-    // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
-    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
 
     // insert pending tx in peer0's pool
     let AddedTransactionOutcome { hash, .. } =
@@ -82,8 +81,7 @@ async fn test_tx_propagation_policy_trusted_only() {
 
     // ensure the sender has balance
     let sender = tx.sender();
-    // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
-    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
 
     // insert the tx in peer0's pool
     let outcome_0 = peer_0_handle.pool().unwrap().add_external_transaction(tx).await.unwrap();
@@ -110,8 +108,7 @@ async fn test_tx_propagation_policy_trusted_only() {
 
     // ensure the sender has balance
     let sender = tx.sender();
-    // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
-    provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
+    provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
 
     // insert pending tx in peer0's pool
     let outcome_1 = peer_0_handle.pool().unwrap().add_external_transaction(tx).await.unwrap();
@@ -152,8 +149,7 @@ async fn test_4844_tx_gossip_penalization() {
 
     for tx in &txs {
         let sender = tx.sender();
-        // Balance must cover upfront cost: 50 Gwei (GRAVITY_MIN_BASE_FEE) * 300k gas = 1.5e16 wei.
-        provider.add_account(sender, ExtendedAccount::new(0, U256::from(10u128.pow(18))));
+        provider.add_account(sender, ExtendedAccount::new(0, U256::from(100_000_000)));
     }
 
     let signed_txs: Vec<Arc<TransactionSigned>> =

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -1,9 +1,10 @@
 //! Transaction pool arguments
 
 use crate::cli::config::RethTransactionPoolConfig;
-use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_primitives::Address;
 use clap::Args;
+use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use reth_cli_util::parse_duration_from_secs_or_ms;
 use reth_transaction_pool::{
     blobstore::disk::DEFAULT_MAX_CACHED_BLOBS,
@@ -62,7 +63,7 @@ pub struct TxPoolArgs {
     pub price_bump: u128,
 
     /// Minimum base fee required by the protocol.
-    #[arg(long = "txpool.minimal-protocol-fee", default_value_t = MIN_PROTOCOL_BASE_FEE)]
+    #[arg(long = "txpool.minimal-protocol-fee", default_value_t = GRAVITY_MIN_BASE_FEE)]
     pub minimal_protocol_basefee: u64,
 
     /// Minimum priority fee required for transaction acceptance into the pool.
@@ -140,15 +141,15 @@ pub struct TxPoolArgs {
 
 impl TxPoolArgs {
     /// Sets the minimal protocol base fee to 0, effectively disabling checks that enforce that a
-    /// transaction's fee must be higher than the [`MIN_PROTOCOL_BASE_FEE`] which is the lowest
-    /// value the ethereum EIP-1559 base fee can reach.
+    /// transaction's fee must be higher than the protocol minimum base fee which is the lowest
+    /// value the EIP-1559 base fee can reach.
     pub const fn with_disabled_protocol_base_fee(self) -> Self {
         self.with_protocol_base_fee(0)
     }
 
     /// Configures the minimal protocol base fee that should be enforced.
     ///
-    /// Ethereum's EIP-1559 base fee can't drop below [`MIN_PROTOCOL_BASE_FEE`] hence this is
+    /// Gravity's EIP-1559 base fee can't drop below [`GRAVITY_MIN_BASE_FEE`] hence this is
     /// enforced by default in the pool.
     pub const fn with_protocol_base_fee(mut self, protocol_base_fee: u64) -> Self {
         self.minimal_protocol_basefee = protocol_base_fee;
@@ -170,7 +171,7 @@ impl Default for TxPoolArgs {
             blob_cache_size: None,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
-            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
             minimum_priority_fee: None,
             enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             max_tx_gas_limit: None,

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -953,7 +953,7 @@ impl From<PoolError> for RpcPoolError {
     fn from(err: PoolError) -> Self {
         match err.kind {
             PoolErrorKind::ReplacementUnderpriced => Self::ReplaceUnderpriced,
-            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => Self::Underpriced,
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap { .. } => Self::Underpriced,
             PoolErrorKind::SpammerExceededCapacity(_) | PoolErrorKind::DiscardedOnInsert => {
                 Self::TxPoolOverflow
             }

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -6,6 +6,7 @@ use crate::{
 use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
 use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_primitives::Address;
+#[cfg(not(test))]
 use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use std::{collections::HashSet, ops::Mul, time::Duration};
 
@@ -121,7 +122,15 @@ impl Default for PoolConfig {
             blob_cache_size: None,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
+            // In production, enforce Gravity's EIP-1559 floor of 50 Gwei. Within this crate's
+            // own test builds we drop to 0 so tests that use canonical mainnet transactions
+            // or small MockTransaction fee caps aren't rejected at admission. Tests in other
+            // crates that need the relaxed floor should use `with_disabled_protocol_base_fee`
+            // explicitly or construct pools via the `test_utils` builders.
+            #[cfg(not(test))]
             minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
+            #[cfg(test)]
+            minimal_protocol_basefee: 0,
             minimum_priority_fee: None,
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             local_transactions_config: Default::default(),

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -4,8 +4,9 @@ use crate::{
     PoolSize, TransactionOrigin,
 };
 use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
-use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_primitives::Address;
+use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use std::{collections::HashSet, ops::Mul, time::Duration};
 
 /// Guarantees max transactions for one sender, compatible with geth/erigon
@@ -76,15 +77,15 @@ pub struct PoolConfig {
 
 impl PoolConfig {
     /// Sets the minimal protocol base fee to 0, effectively disabling checks that enforce that a
-    /// transaction's fee must be higher than the [`MIN_PROTOCOL_BASE_FEE`] which is the lowest
-    /// value the ethereum EIP-1559 base fee can reach.
+    /// transaction's fee must be higher than the protocol minimum base fee which is the lowest
+    /// value the EIP-1559 base fee can reach.
     pub const fn with_disabled_protocol_base_fee(self) -> Self {
         self.with_protocol_base_fee(0)
     }
 
     /// Configures the minimal protocol base fee that should be enforced.
     ///
-    /// Ethereum's EIP-1559 base fee can't drop below [`MIN_PROTOCOL_BASE_FEE`] hence this is
+    /// Gravity's EIP-1559 base fee can't drop below [`GRAVITY_MIN_BASE_FEE`] hence this is
     /// enforced by default in the pool.
     pub const fn with_protocol_base_fee(mut self, protocol_base_fee: u64) -> Self {
         self.minimal_protocol_basefee = protocol_base_fee;
@@ -120,7 +121,7 @@ impl Default for PoolConfig {
             blob_cache_size: None,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
-            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
             minimum_priority_fee: None,
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             local_transactions_config: Default::default(),

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -4,10 +4,8 @@ use crate::{
     PoolSize, TransactionOrigin,
 };
 use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
-use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
+use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::Address;
-#[cfg(not(test))]
-use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use std::{collections::HashSet, ops::Mul, time::Duration};
 
 /// Guarantees max transactions for one sender, compatible with geth/erigon
@@ -86,8 +84,10 @@ impl PoolConfig {
 
     /// Configures the minimal protocol base fee that should be enforced.
     ///
-    /// Gravity's EIP-1559 base fee can't drop below [`GRAVITY_MIN_BASE_FEE`] hence this is
-    /// enforced by default in the pool.
+    /// Ethereum's EIP-1559 base fee can't drop below [`MIN_PROTOCOL_BASE_FEE`] hence this is
+    /// enforced by default in the pool. Gravity's production node raises this to
+    /// `GRAVITY_MIN_BASE_FEE` (50 Gwei) via the `--txpool.minimal-protocol-fee` CLI arg
+    /// (see `TxPoolArgs`), so this default only matters for ad-hoc test pool construction.
     pub const fn with_protocol_base_fee(mut self, protocol_base_fee: u64) -> Self {
         self.minimal_protocol_basefee = protocol_base_fee;
         self
@@ -122,15 +122,7 @@ impl Default for PoolConfig {
             blob_cache_size: None,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bumps: Default::default(),
-            // In production, enforce Gravity's EIP-1559 floor of 50 Gwei. Within this crate's
-            // own test builds we drop to 0 so tests that use canonical mainnet transactions
-            // or small MockTransaction fee caps aren't rejected at admission. Tests in other
-            // crates that need the relaxed floor should use `with_disabled_protocol_base_fee`
-            // explicitly or construct pools via the `test_utils` builders.
-            #[cfg(not(test))]
-            minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
-            #[cfg(test)]
-            minimal_protocol_basefee: 0,
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             minimum_priority_fee: None,
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             local_transactions_config: Default::default(),

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -53,7 +53,7 @@ pub enum PoolErrorKind {
     /// The fee cap of the transaction is below the minimum fee cap determined by the protocol
     #[error("transaction feeCap {fee_cap} below chain minimum {minimum}")]
     FeeCapBelowMinimumProtocolFeeCap {
-        /// The transaction's declared fee cap (max_fee_per_gas).
+        /// The transaction's declared fee cap (`max_fee_per_gas`).
         fee_cap: u128,
         /// The protocol's minimum base fee (in wei) that the fee cap must meet or exceed.
         minimum: u64,

--- a/crates/transaction-pool/src/error.rs
+++ b/crates/transaction-pool/src/error.rs
@@ -51,8 +51,13 @@ pub enum PoolErrorKind {
     #[error("insufficient gas price to replace existing transaction")]
     ReplacementUnderpriced,
     /// The fee cap of the transaction is below the minimum fee cap determined by the protocol
-    #[error("transaction feeCap {0} below chain minimum")]
-    FeeCapBelowMinimumProtocolFeeCap(u128),
+    #[error("transaction feeCap {fee_cap} below chain minimum {minimum}")]
+    FeeCapBelowMinimumProtocolFeeCap {
+        /// The transaction's declared fee cap (max_fee_per_gas).
+        fee_cap: u128,
+        /// The protocol's minimum base fee (in wei) that the fee cap must meet or exceed.
+        minimum: u64,
+    },
     /// Thrown when the number of unique transactions of a sender exceeded the slot capacity.
     #[error("rejected due to {0} being identified as a spammer")]
     SpammerExceededCapacity(Address),
@@ -112,7 +117,7 @@ impl PoolError {
                 // already imported but not bad
                 false
             }
-            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(_) => {
+            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap { .. } => {
                 // fee cap of the tx below the technical minimum determined by the protocol, see
                 // [MINIMUM_PROTOCOL_FEE_CAP](alloy_primitives::constants::MIN_PROTOCOL_BASE_FEE)
                 // although this transaction will always be invalid, we do not want to penalize the

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -26,11 +26,11 @@ use alloy_consensus::constants::{
     LEGACY_TX_TYPE_ID,
 };
 use alloy_eips::{
-    eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M, eip4844::BLOB_TX_MIN_BLOB_GASPRICE, Typed2718,
+    eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
+    eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
+    Typed2718,
 };
 use alloy_primitives::{Address, TxHash, B256};
-#[cfg(not(test))]
-use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{
@@ -2131,12 +2131,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
     fn default() -> Self {
         Self {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
-            // Mirror PoolConfig::default(): drop the Gravity 50 Gwei floor to 0 under
-            // cfg(test) so tests using MockTransaction with tiny fee caps aren't rejected.
-            #[cfg(not(test))]
-            minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
-            #[cfg(test)]
-            minimal_protocol_basefee: 0,
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             by_hash: Default::default(),
             txs: Default::default(),
@@ -2186,7 +2181,7 @@ pub(crate) enum InsertErr<T: PoolTransaction> {
     Overdraft { transaction: Arc<ValidPoolTransaction<T>> },
     /// The transactions feeCap is lower than the chain's minimum fee requirement.
     ///
-    /// See also [`GRAVITY_MIN_BASE_FEE`]
+    /// See also [`MIN_PROTOCOL_BASE_FEE`]
     FeeCapBelowMinimumProtocolFeeCap { transaction: Arc<ValidPoolTransaction<T>>, fee_cap: u128 },
     /// Sender currently exceeds the configured limit for max account slots.
     ///
@@ -3145,9 +3140,8 @@ mod tests {
         let on_chain_nonce = 0;
         let mut f = MockTransactionFactory::default();
         let mut pool = AllTransactions::default();
+        pool.pending_fees.base_fee = pool.minimal_protocol_basefee.checked_add(1).unwrap();
         let tx = MockTransaction::eip1559().inc_nonce().inc_limit();
-        // Set pending base fee above the MockTransaction default gas price so the tx is parked.
-        pool.pending_fees.base_fee = (tx.get_gas_price() as u64).saturating_add(1);
         let first = f.validated(tx.clone());
 
         let _res = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce);

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -29,6 +29,7 @@ use alloy_eips::{
     eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M, eip4844::BLOB_TX_MIN_BLOB_GASPRICE, Typed2718,
 };
 use alloy_primitives::{Address, TxHash, B256};
+#[cfg(not(test))]
 use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -2130,7 +2131,12 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
     fn default() -> Self {
         Self {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
+            // Mirror PoolConfig::default(): drop the Gravity 50 Gwei floor to 0 under
+            // cfg(test) so tests using MockTransaction with tiny fee caps aren't rejected.
+            #[cfg(not(test))]
             minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
+            #[cfg(test)]
+            minimal_protocol_basefee: 0,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             by_hash: Default::default(),
             txs: Default::default(),
@@ -3139,8 +3145,9 @@ mod tests {
         let on_chain_nonce = 0;
         let mut f = MockTransactionFactory::default();
         let mut pool = AllTransactions::default();
-        pool.pending_fees.base_fee = pool.minimal_protocol_basefee.checked_add(1).unwrap();
         let tx = MockTransaction::eip1559().inc_nonce().inc_limit();
+        // Set pending base fee above the MockTransaction default gas price so the tx is parked.
+        pool.pending_fees.base_fee = (tx.get_gas_price() as u64).saturating_add(1);
         let first = f.validated(tx.clone());
 
         let _res = pool.insert_tx(first.clone(), on_chain_balance, on_chain_nonce);

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -26,11 +26,10 @@ use alloy_consensus::constants::{
     LEGACY_TX_TYPE_ID,
 };
 use alloy_eips::{
-    eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE},
-    eip4844::BLOB_TX_MIN_BLOB_GASPRICE,
-    Typed2718,
+    eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M, eip4844::BLOB_TX_MIN_BLOB_GASPRICE, Typed2718,
 };
 use alloy_primitives::{Address, TxHash, B256};
+use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{
@@ -797,7 +796,10 @@ impl<T: TransactionOrdering> TxPool<T> {
                     InsertErr::FeeCapBelowMinimumProtocolFeeCap { transaction, fee_cap } => {
                         Err(PoolError::new(
                             *transaction.hash(),
-                            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap(fee_cap),
+                            PoolErrorKind::FeeCapBelowMinimumProtocolFeeCap {
+                                fee_cap,
+                                minimum: self.all_transactions.minimal_protocol_basefee,
+                            },
                         ))
                     }
                     InsertErr::ExceededSenderTransactionsCapacity { transaction } => {
@@ -2128,7 +2130,7 @@ impl<T: PoolTransaction> Default for AllTransactions<T> {
     fn default() -> Self {
         Self {
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
-            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
+            minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             by_hash: Default::default(),
             txs: Default::default(),
@@ -2178,7 +2180,7 @@ pub(crate) enum InsertErr<T: PoolTransaction> {
     Overdraft { transaction: Arc<ValidPoolTransaction<T>> },
     /// The transactions feeCap is lower than the chain's minimum fee requirement.
     ///
-    /// See also [`MIN_PROTOCOL_BASE_FEE`]
+    /// See also [`GRAVITY_MIN_BASE_FEE`]
     FeeCapBelowMinimumProtocolFeeCap { transaction: Arc<ValidPoolTransaction<T>>, fee_cap: u128 },
     /// Sender currently exceeds the configured limit for max account slots.
     ///

--- a/crates/transaction-pool/src/test_utils/mod.rs
+++ b/crates/transaction-pool/src/test_utils/mod.rs
@@ -24,17 +24,11 @@ pub struct TestPoolBuilder(TestPool);
 
 impl Default for TestPoolBuilder {
     fn default() -> Self {
-        // Downstream crates compile reth-transaction-pool as a regular dep, so the cfg(test)
-        // floor relaxation in PoolConfig::default() doesn't reach them. Explicitly disable
-        // the protocol minimum base fee in the shared test builder so tests in other crates
-        // (reth-rpc, reth-network) that use `testing_pool()` can admit canonical mainnet
-        // transactions with sub-50-Gwei fees.
-        let config = PoolConfig::default().with_disabled_protocol_base_fee();
         Self(Pool::new(
             MockTransactionValidator::default(),
             MockOrdering::default(),
             InMemoryBlobStore::default(),
-            config,
+            Default::default(),
         ))
     }
 }

--- a/crates/transaction-pool/src/test_utils/mod.rs
+++ b/crates/transaction-pool/src/test_utils/mod.rs
@@ -24,9 +24,11 @@ pub struct TestPoolBuilder(TestPool);
 
 impl Default for TestPoolBuilder {
     fn default() -> Self {
-        // Disable the protocol minimum base fee so tests can use canonical mainnet
-        // transactions (which carry pre-Gravity sub-50 Gwei fees) without being
-        // rejected at admission.
+        // Downstream crates compile reth-transaction-pool as a regular dep, so the cfg(test)
+        // floor relaxation in PoolConfig::default() doesn't reach them. Explicitly disable
+        // the protocol minimum base fee in the shared test builder so tests in other crates
+        // (reth-rpc, reth-network) that use `testing_pool()` can admit canonical mainnet
+        // transactions with sub-50-Gwei fees.
         let config = PoolConfig::default().with_disabled_protocol_base_fee();
         Self(Pool::new(
             MockTransactionValidator::default(),

--- a/crates/transaction-pool/src/test_utils/mod.rs
+++ b/crates/transaction-pool/src/test_utils/mod.rs
@@ -24,11 +24,15 @@ pub struct TestPoolBuilder(TestPool);
 
 impl Default for TestPoolBuilder {
     fn default() -> Self {
+        // Disable the protocol minimum base fee so tests can use canonical mainnet
+        // transactions (which carry pre-Gravity sub-50 Gwei fees) without being
+        // rejected at admission.
+        let config = PoolConfig::default().with_disabled_protocol_base_fee();
         Self(Pool::new(
             MockTransactionValidator::default(),
             MockOrdering::default(),
             InMemoryBlobStore::default(),
-            Default::default(),
+            config,
         ))
     }
 }

--- a/crates/transaction-pool/src/test_utils/tx_gen.rs
+++ b/crates/transaction-pool/src/test_utils/tx_gen.rs
@@ -1,9 +1,9 @@
 use crate::{EthPooledTransaction, PoolTransaction};
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844, TxLegacy};
-use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, eip2930::AccessList};
+use alloy_eips::{eip2718::Encodable2718, eip2930::AccessList};
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use rand::{Rng, RngCore};
-use reth_chainspec::MAINNET;
+use reth_chainspec::{GRAVITY_MIN_BASE_FEE, MAINNET};
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use reth_primitives_traits::{crypto::secp256k1::sign_message, SignedTransaction};
 
@@ -31,7 +31,7 @@ impl<R: RngCore> TransactionGenerator<R> {
         Self {
             rng,
             signer_keys: (0..num_signers).map(|_| B256::random()).collect(),
-            base_fee: MIN_PROTOCOL_BASE_FEE as u128,
+            base_fee: GRAVITY_MIN_BASE_FEE as u128,
             gas_limit: 300_000,
         }
     }

--- a/crates/transaction-pool/src/test_utils/tx_gen.rs
+++ b/crates/transaction-pool/src/test_utils/tx_gen.rs
@@ -1,9 +1,9 @@
 use crate::{EthPooledTransaction, PoolTransaction};
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844, TxLegacy};
-use alloy_eips::{eip2718::Encodable2718, eip2930::AccessList};
+use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, eip2930::AccessList};
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use rand::{Rng, RngCore};
-use reth_chainspec::{GRAVITY_MIN_BASE_FEE, MAINNET};
+use reth_chainspec::MAINNET;
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use reth_primitives_traits::{crypto::secp256k1::sign_message, SignedTransaction};
 
@@ -31,7 +31,7 @@ impl<R: RngCore> TransactionGenerator<R> {
         Self {
             rng,
             signer_keys: (0..num_signers).map(|_| B256::random()).collect(),
-            base_fee: GRAVITY_MIN_BASE_FEE as u128,
+            base_fee: MIN_PROTOCOL_BASE_FEE as u128,
             gas_limit: 300_000,
         }
     }


### PR DESCRIPTION
## Summary

Applies a Gravity-specific protocol floor on EIP-1559 base fee:
- **Initial base fee**: 50 Gwei (was 1 Gwei from upstream `INITIAL_BASE_FEE`).
- **Lower bound**: 50 Gwei. The EIP-1559 recurrence still runs normally, but its output is clamped so base fee never drops below 50 Gwei.
- **Txpool admission**: `minimal_protocol_basefee` default raised to 50 Gwei so transactions with `max_fee_per_gas < 50 Gwei` are rejected at the pool.

This means base fee can still rise and fall with demand, but it is floored at 50 Gwei — effectively an "only-increase-above-floor" model starting from 50 Gwei.

## Changes

- `crates/chainspec/src/constants.rs` — add `GRAVITY_MIN_BASE_FEE = 50_000_000_000`.
- `crates/chainspec/src/api.rs` — override `EthChainSpec::next_block_base_fee` to clamp the EIP-1559 result to the floor and fall back to the floor when the parent has no base fee.
- `crates/chainspec/src/spec.rs` — use `GRAVITY_MIN_BASE_FEE` as the fallback for genesis and `initial_base_fee()` when `baseFeePerGas` is absent from the genesis config.
- `crates/ethereum/evm/src/lib.rs` — use the floor at the London transition boundary (defensive; not hit on fresh Gravity genesis).
- `crates/consensus/common/src/validation.rs` — align the London-transition expected base fee with the new floor.
- `crates/transaction-pool/{config.rs,pool/txpool.rs}` and `crates/node/core/src/args/txpool.rs` — raise default `minimal_protocol_basefee` (and the `--txpool.minimal-protocol-fee` CLI default) to 50 Gwei.
- `crates/transaction-pool/src/error.rs` (+ call sites) — extend `FeeCapBelowMinimumProtocolFeeCap` with the configured `minimum` so the error message reports it: `"transaction feeCap {fee_cap} below chain minimum {minimum}"`.

## Note on genesis.json

If a deployed genesis JSON explicitly sets `baseFeePerGas`, that value still wins for block 0 (only block 0; block 1 onward is clamped by the new floor). Deployments should either omit `baseFeePerGas` (to pick up the 50 Gwei default) or set it explicitly to `"0xba43b7400"`.

## Test plan

- [x] `cargo check` across changed crates (chainspec, evm-ethereum, transaction-pool, consensus-common, node-core).
- [x] `cargo test -p reth-chainspec test_centralized_base_fee_calculation` — updated to account for the clamp.
- [ ] Verify on a devnet that block 1 base fee is >= 50 Gwei regardless of block 0 utilization.
- [ ] Verify wallet (MetaMask/Rabby) can submit EIP-1559 tx without manual fee override.
- [ ] Verify tx with `max_fee_per_gas < 50 Gwei` is rejected by `eth_sendRawTransaction` with a clear error.