### PR TITLE
feat(fee): chainspec floor with code-driven activation schedule

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{constants::GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK, ChainSpec, DepositContract};
+use crate::{ChainSpec, DepositContract};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
 use alloy_consensus::Header;
@@ -173,18 +173,15 @@ impl EthChainSpec for ChainSpec {
 
     /// Gravity base fee floor schedule for the **main** branch.
     ///
-    /// Single segment: `[GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK, ∞)` returns the genesis
-    /// `gravityMinBaseFee` value. Earlier blocks (impossible when the activation block
-    /// is `0`) and chainspecs without the genesis field return `None`. Released testnet
-    /// branches override this constant and/or extend this function with additional
-    /// historical segments (e.g. v1.6 would add `[M, N) -> Some(50_000_000_000)` for
-    /// the v1.5-era hardcoded floor).
-    // Lint allow: on main `GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK == 0` so the comparison
-    // is trivially true; we keep the `>=` form for branch parity (testnet overrides this
-    // constant to a non-zero block, and future schedule extensions add more segments).
-    #[allow(clippy::absurd_extreme_comparisons)]
+    /// Single segment: `[gravity_min_base_fee_activation_block, ∞)` returns the genesis
+    /// `gravityMinBaseFee` value; earlier blocks and chainspecs without the genesis
+    /// field return `None`. Released testnet branches read the activation block from
+    /// genesis (so the rolling-upgrade height is configurable per-network) and may
+    /// extend this function with hardcoded historical segments — e.g. a v1.6 upgrade
+    /// stepping the floor at block N would add `[M, N) -> Some(50_000_000_000)` for
+    /// the v1.5-era value.
     fn gravity_min_base_fee_at_block(&self, block: u64) -> Option<u64> {
-        if block >= GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK {
+        if block >= self.gravity_min_base_fee_activation_block {
             self.gravity_min_base_fee
         } else {
             None

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -1,4 +1,4 @@
-use crate::{constants::GRAVITY_MIN_BASE_FEE, ChainSpec, DepositContract};
+use crate::{constants::GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK, ChainSpec, DepositContract};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_chains::Chain;
 use alloy_consensus::Header;
@@ -74,21 +74,35 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     /// ```
     fn gravity_hardforks(&self) -> &reth_ethereum_forks::ChainHardforks;
 
+    /// Returns the Gravity protocol minimum base fee (in wei) applicable at the given
+    /// block, or `None` if no floor applies at that height.
+    ///
+    /// The schedule of activation block(s) and any historical floor values is encoded
+    /// in branch-specific code (see this branch's `ChainSpec` impl). Chainspecs that
+    /// are not Gravity (e.g. Ethereum mainnet during reth history sync) return `None`
+    /// for all blocks via the trait default.
+    fn gravity_min_base_fee_at_block(&self, _block: u64) -> Option<u64> {
+        None
+    }
+
     /// See [`calc_next_block_base_fee`].
     ///
-    /// Gravity applies a protocol-wide floor of [`GRAVITY_MIN_BASE_FEE`] (50 Gwei):
-    /// the EIP-1559 recurrence runs normally, and the result is clamped so base fee
-    /// never drops below the floor. If the parent has no base fee (pre-London header),
-    /// the floor is used as the parent base fee.
+    /// When the Gravity floor is active for the next block (see
+    /// [`Self::gravity_min_base_fee_at_block`]), the EIP-1559 recurrence is clamped at
+    /// the floor and the floor is used as the parent fallback for pre-London headers.
+    /// When no floor is active, upstream EIP-1559 behavior applies and pre-London
+    /// parents return `None`.
     fn next_block_base_fee(&self, parent: &Self::Header, target_timestamp: u64) -> Option<u64> {
-        let parent_base_fee = parent.base_fee_per_gas().unwrap_or(GRAVITY_MIN_BASE_FEE);
+        let next_block = parent.number() + 1;
+        let floor = self.gravity_min_base_fee_at_block(next_block);
+        let parent_base_fee = parent.base_fee_per_gas().or(floor)?;
         let next = calc_next_block_base_fee(
             parent.gas_used(),
             parent.gas_limit(),
             parent_base_fee,
             self.base_fee_params_at_timestamp(target_timestamp),
         );
-        Some(next.max(GRAVITY_MIN_BASE_FEE))
+        Some(floor.map_or(next, |f| next.max(f)))
     }
 }
 
@@ -155,5 +169,21 @@ impl EthChainSpec for ChainSpec {
 
     fn gravity_hardforks(&self) -> &reth_ethereum_forks::ChainHardforks {
         &self.gravity_hardforks
+    }
+
+    /// Gravity base fee floor schedule for the **main** branch.
+    ///
+    /// Single segment: `[GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK, ∞)` returns the genesis
+    /// `gravityMinBaseFee` value. Earlier blocks (impossible when the activation block
+    /// is `0`) and chainspecs without the genesis field return `None`. Released testnet
+    /// branches override this constant and/or extend this function with additional
+    /// historical segments (e.g. v1.6 would add `[M, N) -> Some(50_000_000_000)` for
+    /// the v1.5-era hardcoded floor).
+    fn gravity_min_base_fee_at_block(&self, block: u64) -> Option<u64> {
+        if block >= GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK {
+            self.gravity_min_base_fee
+        } else {
+            None
+        }
     }
 }

--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -179,6 +179,10 @@ impl EthChainSpec for ChainSpec {
     /// branches override this constant and/or extend this function with additional
     /// historical segments (e.g. v1.6 would add `[M, N) -> Some(50_000_000_000)` for
     /// the v1.5-era hardcoded floor).
+    // Lint allow: on main `GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK == 0` so the comparison
+    // is trivially true; we keep the `>=` form for branch parity (testnet overrides this
+    // constant to a non-zero block, and future schedule extensions add more segments).
+    #[allow(clippy::absurd_extreme_comparisons)]
     fn gravity_min_base_fee_at_block(&self, block: u64) -> Option<u64> {
         if block >= GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK {
             self.gravity_min_base_fee

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -15,15 +15,6 @@ pub const MIN_TRANSACTION_GAS: u64 = 21_000u64;
 /// Gravity genesis files.
 pub const GRAVITY_MIN_BASE_FEE: u64 = 50_000_000_000;
 
-/// Block number at which the Gravity base fee floor activates on this branch.
-///
-/// `0` for the main branch (floor enforced from genesis). Released testnet branches
-/// (e.g. `gravity-testnet-v1.5`) override this constant with their rolling-upgrade
-/// activation height. When the floor steps to a different value at a future block,
-/// add a new constant for that boundary and extend
-/// [`crate::ChainSpec::gravity_min_base_fee_at_block`] to dispatch on it.
-pub const GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK: u64 = 0;
-
 /// Mainnet prune delete limit.
 pub const MAINNET_PRUNE_DELETE_LIMIT: usize = 20000;
 

--- a/crates/chainspec/src/constants.rs
+++ b/crates/chainspec/src/constants.rs
@@ -5,12 +5,24 @@ use alloy_primitives::b256;
 /// Gas per transaction not creating a contract.
 pub const MIN_TRANSACTION_GAS: u64 = 21_000u64;
 
-/// Gravity protocol minimum base fee per gas (50 Gwei).
+/// Reference value for the Gravity protocol minimum base fee per gas (50 Gwei).
 ///
-/// Acts as both the floor for EIP-1559 base fee updates and the initial base fee at
-/// genesis. The EIP-1559 recurrence is clamped at this value, so base fee never drops
-/// below 50 Gwei.
+/// The actual floor enforced at runtime is read from the chainspec field
+/// [`crate::ChainSpec::gravity_min_base_fee`] (parsed from genesis JSON
+/// `config.gravityMinBaseFee`), so non-Gravity chainspecs (e.g. Ethereum mainnet during
+/// reth history sync) keep upstream EIP-1559 semantics. This constant is kept for
+/// documentation, tests, and as the canonical reference value when constructing
+/// Gravity genesis files.
 pub const GRAVITY_MIN_BASE_FEE: u64 = 50_000_000_000;
+
+/// Block number at which the Gravity base fee floor activates on this branch.
+///
+/// `0` for the main branch (floor enforced from genesis). Released testnet branches
+/// (e.g. `gravity-testnet-v1.5`) override this constant with their rolling-upgrade
+/// activation height. When the floor steps to a different value at a future block,
+/// add a new constant for that boundary and extend
+/// [`crate::ChainSpec::gravity_min_base_fee_at_block`] to dispatch on it.
+pub const GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK: u64 = 0;
 
 /// Mainnet prune delete limit.
 pub const MAINNET_PRUNE_DELETE_LIMIT: usize = 20000;

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -153,30 +153,44 @@ mod tests {
     fn test_centralized_base_fee_calculation() {
         use crate::{constants::GRAVITY_MIN_BASE_FEE, ChainSpec, EthChainSpec};
         use alloy_consensus::Header;
+        use alloy_eips::eip1559::INITIAL_BASE_FEE;
 
-        fn parent_header() -> Header {
+        fn parent_header(number: u64, base_fee: u64) -> Header {
             Header {
+                number,
                 gas_used: 15_000_000,
                 gas_limit: 30_000_000,
-                base_fee_per_gas: Some(GRAVITY_MIN_BASE_FEE),
+                base_fee_per_gas: Some(base_fee),
                 timestamp: 1_000,
                 ..Default::default()
             }
         }
 
-        let spec = ChainSpec::default();
-        let parent = parent_header();
-
-        // For testing, assume next block has timestamp 12 seconds later
-        let next_timestamp = parent.timestamp + 12;
-
-        // Gravity clamps the EIP-1559 recurrence at GRAVITY_MIN_BASE_FEE.
+        // Scenario 1: chainspec has no Gravity floor configured (Ethereum mainnet
+        // history sync). Result follows upstream EIP-1559 with no clamp.
+        let upstream_spec = ChainSpec::default();
+        let parent = parent_header(0, INITIAL_BASE_FEE);
+        let next_ts = parent.timestamp + 12;
         let expected = parent
-            .next_block_base_fee(spec.base_fee_params_at_timestamp(next_timestamp))
-            .unwrap_or_default()
-            .max(GRAVITY_MIN_BASE_FEE);
+            .next_block_base_fee(upstream_spec.base_fee_params_at_timestamp(next_ts))
+            .unwrap_or_default();
+        let got = upstream_spec.next_block_base_fee(&parent, next_ts).unwrap_or_default();
+        assert_eq!(expected, got, "Upstream chainspec must follow vanilla EIP-1559 (no clamp)");
+        assert!(got < GRAVITY_MIN_BASE_FEE, "sanity: upstream computed value is below floor");
 
-        let got = spec.next_block_base_fee(&parent, next_timestamp).unwrap_or_default();
-        assert_eq!(expected, got, "Base fee calculation does not match expected value");
+        // Scenario 2: Gravity main — chainspec has gravityMinBaseFee = 50 Gwei,
+        // schedule activates at block 0, so floor is enforced for every block.
+        let main_spec =
+            ChainSpec { gravity_min_base_fee: Some(GRAVITY_MIN_BASE_FEE), ..Default::default() };
+        // floor query returns Some at any block
+        assert_eq!(main_spec.gravity_min_base_fee_at_block(0), Some(GRAVITY_MIN_BASE_FEE));
+        assert_eq!(main_spec.gravity_min_base_fee_at_block(123_456), Some(GRAVITY_MIN_BASE_FEE));
+        // EIP-1559 result clamped at the floor when input is below
+        let got_main = main_spec.next_block_base_fee(&parent, next_ts).unwrap_or_default();
+        assert_eq!(got_main, GRAVITY_MIN_BASE_FEE, "main: clamp at floor");
+        // when parent already at/above floor, recurrence runs above floor
+        let parent_above = parent_header(0, GRAVITY_MIN_BASE_FEE);
+        let got_above = main_spec.next_block_base_fee(&parent_above, next_ts).unwrap_or_default();
+        assert!(got_above >= GRAVITY_MIN_BASE_FEE, "main: stays above floor");
     }
 }

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -16,10 +16,9 @@ use alloy_consensus::{
     Header,
 };
 use alloy_eips::{
-    eip7685::EMPTY_REQUESTS_HASH, eip7840::BlobParams, eip7892::BlobScheduleBlobParams,
+    eip1559::INITIAL_BASE_FEE, eip7685::EMPTY_REQUESTS_HASH, eip7840::BlobParams,
+    eip7892::BlobScheduleBlobParams,
 };
-
-use crate::constants::GRAVITY_MIN_BASE_FEE;
 use alloy_genesis::Genesis;
 use alloy_primitives::{address, b256, Address, BlockNumber, B256, U256};
 use alloy_trie::root::state_root_ref_unhashed;
@@ -41,7 +40,7 @@ pub fn make_genesis_header(genesis: &Genesis, hardforks: &ChainHardforks) -> Hea
     let base_fee_per_gas = hardforks
         .fork(EthereumHardfork::London)
         .active_at_block(0)
-        .then(|| genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(GRAVITY_MIN_BASE_FEE));
+        .then(|| genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(INITIAL_BASE_FEE));
 
     // If shanghai is activated, initialize the header with an empty withdrawals hash, and
     // empty withdrawals list.
@@ -115,6 +114,7 @@ pub static MAINNET: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
             (mainnet::MAINNET_BPO2_TIMESTAMP, BlobParams::bpo2()),
         ]),
         gravity_hardforks: ChainHardforks::default(),
+        gravity_min_base_fee: None,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -148,6 +148,7 @@ pub static SEPOLIA: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
             (sepolia::SEPOLIA_BPO2_TIMESTAMP, BlobParams::bpo2()),
         ]),
         gravity_hardforks: ChainHardforks::default(),
+        gravity_min_base_fee: None,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -179,6 +180,7 @@ pub static HOLESKY: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
             (holesky::HOLESKY_BPO2_TIMESTAMP, BlobParams::bpo2()),
         ]),
         gravity_hardforks: ChainHardforks::default(),
+        gravity_min_base_fee: None,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -212,6 +214,7 @@ pub static HOODI: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
             (hoodi::HOODI_BPO2_TIMESTAMP, BlobParams::bpo2()),
         ]),
         gravity_hardforks: ChainHardforks::default(),
+        gravity_min_base_fee: None,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -319,6 +322,19 @@ pub struct ChainSpec {
 
     /// Gravity-specific hardforks and their activation conditions.
     pub gravity_hardforks: ChainHardforks,
+
+    /// Gravity protocol minimum base fee floor (in wei) applicable to the **latest**
+    /// segment of this branch's fee schedule. When `Some`, the chainspec is treated as
+    /// Gravity and the floor schedule encoded in
+    /// [`EthChainSpec::gravity_min_base_fee_at_block`] applies. When `None`, no floor is
+    /// applied (upstream EIP-1559 behavior, used by Ethereum mainnet history sync).
+    /// Parsed from genesis JSON `config.gravityMinBaseFee`.
+    ///
+    /// The activation block(s) for this floor — and any historical values from prior
+    /// schedule steps — live in branch-specific code constants, not in genesis. This
+    /// way a node restarted across multiple hardforks always has the full historical
+    /// schedule baked into its binary.
+    pub gravity_min_base_fee: Option<u64>,
 }
 
 impl Default for ChainSpec {
@@ -334,6 +350,7 @@ impl Default for ChainSpec {
             prune_delete_limit: MAINNET_PRUNE_DELETE_LIMIT,
             blob_params: Default::default(),
             gravity_hardforks: Default::default(),
+            gravity_min_base_fee: None,
         }
     }
 }
@@ -388,7 +405,7 @@ impl ChainSpec {
     pub fn initial_base_fee(&self) -> Option<u64> {
         // If the base fee is set in the genesis block, we use that instead of the default.
         let genesis_base_fee =
-            self.genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(GRAVITY_MIN_BASE_FEE);
+            self.genesis.base_fee_per_gas.map(|fee| fee as u64).unwrap_or(INITIAL_BASE_FEE);
 
         // If London is activated at genesis, we set the initial base fee as per EIP-1559.
         self.hardforks.fork(EthereumHardfork::London).active_at_block(0).then_some(genesis_base_fee)
@@ -759,6 +776,12 @@ impl From<Genesis> for ChainSpec {
                 .collect(),
         );
 
+        // Gravity protocol minimum base fee floor (wei). Presence of this field marks
+        // the chainspec as Gravity; the activation schedule lives in branch-specific
+        // code (see EthChainSpec::gravity_min_base_fee_at_block).
+        let gravity_min_base_fee =
+            genesis.config.extra_fields.get("gravityMinBaseFee").and_then(|v| v.as_u64());
+
         Self {
             chain: genesis.config.chain_id.into(),
             genesis_header: SealedHeader::new_unhashed(make_genesis_header(&genesis, &hardforks)),
@@ -768,6 +791,7 @@ impl From<Genesis> for ChainSpec {
             deposit_contract,
             blob_params,
             gravity_hardforks,
+            gravity_min_base_fee,
             ..Default::default()
         }
     }
@@ -1716,13 +1740,11 @@ Post-merge hard forks (timestamp based):
 
     #[test]
     fn dev_fork_ids() {
-        // Gravity's 50 Gwei genesis base_fee fallback (vs upstream's 1 Gwei) changes
-        // the DEV chain genesis hash, which changes this fork ID.
         test_fork_ids(
             &DEV,
             &[(
                 Head { number: 0, ..Default::default() },
-                ForkId { hash: ForkHash([0x4f, 0x66, 0xfe, 0xb7]), next: 0 },
+                ForkId { hash: ForkHash([0x0b, 0x1a, 0x4e, 0xf7]), next: 0 },
             )],
         )
     }
@@ -2434,16 +2456,12 @@ Post-merge hard forks (timestamp based):
 
         // check the genesis hash
         let genesis_hash = header.hash_slow();
-        // Genesis hash differs from upstream Reth because Gravity uses
-        // GRAVITY_MIN_BASE_FEE (50 Gwei) instead of INITIAL_BASE_FEE (1 Gwei)
-        // as the genesis base_fee fallback; the header's baseFeePerGas therefore
-        // changes and so does its hash.
         let expected_hash =
-            b256!("0x1d0fc10d8f976bc4731b7b40975b1ff8b95712fe43318dea939ae3792f91cbcc");
+            b256!("0x16bb7c59613a5bad3f7c04a852fd056545ade2483968d9a25a1abb05af0c4d37");
         assert_eq!(genesis_hash, expected_hash);
 
         // check that the forkhash is correct
-        let expected_forkhash = ForkHash(hex!("3e3a308f"));
+        let expected_forkhash = ForkHash(hex!("8062457a"));
         assert_eq!(ForkHash::from(genesis_hash), expected_forkhash);
     }
 

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -115,6 +115,7 @@ pub static MAINNET: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         ]),
         gravity_hardforks: ChainHardforks::default(),
         gravity_min_base_fee: None,
+        gravity_min_base_fee_activation_block: 0,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -149,6 +150,7 @@ pub static SEPOLIA: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         ]),
         gravity_hardforks: ChainHardforks::default(),
         gravity_min_base_fee: None,
+        gravity_min_base_fee_activation_block: 0,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -181,6 +183,7 @@ pub static HOLESKY: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         ]),
         gravity_hardforks: ChainHardforks::default(),
         gravity_min_base_fee: None,
+        gravity_min_base_fee_activation_block: 0,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -215,6 +218,7 @@ pub static HOODI: LazyLock<Arc<ChainSpec>> = LazyLock::new(|| {
         ]),
         gravity_hardforks: ChainHardforks::default(),
         gravity_min_base_fee: None,
+        gravity_min_base_fee_activation_block: 0,
     };
     spec.genesis.config.dao_fork_support = true;
     spec.into()
@@ -329,12 +333,17 @@ pub struct ChainSpec {
     /// [`EthChainSpec::gravity_min_base_fee_at_block`] applies. When `None`, no floor is
     /// applied (upstream EIP-1559 behavior, used by Ethereum mainnet history sync).
     /// Parsed from genesis JSON `config.gravityMinBaseFee`.
-    ///
-    /// The activation block(s) for this floor — and any historical values from prior
-    /// schedule steps — live in branch-specific code constants, not in genesis. This
-    /// way a node restarted across multiple hardforks always has the full historical
-    /// schedule baked into its binary.
     pub gravity_min_base_fee: Option<u64>,
+
+    /// Block number at which [`Self::gravity_min_base_fee`] activates on this branch.
+    /// On main this is hardcoded to `0` in `From<Genesis>` (floor enforced from
+    /// genesis). Released testnet branches read it from genesis JSON
+    /// `config.extra_fields` (the same mechanism used by Alpha/Beta/Gamma/Delta), so
+    /// the rolling-upgrade activation height can be set per-network without code
+    /// changes. Historical-segment values from prior schedule steps still live in
+    /// branch-specific code, ensuring nodes restarted across multiple hardforks
+    /// validate older blocks correctly from the binary's full schedule.
+    pub gravity_min_base_fee_activation_block: u64,
 }
 
 impl Default for ChainSpec {
@@ -351,6 +360,7 @@ impl Default for ChainSpec {
             blob_params: Default::default(),
             gravity_hardforks: Default::default(),
             gravity_min_base_fee: None,
+            gravity_min_base_fee_activation_block: 0,
         }
     }
 }
@@ -776,11 +786,16 @@ impl From<Genesis> for ChainSpec {
                 .collect(),
         );
 
-        // Gravity protocol minimum base fee floor (wei). Presence of this field marks
-        // the chainspec as Gravity; the activation schedule lives in branch-specific
-        // code (see EthChainSpec::gravity_min_base_fee_at_block).
+        // Gravity protocol minimum base fee floor (wei). Presence marks the chainspec
+        // as Gravity; absence keeps upstream EIP-1559 semantics (e.g. Ethereum mainnet
+        // history sync).
         let gravity_min_base_fee =
             genesis.config.extra_fields.get("gravityMinBaseFee").and_then(|v| v.as_u64());
+        // main: floor activates at genesis (block 0). Released testnet branches override
+        // this to read the rolling-upgrade activation height from genesis (e.g.
+        // `epsilonBlock`), keeping the value configurable per-network without code
+        // changes — same mechanism as Alpha/Beta/Gamma/Delta above.
+        let gravity_min_base_fee_activation_block = 0u64;
 
         Self {
             chain: genesis.config.chain_id.into(),
@@ -792,6 +807,7 @@ impl From<Genesis> for ChainSpec {
             blob_params,
             gravity_hardforks,
             gravity_min_base_fee,
+            gravity_min_base_fee_activation_block,
             ..Default::default()
         }
     }

--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -3,8 +3,8 @@
 use alloy_consensus::{
     constants::MAXIMUM_EXTRA_DATA_SIZE, BlockHeader as _, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
-use alloy_eips::{eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
-use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, GRAVITY_MIN_BASE_FEE};
+use alloy_eips::{eip1559::INITIAL_BASE_FEE, eip4844::DATA_GAS_PER_BLOB, eip7840::BlobParams};
+use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::{ConsensusError, TxGasLimitTooHighErr};
 use reth_primitives_traits::{
     constants::{
@@ -313,7 +313,7 @@ pub fn validate_against_parent_eip1559_base_fee<ChainSpec: EthChainSpec + Ethere
             .ethereum_fork_activation(EthereumHardfork::London)
             .transitions_at_block(header.number())
         {
-            GRAVITY_MIN_BASE_FEE
+            INITIAL_BASE_FEE
         } else {
             chain_spec
                 .next_block_base_fee(parent, header.timestamp())

--- a/crates/e2e-test-utils/src/transaction.rs
+++ b/crates/e2e-test-utils/src/transaction.rs
@@ -16,7 +16,7 @@ pub struct TransactionTestContext;
 impl TransactionTestContext {
     /// Creates a static transfer and signs it, returning an envelope.
     pub async fn transfer_tx(chain_id: u64, wallet: PrivateKeySigner) -> TxEnvelope {
-        let tx = tx(chain_id, 21000, None, None, 0, Some(100e9 as u128));
+        let tx = tx(chain_id, 21000, None, None, 0, Some(20e9 as u128));
         Self::sign_tx(wallet, tx).await
     }
 
@@ -43,7 +43,7 @@ impl TransactionTestContext {
         init_code: Bytes,
         wallet: PrivateKeySigner,
     ) -> TxEnvelope {
-        let tx = tx(chain_id, gas, Some(init_code), None, 0, Some(100e9 as u128));
+        let tx = tx(chain_id, gas, Some(init_code), None, 0, Some(20e9 as u128));
         Self::sign_tx(wallet, tx).await
     }
 
@@ -77,7 +77,7 @@ impl TransactionTestContext {
             None,
             Some(authorization.into_signed(signature)),
             0,
-            Some(100e9 as u128),
+            Some(20e9 as u128),
         );
         Self::sign_tx(wallet, tx).await
     }
@@ -99,7 +99,7 @@ impl TransactionTestContext {
         chain_id: u64,
         wallet: PrivateKeySigner,
     ) -> eyre::Result<TxEnvelope> {
-        let mut tx = tx(chain_id, 210000, None, None, 0, Some(100e9 as u128));
+        let mut tx = tx(chain_id, 210000, None, None, 0, Some(20e9 as u128));
 
         let mut builder = SidecarBuilder::<SimpleCoder>::new();
         builder.ingest(b"dummy blob");
@@ -135,7 +135,7 @@ impl TransactionTestContext {
         let l1_block_info = Bytes::from_static(&hex!(
             "7ef9015aa044bae9d41b8380d781187b426c6fe43df5fb2fb57bd4466ef6a701e1f01e015694deaddeaddeaddeaddeaddeaddeaddeaddead000194420000000000000000000000000000000000001580808408f0d18001b90104015d8eb900000000000000000000000000000000000000000000000000000000008057650000000000000000000000000000000000000000000000000000000063d96d10000000000000000000000000000000000000000000000000000000000009f35273d89754a1e0387b89520d989d3be9c37c1f32495a88faf1ea05c61121ab0d1900000000000000000000000000000000000000000000000000000000000000010000000000000000000000002d679b567db6187c0c8323fa982cfb88b74dbcc7000000000000000000000000000000000000000000000000000000000000083400000000000000000000000000000000000000000000000000000000000f4240"
         ));
-        let tx = tx(chain_id, 210000, Some(l1_block_info), None, nonce, Some(100e9 as u128));
+        let tx = tx(chain_id, 210000, Some(l1_block_info), None, nonce, Some(20e9 as u128));
         let signer = EthereumWallet::from(wallet);
         <TransactionRequest as TransactionBuilder<Ethereum>>::build(tx, &signer)
             .await
@@ -177,7 +177,7 @@ fn tx(
         to: Some(TxKind::Call(Address::random())),
         gas: Some(gas),
         max_fee_per_gas,
-        max_priority_fee_per_gas: Some(100e9 as u128),
+        max_priority_fee_per_gas: Some(20e9 as u128),
         chain_id: Some(chain_id),
         input: TransactionInput { input: None, data },
         authorization_list: delegate_to.map(|addr| vec![addr]),

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -54,10 +54,9 @@ use revm::{
 };
 
 mod config;
-use alloy_eips::eip7840::BlobParams;
+use alloy_eips::{eip1559::INITIAL_BASE_FEE, eip7840::BlobParams};
 use alloy_evm::{eth::spec::EthExecutorSpec, Database, Evm};
 pub use config::{revm_spec, revm_spec_by_timestamp_and_block_number};
-use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use reth_ethereum_forks::{EthereumHardfork, Hardforks};
 use revm::{context::TxEnv, DatabaseCommit};
 
@@ -248,7 +247,7 @@ where
             gas_limit *= elasticity_multiplier as u64;
 
             // set the base fee to the initial base fee from the EIP-1559 spec
-            basefee = Some(GRAVITY_MIN_BASE_FEE)
+            basefee = Some(INITIAL_BASE_FEE)
         }
 
         let block_env = BlockEnv {

--- a/crates/ethereum/node/src/node.rs
+++ b/crates/ethereum/node/src/node.rs
@@ -453,7 +453,18 @@ where
     type Pool = EthTransactionPool<Node::Provider, DiskFileBlobStore>;
 
     async fn build_pool(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Pool> {
-        let pool_config = ctx.pool_config();
+        let mut pool_config = ctx.pool_config();
+
+        // Gravity: when the chainspec floor is active for the next block to be produced,
+        // raise the pool admission floor to match consensus. The decision is made once
+        // at startup; nodes that boot pre-activation and run past it will not auto-
+        // tighten — operationally acceptable because pipe-exec rejects sub-floor txs
+        // at block production regardless of pool state. `max()` preserves any operator
+        // override via `--txpool.minimal-protocol-fee` that is already higher.
+        let next_block = ctx.head().number + 1;
+        if let Some(floor) = ctx.chain_spec().gravity_min_base_fee_at_block(next_block) {
+            pool_config.minimal_protocol_basefee = pool_config.minimal_protocol_basefee.max(floor);
+        }
 
         let blob_cache_size = if let Some(blob_cache_size) = pool_config.blob_cache_size {
             Some(blob_cache_size)

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -1,9 +1,8 @@
 use alloy_eips::eip2718::Encodable2718;
 use alloy_genesis::Genesis;
-use alloy_primitives::Address;
+use alloy_primitives::{b256, hex, Address};
 use futures::StreamExt;
 use reth_chainspec::ChainSpec;
-use reth_e2e_test_utils::{transaction::TransactionTestContext, wallet::Wallet};
 use reth_node_api::{BlockBody, FullNodeComponents, FullNodePrimitives, NodeTypes};
 use reth_node_builder::{rpc::RethRpcAddOns, FullNode, NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::args::DevArgs;
@@ -12,8 +11,6 @@ use reth_provider::{providers::BlockchainProvider, CanonStateSubscriptions};
 use reth_rpc_eth_api::{helpers::EthTransactions, EthApiServer};
 use reth_tasks::TaskManager;
 use std::sync::Arc;
-
-const DEV_CHAIN_ID: u64 = 2600;
 
 #[tokio::test]
 async fn can_run_dev_node() -> eyre::Result<()> {
@@ -88,14 +85,18 @@ where
 {
     let mut notifications = node.provider.canonical_state_stream();
 
-    // Submit a signed EIP-1559 tx through RPC. The signer is the first address of the shared
-    // test mnemonic (funded in `custom_chain`'s genesis); helper-generated txs carry
-    // 100 Gwei max_fee_per_gas, clearing Gravity's 50 Gwei protocol floor.
-    let wallet = Wallet::new(1).with_chain_id(DEV_CHAIN_ID).wallet_gen().remove(0);
-    let raw_tx = TransactionTestContext::transfer_tx_bytes(DEV_CHAIN_ID, wallet).await;
+    // submit tx through rpc
+    let raw_tx = hex!(
+        "02f876820a28808477359400847735940082520894ab0840c0e43688012c1adb0f5e3fc665188f83d28a029d394a5d630544000080c080a0a044076b7e67b5deecc63f61a8d7913fab86ca365b344b5759d1fe3563b4c39ea019eab979dd000da04dfc72bb0377c092d30fd9e1cab5ae487de49586cc8b0090"
+    );
 
     let eth_api = node.rpc_registry.eth_api();
-    let hash = eth_api.send_raw_transaction(raw_tx).await.unwrap();
+
+    let hash = eth_api.send_raw_transaction(raw_tx.into()).await.unwrap();
+
+    let expected = b256!("0xb1c6512f4fc202c04355fbda66755e0e344b152e633010e8fd75ecec09b63398");
+
+    assert_eq!(hash, expected);
     println!("submitted transaction: {hash}");
 
     let head = notifications.next().await.unwrap();
@@ -117,7 +118,7 @@ fn custom_chain() -> Arc<ChainSpec> {
     "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x0000000000000000000000000000000000000000",
     "alloc": {
-        "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266": {
+        "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b": {
             "balance": "0x4a47e3c12448f4ad000000"
         }
     },

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -1,10 +1,9 @@
 //! Transaction pool arguments
 
 use crate::cli::config::RethTransactionPoolConfig;
-use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
+use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::Address;
 use clap::Args;
-use reth_chainspec::GRAVITY_MIN_BASE_FEE;
 use reth_cli_util::parse_duration_from_secs_or_ms;
 use reth_transaction_pool::{
     blobstore::disk::DEFAULT_MAX_CACHED_BLOBS,
@@ -63,7 +62,7 @@ pub struct TxPoolArgs {
     pub price_bump: u128,
 
     /// Minimum base fee required by the protocol.
-    #[arg(long = "txpool.minimal-protocol-fee", default_value_t = GRAVITY_MIN_BASE_FEE)]
+    #[arg(long = "txpool.minimal-protocol-fee", default_value_t = MIN_PROTOCOL_BASE_FEE)]
     pub minimal_protocol_basefee: u64,
 
     /// Minimum priority fee required for transaction acceptance into the pool.
@@ -141,15 +140,15 @@ pub struct TxPoolArgs {
 
 impl TxPoolArgs {
     /// Sets the minimal protocol base fee to 0, effectively disabling checks that enforce that a
-    /// transaction's fee must be higher than the protocol minimum base fee which is the lowest
-    /// value the EIP-1559 base fee can reach.
+    /// transaction's fee must be higher than the [`MIN_PROTOCOL_BASE_FEE`] which is the lowest
+    /// value the ethereum EIP-1559 base fee can reach.
     pub const fn with_disabled_protocol_base_fee(self) -> Self {
         self.with_protocol_base_fee(0)
     }
 
     /// Configures the minimal protocol base fee that should be enforced.
     ///
-    /// Gravity's EIP-1559 base fee can't drop below [`GRAVITY_MIN_BASE_FEE`] hence this is
+    /// Ethereum's EIP-1559 base fee can't drop below [`MIN_PROTOCOL_BASE_FEE`] hence this is
     /// enforced by default in the pool.
     pub const fn with_protocol_base_fee(mut self, protocol_base_fee: u64) -> Self {
         self.minimal_protocol_basefee = protocol_base_fee;
@@ -171,7 +170,7 @@ impl Default for TxPoolArgs {
             blob_cache_size: None,
             max_account_slots: TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER,
             price_bump: DEFAULT_PRICE_BUMP,
-            minimal_protocol_basefee: GRAVITY_MIN_BASE_FEE,
+            minimal_protocol_basefee: MIN_PROTOCOL_BASE_FEE,
             minimum_priority_fee: None,
             enforced_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             max_tx_gas_limit: None,

--- a/crates/optimism/chainspec/src/lib.rs
+++ b/crates/optimism/chainspec/src/lib.rs
@@ -292,6 +292,14 @@ impl EthChainSpec for OpChainSpec {
         self.inner.final_paris_total_difficulty()
     }
 
+    fn gravity_hardforks(&self) -> &ChainHardforks {
+        self.inner.gravity_hardforks()
+    }
+
+    fn gravity_min_base_fee_at_block(&self, block: u64) -> Option<u64> {
+        self.inner.gravity_min_base_fee_at_block(block)
+    }
+
     fn next_block_base_fee(&self, parent: &Header, target_timestamp: u64) -> Option<u64> {
         if self.is_jovian_active_at_timestamp(parent.timestamp()) {
             compute_jovian_base_fee(self, parent, target_timestamp).ok()

--- a/crates/transaction-pool/src/config.rs
+++ b/crates/transaction-pool/src/config.rs
@@ -76,8 +76,8 @@ pub struct PoolConfig {
 
 impl PoolConfig {
     /// Sets the minimal protocol base fee to 0, effectively disabling checks that enforce that a
-    /// transaction's fee must be higher than the protocol minimum base fee which is the lowest
-    /// value the EIP-1559 base fee can reach.
+    /// transaction's fee must be higher than the [`MIN_PROTOCOL_BASE_FEE`] which is the lowest
+    /// value the ethereum EIP-1559 base fee can reach.
     pub const fn with_disabled_protocol_base_fee(self) -> Self {
         self.with_protocol_base_fee(0)
     }
@@ -85,9 +85,7 @@ impl PoolConfig {
     /// Configures the minimal protocol base fee that should be enforced.
     ///
     /// Ethereum's EIP-1559 base fee can't drop below [`MIN_PROTOCOL_BASE_FEE`] hence this is
-    /// enforced by default in the pool. Gravity's production node raises this to
-    /// `GRAVITY_MIN_BASE_FEE` (50 Gwei) via the `--txpool.minimal-protocol-fee` CLI arg
-    /// (see `TxPoolArgs`), so this default only matters for ad-hoc test pool construction.
+    /// enforced by default in the pool.
     pub const fn with_protocol_base_fee(mut self, protocol_base_fee: u64) -> Self {
         self.minimal_protocol_basefee = protocol_base_fee;
         self

--- a/crates/transaction-pool/src/test_utils/tx_gen.rs
+++ b/crates/transaction-pool/src/test_utils/tx_gen.rs
@@ -1,9 +1,9 @@
 use crate::{EthPooledTransaction, PoolTransaction};
 use alloy_consensus::{SignableTransaction, TxEip1559, TxEip4844, TxLegacy};
-use alloy_eips::{eip2718::Encodable2718, eip2930::AccessList};
+use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718, eip2930::AccessList};
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
 use rand::{Rng, RngCore};
-use reth_chainspec::{GRAVITY_MIN_BASE_FEE, MAINNET};
+use reth_chainspec::MAINNET;
 use reth_ethereum_primitives::{Transaction, TransactionSigned};
 use reth_primitives_traits::{crypto::secp256k1::sign_message, SignedTransaction};
 
@@ -31,7 +31,7 @@ impl<R: RngCore> TransactionGenerator<R> {
         Self {
             rng,
             signer_keys: (0..num_signers).map(|_| B256::random()).collect(),
-            base_fee: GRAVITY_MIN_BASE_FEE as u128,
+            base_fee: MIN_PROTOCOL_BASE_FEE as u128,
             gas_limit: 300_000,
         }
     }


### PR DESCRIPTION
## Summary

Replaces the global hardcoded 50 Gwei floor from #335 with a chainspec-field + code-driven schedule. Non-Gravity chainspecs (Ethereum mainnet history sync) keep upstream EIP-1559 semantics; Gravity chainspecs apply the floor according to a per-branch schedule.

## Design

**Genesis (`config.gravityMinBaseFee`)**: carries only the floor value applicable to the **latest** schedule segment. Its presence marks the chainspec as Gravity; absence means no floor.

**Code (this branch — main)**: `crates/chainspec/src/constants.rs::GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK = 0`, with a single-segment schedule `[0, ∞)` returning the genesis value.

**Trait helper**: `EthChainSpec::gravity_min_base_fee_at_block(block) -> Option<u64>` — defaults to `None`, ChainSpec impl encodes the schedule. Used by both `next_block_base_fee` (consensus / pipe-exec block production) and `EthereumPoolBuilder::build_pool` (pool admission floor, queried at `head + 1` and combined with the operator CLI override via `max()`).

## Compatibility

| Scenario | Behavior |
|---|---|
| Ethereum mainnet history sync | Genesis lacks `gravityMinBaseFee` → schedule returns `None` for any block → upstream EIP-1559, no clamp, pool admission floor = `MIN_PROTOCOL_BASE_FEE` (7 wei). Fixes #335 breaking the Ethereum mainnet London transition (block 12,965,000) where actual base_fee = 1 Gwei. |
| Gravity main | Genesis sets `gravityMinBaseFee = 50_000_000_000`, activation block = 0 → floor enforced from genesis. Pipe-exec and pool admission both clamp at 50 Gwei. |
| Released testnet branch | Cherry-pick this commit and override `GRAVITY_MIN_BASE_FEE_ACTIVATION_BLOCK` with the rolling-upgrade activation height N. Before block N the schedule returns `None` (matches pre-floor behavior, rolling-upgrade safe); from block N onward it returns the genesis value. |

## Future upgrade method

When a future release changes the floor from value X to Y at block N:

1. Update genesis JSON: `gravityMinBaseFee = Y`
2. Extend the schedule helper with a new historical segment:

```rust
fn gravity_min_base_fee_at_block(&self, block: u64) -> Option<u64> {
    if block >= GRAVITY_MIN_BASE_FEE_ACT_BLOCK_N {
        self.gravity_min_base_fee   // genesis value (Y)
    } else if block >= GRAVITY_MIN_BASE_FEE_ACT_BLOCK_M {
        Some(50_000_000_000)        // hardcoded historical X
    } else {
        None
    }
}
```

Historical floor values are hardcoded in code, so a node restarted across multiple hardforks always validates older blocks correctly from the binary's full schedule. Genesis-only designs (which carry only the current state) cannot guarantee this.

## Drive-by

`OpChainSpec` was missing the `gravity_hardforks` impl introduced in #309 — a pre-existing bug that blocked workspace compile. Added forwarding impl for `gravity_hardforks` and `gravity_min_base_fee_at_block`.