### PR TITLE
chore(deps): bump gravity-api-types to aptos-node tip (e9544c8cb3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos?rev=1d1153b6fdfbc14960d433c3949c781bb1739c64#1d1153b6fdfbc14960d433c3949c781bb1739c64"
+source = "git+https://github.com/Galxe/gravity-aptos?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4775,7 +4775,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 # reth
-gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "1d1153b6fdfbc14960d433c3949c781bb1739c64" }
+gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "e9544c8cb3d8a5757d4c7f1b4807b312c03ba060" }
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }


### PR DESCRIPTION
## Summary

Bumps the `gravity-api-types` (aliased `api-types`) pin from the stale `1d1153b6fd` to `e9544c8cb3d8a5757d4c7f1b4807b312c03ba060` — the post-merge tip of `aptos-node` after [Galxe/gravity-aptos#72](https://github.com/Galxe/gravity-aptos/pull/72).

## Why this is needed

Follows Galxe/gravity-aptos#72 which introduced `Identity::FromGcpSecret` and `InitialSafetyRulesConfig::FromGcpSecret` on the `aptos-node` branch. Downstream `gravity-sdk` will bump its `gaptos` rev to this same aptos-node tip in the companion PR Galxe/gravity-sdk#688.

Without this bump, greth ends up with `api-types @ 1d1153b6fd` while sdk's `gaptos` pulls `api-types @ e9544c8cb3`. Cargo identifies packages by `(name, source_url, rev)` — two distinct rev SHAs = two distinct packages in the resolved graph. The `impl ConfigStorage for PipeExecLayerApi` defined in this crate (`crates/pipe-exec-layer-ext-v2/execute/src/lib.rs`) would then be keyed to greth's copy of the `ConfigStorage` trait, while sdk's `use gaptos::api_types::config_storage::ConfigStorage` imports gaptos's copy. Method lookups fail with:

```
error[E0599]: no method named `fetch_config_bytes` found for struct
              `PipeExecLayerApi<Storage, EthApi>` in the current scope
help: trait `ConfigStorage` which provides `fetch_config_bytes` is implemented
      but not in scope; perhaps you want to import it
```

## What changes in greth

**Nothing behaviorally.** `api-types` subcrate contents are byte-identical between `1d1153b6fd` and `e9544c8cb3` — the three intermediate commits only touch `aptos-config/config/` (adds the `FromGcpSecret` enum variants behind an off-by-default cargo feature `gcp-secret-manager`). This is pure dep-version alignment.

## Test plan

- [x] `cargo build -p reth-pipe-exec-layer-ext-v2` locally (verified during pilot, greth-side impls compile unchanged)
- [ ] CI green on this PR
- [ ] Downstream: gravity-sdk#688 rebuild and `cargo check` pass after both this and gravity-aptos#72 are merged

## Merge ordering

1. Galxe/gravity-aptos#72 ✅ (already merged)
2. **This PR** (ideally rebase/fast-forward to keep a clean tip SHA for the downstream pin)
3. Galxe/gravity-sdk#688 (bumps `gaptos` to `e9544c8cb3` and `greth` to this PR's merge SHA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
