### PR TITLE
fix(oracle): emit oracle nonce carrier in DataRecorded JWKs

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -920,7 +920,14 @@ impl<Storage: GravityStorage> Core<Storage> {
                     ProviderJWKs {
                         issuer: issuer.into_bytes(),
                         version: nonce as u64, // nonce as version
-                        jwks: vec![],          // return empty jwks
+                        jwks: vec![gravity_api_types::on_chain_config::jwks::JWKStruct {
+                            // gaptos reads gravity:// oracle progress from Any.data as a raw
+                            // 16-byte nonce. The GravityEvent adapter only preserves raw bytes
+                            // for known JWK wrappers, so this entry is a nonce carrier rather
+                            // than an RSA key.
+                            type_name: "0x1::jwks::RSA_JWK".to_string(),
+                            data: nonce.to_be_bytes().to_vec(),
+                        }],
                     }
                 })
                 .collect();


### PR DESCRIPTION
## Summary

`DataRecorded`-derived `ProviderJWKs` are the channel by which gravity oracle progress reaches the consensus layer. Previously this branch built each `ProviderJWKs` with `jwks: vec![]` and relied on `version = nonce`. Downstream, gaptos's `ObservedJWKsUpdated → oracle nonce` adapter pulls the nonce out of the **first JWK entry's raw `data` bytes**, not the `version` field — with empty `jwks`, that conversion fails and `aptos-jwk-consensus/src/jwk_manager/mod.rs:154` logs:

```
JWKManager handling error: No JWK entries to convert oracle nonce {"epoch":N}
```

The first oracle update in an epoch happens to succeed because the JWK consensus state is freshly seeded, but any subsequent in-epoch oracle nonce push fails to convert. `jwk_observer`'s 10 s retry loop then re-logs the same error indefinitely, and the relayer's NativeMinted pipeline stalls for the rest of the epoch.

## Fix

In `crates/pipe-exec-layer-ext-v2/execute/src/lib.rs::Core::handle_*` (the path that turns `DataRecorded` events into `ProviderJWKs`), supply exactly one synthetic `JWKStruct` whose `data` carries the oracle nonce as 16 big-endian bytes:

```rust
jwks: vec![gravity_api_types::on_chain_config::jwks::JWKStruct {
    // gaptos reads gravity:// oracle progress from Any.data as a raw 16-byte
    // nonce. The GravityEvent adapter only preserves raw bytes for known JWK
    // wrappers, so this entry is a nonce carrier rather than an RSA key.
    type_name: "0x1::jwks::RSA_JWK".to_string(),
    data: nonce.to_be_bytes().to_vec(),
}],
```

`type_name = "0x1::jwks::RSA_JWK"` is required so the gaptos `GravityEvent → JWK` adapter preserves the raw `data` bytes (the wrapper type is recognised, even though the payload is a nonce rather than an actual RSA JWK). No changes needed on the gaptos or gravity-sdk side beyond bumping greth.

## Cross-link

Downstream validation lives in [Galxe/gravity-sdk#725](https://github.com/Galxe/gravity-sdk/pull/725), which bumps `bin/gravity_node/Cargo.toml::greth` to this branch's tip (`b0ec42c`) and adds two new e2e cases:

- `bridge_multi_round` — 5 oracle update rounds within one epoch (the exact scenario this PR fixes)
- `bridge_cross_epoch` — bridge events spanning an epoch transition

That PR also includes a regression reproduction: re-pointing greth at the previous tip `364b851665cad891b9cc3cfbc0f958cb21f62bdd` reproduces the bug deterministically. With this PR's commit (`b0ec42c`) merged in, `bridge_multi_round` passes with all 5 rounds settling in the same epoch and **zero** `No JWK entries to convert oracle nonce` log lines.

| | Without this fix | With this fix |
|---|---|---|
| Round 1 (in-epoch) | ✅ | ✅ |
| Round 2+ (in-epoch) | ❌ timeout, log spam | ✅ |
| Cross-epoch (round 1 in epoch N, round 2 in epoch N+1) | ✅ (round 1 only) | ✅ |
| `No JWK entries to convert oracle nonce` lines per run | ≥18 (same-epoch case) | 0 |

## Test plan

- [x] `cargo build -p reth-pipe-exec-layer-ext-v2` clean
- [x] Downstream regression check (Galxe/gravity-sdk#725 — see table above)
  - [x] `bridge_multi_round` (10 events, 5 rounds, same epoch) — PASSED
  - [x] `bridge_cross_epoch` (10 events, 5+5 across an epoch transition) — PASSED
  - [x] Re-pinning to old tip `364b851` reproduces the failure
- [ ] CI green on this PR
- [ ] After merge: rebase Galxe/gravity-sdk#725's `Cargo.toml` pin to the final merge SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)