### PR TITLE
fix(eip-7702): filter intrinsic gas + Gravity acceptance tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,3 +15,12 @@ slow-timeout = { period = "2m", terminate-after = 10 }
 [[profile.default.overrides]]
 filter = "binary(e2e_testsuite)"
 slow-timeout = { period = "2m", terminate-after = 3 }
+
+# Gravity pipe-exec-layer integration tests: each test boots a full reth node
+# and pushes 100s–1000s of blocks through MockConsensus + PipeExecLayerApi.
+# Under runner contention (multiple of these tests share a 2-core box) wall
+# clock can routinely brush the default 120s kill — gravity_pipe_test alone
+# pushes 1671 blocks. Grant the same headroom as e2e_testsuite.
+[[profile.default.overrides]]
+filter = "binary(gravity_pipe_test) + binary(gravity_eip2935_test) + binary(gravity_eip7702_test)"
+slow-timeout = { period = "2m", terminate-after = 3 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,9 +18,14 @@ slow-timeout = { period = "2m", terminate-after = 3 }
 
 # Gravity pipe-exec-layer integration tests: each test boots a full reth node
 # and pushes 100s–1000s of blocks through MockConsensus + PipeExecLayerApi.
-# Under runner contention (multiple of these tests share a 2-core box) wall
-# clock can routinely brush the default 120s kill — gravity_pipe_test alone
-# pushes 1671 blocks. Grant the same headroom as e2e_testsuite.
+# Mirror the effective contract of the pre-nextest CI command (plain
+# `cargo test --test gravity_pipe_test`, which had no per-test timeout and
+# relied solely on the 60-min job-level cap). Grant a generous 30-minute
+# per-test ceiling so contention-induced slowness doesn't cause flake kills.
+# Retries are forced to 0: (a) these are deterministic state-machine tests
+# where retry adds no signal, (b) 30m × default 3 attempts = 90m would blow
+# past the 60-min job timeout-minutes.
 [[profile.default.overrides]]
 filter = "binary(gravity_pipe_test) + binary(gravity_eip2935_test) + binary(gravity_eip7702_test)"
-slow-timeout = { period = "2m", terminate-after = 3 }
+slow-timeout = { period = "5m", terminate-after = 6 }
+retries = 0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -94,14 +94,19 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Run gravity pipe + EIP-7702 / EIP-2935 integration tests
-        # Runs gravity_pipe_test plus the EIP-7702 and EIP-2935 integration
-        # binaries together — they share the same MockConsensus + PipeExecLayerApi
-        # harness, so one cold build covers all three.
+        # `--test <name>` is required (vs. just `-E 'binary(...)'`) because
+        # nextest's filterset only filters at *run* time — without `--test`,
+        # `-p <crate>` still tries to compile every integration binary in the
+        # crate, including ones that don't compile in this workspace (e.g.
+        # gravity_hardfork_test.rs depends on reth-ethereum-forks which is not
+        # in dev-dependencies). `--test` restricts both compile and run.
         run: |
           cargo nextest run \
             --locked \
             -p reth-pipe-exec-layer-ext-v2 \
-            -E 'binary(gravity_pipe_test) + binary(gravity_eip2935_test) + binary(gravity_eip7702_test)'
+            --test gravity_pipe_test \
+            --test gravity_eip2935_test \
+            --test gravity_eip7702_test
 
   integration-success:
     name: integration success

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,6 +72,8 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       RUST_MIN_STACK: 16777216
+      # Intentionally NOT setting GRETH_DISABLE_PIPE_EXECUTION: these tests
+      # drive PipeExecLayerApi end-to-end and assert the real fork-gated path.
     timeout-minutes: 60
     steps:
       - name: Free Disk Space
@@ -90,7 +92,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo test --package reth-pipe-exec-layer-ext-v2 --test gravity_pipe_test -- --exact test --show-output --nocapture
+      - uses: taiki-e/install-action@nextest
+      - name: Run gravity pipe + EIP-7702 / EIP-2935 integration tests
+        # Runs gravity_pipe_test plus the EIP-7702 and EIP-2935 integration
+        # binaries together — they share the same MockConsensus + PipeExecLayerApi
+        # harness, so one cold build covers all three.
+        run: |
+          cargo nextest run \
+            --locked \
+            -p reth-pipe-exec-layer-ext-v2 \
+            -E 'binary(gravity_pipe_test) + binary(gravity_eip2935_test) + binary(gravity_eip7702_test)'
 
   integration-success:
     name: integration success

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9987,6 +9987,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-sol-macro",
  "alloy-sol-types",
  "api-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10031,6 +10031,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-parallel",
  "revm 29.0.1 (git+https://github.com/Galxe/revm?branch=v29.0.1-gravity)",
+ "revm-interpreter 25.0.3 (git+https://github.com/Galxe/revm?branch=v29.0.1-gravity)",
  "revm-primitives 20.2.1 (git+https://github.com/Galxe/revm?branch=v29.0.1-gravity)",
  "serde",
  "serde_json",

--- a/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
+++ b/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
@@ -27,6 +27,7 @@ reth-trie-parallel.workspace = true
 reth-provider.workspace = true
 reth-rpc-eth-api.workspace = true
 revm-primitives.workspace = true
+revm-interpreter.workspace = true
 gravity-storage.workspace = true
 gravity-primitives.workspace = true
 grevm.workspace = true

--- a/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
+++ b/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
@@ -76,6 +76,8 @@ eyre.workspace = true
 rand.workspace = true
 criterion.workspace = true
 hex-literal = "0.4"
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
 
 [features]
 pipe_test = ["reth-provider/pipe_test"]

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -45,7 +45,6 @@ use reth_primitives_traits::{
 use reth_provider::{OriginalValuesKnown, PersistBlockCache, PERSIST_BLOCK_CACHE};
 use reth_rpc_eth_api::RpcTypes;
 use revm::DatabaseRef;
-use revm_primitives::hardfork::SpecId;
 use std::{
     collections::BTreeMap,
     sync::{
@@ -641,20 +640,14 @@ impl<Storage: GravityStorage> Core<Storage> {
 
         // Discard the invalid txs
         let start_time = Instant::now();
-        let spec_id = if self.chain_spec.is_prague_active_at_timestamp(block.timestamp) {
-            SpecId::PRAGUE
-        } else if self.chain_spec.is_shanghai_active_at_timestamp(block.timestamp) {
-            SpecId::SHANGHAI
-        } else {
-            SpecId::MERGE
-        };
         let (txs, senders, txs_info) = self.filter_invalid_txs(
             state,
             ordered_block.transactions,
             ordered_block.senders,
             base_fee,
             block.gas_limit,
-            spec_id,
+            block.timestamp,
+            block.number,
         );
         self.metrics.filter_transaction_duration.record(start_time.elapsed());
         let (txs, senders) = if !validator_txns.is_empty() {
@@ -1218,10 +1211,19 @@ impl<Storage: GravityStorage> Core<Storage> {
         senders: Vec<Address>,
         base_fee_per_gas: u64,
         gas_limit: u64,
-        spec_id: SpecId,
+        block_timestamp: u64,
+        block_number: u64,
     ) -> (Vec<TransactionSigned>, Vec<Address>, Vec<TxInfo>) {
-        let invalid_idxs =
-            tx_filter::filter_invalid_txs(db, &txs, &senders, base_fee_per_gas, gas_limit, spec_id);
+        let invalid_idxs = tx_filter::filter_invalid_txs(
+            db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &self.chain_spec,
+            block_timestamp,
+            block_number,
+        );
         if invalid_idxs.is_empty() {
             let mut txs_info = Vec::with_capacity(txs.len());
             for (tx, sender) in txs.iter().zip(senders.iter()) {

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -6,6 +6,7 @@ mod eip_2935;
 mod metrics;
 pub mod mint_precompile;
 pub mod onchain_config;
+mod tx_filter;
 use alloy_sol_types::SolEvent;
 
 use channel::Channel;
@@ -20,19 +21,15 @@ use alloy_consensus::{
     constants::EMPTY_WITHDRAWALS, BlockHeader, Header, Transaction, EMPTY_OMMER_ROOT_HASH,
 };
 use alloy_eips::{eip4895::Withdrawals, merge::BEACON_NONCE, BlockNumberOrTag};
-use alloy_primitives::{
-    map::{HashMap, HashSet},
-    Address, TxHash, B256, U256,
-};
+use alloy_primitives::{Address, TxHash, B256, U256};
 use alloy_rpc_types_eth::TransactionRequest;
 use gravity_primitives::get_gravity_config;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_chain_state::{ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates};
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_ethereum_primitives::{Block, BlockBody, Receipt, TransactionSigned};
 use reth_evm::{
     execute::BlockExecutionError, precompiles::DynPrecompile, ConfigureEvm, IntoTxEnv,
-    NextBlockEnvAttributes, ParallelDatabase,
+    NextBlockEnvAttributes,
 };
 use reth_evm_ethereum::EthEvmConfig;
 use reth_execution_types::{BlockExecutionOutput, ExecutionOutcome};
@@ -47,7 +44,8 @@ use reth_primitives_traits::{
 };
 use reth_provider::{OriginalValuesKnown, PersistBlockCache, PERSIST_BLOCK_CACHE};
 use reth_rpc_eth_api::RpcTypes;
-use revm::{state::AccountInfo, DatabaseRef};
+use revm::DatabaseRef;
+use revm_primitives::hardfork::SpecId;
 use std::{
     collections::BTreeMap,
     sync::{
@@ -643,12 +641,20 @@ impl<Storage: GravityStorage> Core<Storage> {
 
         // Discard the invalid txs
         let start_time = Instant::now();
+        let spec_id = if self.chain_spec.is_prague_active_at_timestamp(block.timestamp) {
+            SpecId::PRAGUE
+        } else if self.chain_spec.is_shanghai_active_at_timestamp(block.timestamp) {
+            SpecId::SHANGHAI
+        } else {
+            SpecId::MERGE
+        };
         let (txs, senders, txs_info) = self.filter_invalid_txs(
             state,
             ordered_block.transactions,
             ordered_block.senders,
             base_fee,
             block.gas_limit,
+            spec_id,
         );
         self.metrics.filter_transaction_duration.record(start_time.elapsed());
         let (txs, senders) = if !validator_txns.is_empty() {
@@ -1212,8 +1218,10 @@ impl<Storage: GravityStorage> Core<Storage> {
         senders: Vec<Address>,
         base_fee_per_gas: u64,
         gas_limit: u64,
+        spec_id: SpecId,
     ) -> (Vec<TransactionSigned>, Vec<Address>, Vec<TxInfo>) {
-        let invalid_idxs = filter_invalid_txs(db, &txs, &senders, base_fee_per_gas, gas_limit);
+        let invalid_idxs =
+            tx_filter::filter_invalid_txs(db, &txs, &senders, base_fee_per_gas, gas_limit, spec_id);
         if invalid_idxs.is_empty() {
             let mut txs_info = Vec::with_capacity(txs.len());
             for (tx, sender) in txs.iter().zip(senders.iter()) {
@@ -1256,93 +1264,6 @@ impl<Storage: GravityStorage> Core<Storage> {
             (filtered_txs, filtered_senders, txs_info)
         }
     }
-}
-
-/// Return the invalid transaction indexes.
-fn filter_invalid_txs<DB: ParallelDatabase>(
-    db: DB,
-    txs: &[TransactionSigned],
-    senders: &[Address],
-    base_fee_per_gas: u64,
-    gas_limit: u64,
-) -> HashSet<usize> {
-    let mut gas_limit_exceeded_tx_idx = txs.len();
-    let mut tx_gas_limit_sum: u64 = 0;
-    for (idx, tx) in txs.iter().enumerate() {
-        let tx_gas_limit = tx.gas_limit();
-        match tx_gas_limit_sum.checked_add(tx_gas_limit) {
-            Some(new_sum) if new_sum <= gas_limit => {
-                tx_gas_limit_sum = new_sum;
-            }
-            _ => {
-                warn!(target: "filter_invalid_txs",
-                    tx_hash=?txs[idx].hash(),
-                    sender=?senders[idx],
-                    block_gas_limit=?gas_limit,
-                    "gas limit exceeded, truncated to {}",
-                    idx,
-                );
-                gas_limit_exceeded_tx_idx = idx;
-                break;
-            }
-        }
-    }
-
-    let mut sender_idx: HashMap<&Address, Vec<usize>> = HashMap::default();
-    for (i, sender) in senders[..gas_limit_exceeded_tx_idx].iter().enumerate() {
-        sender_idx.entry(sender).or_default().push(i);
-    }
-
-    let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &mut AccountInfo| {
-        if account.nonce != tx.nonce() {
-            warn!(target: "filter_invalid_txs",
-                tx_hash=?tx.hash(),
-                sender=?sender,
-                nonce=?tx.nonce(),
-                account_nonce=?account.nonce,
-                "nonce mismatch"
-            );
-            return false;
-        }
-        let gas_spent = U256::from(tx.effective_gas_price(Some(base_fee_per_gas)))
-            .saturating_mul(U256::from(tx.gas_limit()));
-        let total_spent = gas_spent.saturating_add(tx.value());
-        if account.balance < total_spent {
-            warn!(target: "filter_invalid_txs",
-                tx_hash=?tx.hash(),
-                sender=?sender,
-                balance=?account.balance,
-                gas_spent=?gas_spent,
-                transfer_value=?tx.value(),
-                "insufficient balance"
-            );
-            return false;
-        }
-        account.balance -= total_spent;
-        account.nonce += 1;
-        true
-    };
-
-    let mut invalid_tx_idxs = sender_idx
-        .into_par_iter()
-        .flat_map(|(sender, idxs)| {
-            if let Some(mut account) = db.basic_ref(*sender).unwrap() {
-                idxs.into_iter()
-                    .filter(|&idx| !is_tx_valid(&txs[idx], sender, &mut account))
-                    .collect()
-            } else {
-                // Sender does not exist in the state trie, balance is 0
-                warn!(target: "filter_invalid_txs",
-                    tx_hash=?txs[idxs[0]].hash(),
-                    sender=?sender,
-                    "insufficient balance"
-                );
-                idxs
-            }
-        })
-        .collect::<HashSet<_>>();
-    invalid_tx_idxs.extend(gas_limit_exceeded_tx_idx..txs.len());
-    invalid_tx_idxs
 }
 
 /// Called by Coordinator
@@ -1513,275 +1434,5 @@ where
         event_tx,
         storage,
         onchain_config_fetcher,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_consensus::TxLegacy;
-    use alloy_primitives::{Address, Signature, U256};
-    use reth_ethereum_primitives::{Transaction, TransactionSigned};
-    use reth_revm::state::{AccountInfo, Bytecode};
-    use revm::{
-        primitives::{StorageKey, StorageValue},
-        DatabaseRef,
-    };
-    use std::collections::HashMap;
-
-    // Mock database for testing
-    #[derive(Debug, Default)]
-    struct MockDatabase {
-        accounts: HashMap<Address, AccountInfo>,
-    }
-
-    impl MockDatabase {
-        fn new() -> Self {
-            Self::default()
-        }
-
-        fn insert_account(&mut self, address: Address, account: AccountInfo) {
-            self.accounts.insert(address, account);
-        }
-    }
-
-    impl DatabaseRef for MockDatabase {
-        type Error = std::convert::Infallible;
-
-        fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-            Ok(self.accounts.get(&address).cloned())
-        }
-
-        fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-            unreachable!()
-        }
-
-        fn storage_ref(
-            &self,
-            _address: Address,
-            _index: StorageKey,
-        ) -> Result<StorageValue, Self::Error> {
-            unreachable!()
-        }
-
-        fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
-            unreachable!()
-        }
-    }
-
-    fn create_test_transaction(nonce: u64, gas_limit: u64, gas_price: u128) -> TransactionSigned {
-        TransactionSigned::new_unhashed(
-            Transaction::Legacy(TxLegacy { nonce, gas_price, gas_limit, ..Default::default() }),
-            Signature::test_signature(),
-        )
-    }
-
-    fn create_test_transaction_with_value(
-        nonce: u64,
-        gas_limit: u64,
-        gas_price: u128,
-        value: U256,
-    ) -> TransactionSigned {
-        TransactionSigned::new_unhashed(
-            Transaction::Legacy(TxLegacy {
-                nonce,
-                gas_price,
-                gas_limit,
-                value,
-                ..Default::default()
-            }),
-            Signature::test_signature(),
-        )
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_empty_input() {
-        let db = MockDatabase::new();
-        let txs = vec![];
-        let senders = vec![];
-        let base_fee_per_gas = 20_000_000_000u64; // 20 gwei
-        let gas_limit = 30_000_000u64; // 30M gas
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert!(invalid_idxs.is_empty());
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_account_not_exists() {
-        let db = MockDatabase::new();
-        let sender = Address::random();
-
-        // create a transaction, but the account does not exist
-        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
-        let txs = vec![tx];
-        let senders = vec![sender];
-        let base_fee_per_gas = 20_000_000_000u64;
-        let gas_limit = 30_000_000u64;
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert_eq!(invalid_idxs.len(), 1);
-        assert!(invalid_idxs.contains(&0));
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_nonce_mismatch() {
-        let mut db = MockDatabase::new();
-        let sender = Address::random();
-
-        // the account exists, but the nonce does not match
-        let account = AccountInfo {
-            balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
-            nonce: 5,                                          // 账户 nonce 是 5
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender, account);
-
-        // the transaction nonce is 0, but the account nonce is 5
-        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
-        let txs = vec![tx];
-        let senders = vec![sender];
-        let base_fee_per_gas = 20_000_000_000u64;
-        let gas_limit = 30_000_000u64;
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert_eq!(invalid_idxs.len(), 1);
-        assert!(invalid_idxs.contains(&0));
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_insufficient_balance() {
-        let mut db = MockDatabase::new();
-        let sender = Address::random();
-
-        // the account has insufficient balance
-        let account = AccountInfo {
-            balance: U256::from(1_000_000_000u64), // 1 Gwei
-            nonce: 0,
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender, account);
-
-        // fee = gas_price * gas_limit + value = 25_000_000_000 * 21_000 + 0 =
-        // 525_000_000_000_000
-        let tx1 = create_test_transaction(0, 21_000, 25_000_000_000);
-        let tx2 = create_test_transaction_with_value(0, 21_000, 1_000, U256::from(500_000_000u64));
-        let tx3 = create_test_transaction_with_value(0, 21_000, 1_000, U256::from(500_000_000u64));
-        let txs = vec![tx1, tx2, tx3];
-        let senders = vec![sender, sender, sender];
-        let base_fee_per_gas = 1_000;
-        let gas_limit = 30_000_000u64;
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert_eq!(invalid_idxs.len(), 2);
-        assert!(invalid_idxs.contains(&0));
-        assert!(invalid_idxs.contains(&2));
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_gas_limit_exceeded() {
-        let mut db = MockDatabase::new();
-        let sender = Address::random();
-
-        // the account has enough balance
-        let account = AccountInfo {
-            balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
-            nonce: 0,
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender, account);
-
-        // create multiple transactions, the cumulative gas limit exceeds the block limit
-        let tx1 = create_test_transaction(0, 20_000_000, 25_000_000_000); // 20M gas
-        let tx2 = create_test_transaction(1, 20_000_000, 25_000_000_000); // 20M gas
-        let txs = vec![tx1, tx2];
-        let senders = vec![sender, sender];
-        let base_fee_per_gas = 20_000_000_000u64;
-        let gas_limit = 30_000_000u64; // 30M gas limit
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert_eq!(invalid_idxs.len(), 1);
-        assert!(invalid_idxs.contains(&1));
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_valid_transactions() {
-        let mut db = MockDatabase::new();
-        let sender = Address::random();
-
-        // 账户有足够余额
-        let account = AccountInfo {
-            balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
-            nonce: 0,
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender, account);
-
-        // create valid transactions
-        let tx1 = create_test_transaction(0, 21_000, 25_000_000_000);
-        let tx2 = create_test_transaction(1, 21_000, 25_000_000_000);
-        let txs = vec![tx1, tx2];
-        let senders = vec![sender, sender];
-        let base_fee_per_gas = 20_000_000_000u64;
-        let gas_limit = 30_000_000u64;
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert!(invalid_idxs.is_empty());
-    }
-
-    #[test]
-    fn test_filter_invalid_txs_mixed_scenarios() {
-        let mut db = MockDatabase::new();
-        let sender1 = Address::random();
-        let sender2 = Address::random();
-        let sender3 = Address::random();
-
-        let account1 = AccountInfo {
-            balance: U256::from(1_000_000_000u64), // 1 Gwei
-            nonce: 0,
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender1, account1);
-
-        let account2 = AccountInfo {
-            balance: U256::from(1_000_000_000u64), // 1 Gwei
-            nonce: 5,
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender2, account2);
-
-        let account3 = AccountInfo {
-            balance: U256::from(1_000_000_000u64), // 1 Gwei
-            nonce: 0,
-            code_hash: B256::default(),
-            code: None,
-        };
-        db.insert_account(sender3, account3);
-
-        // create mixed scenarios transactions
-        let tx1 = create_test_transaction(0, 21_000, 25); // sender1: valid
-        let tx2 = create_test_transaction(0, 21_000, 25); // sender1: nonce does not match
-        let tx3 = create_test_transaction(1, 21_000, 25_000_000); // sender1: insufficient balance
-        let tx4 = create_test_transaction(5, 21_000, 25); // sender2: valid
-        let tx5 = create_test_transaction(2, 21_000, 25); // sender1: nonce does not match
-        let tx6 = create_test_transaction(6, 30_000_000, 25); // sender2: gas limit exceeds
-        let tx7 = create_test_transaction(0, 21000, 25); // sender3: truncated
-        let txs = vec![tx1, tx2, tx3, tx4, tx5, tx6, tx7];
-        let senders = vec![sender1, sender1, sender1, sender2, sender2, sender2, sender3];
-        let base_fee_per_gas = 20_000_000_000u64;
-        let gas_limit = 30_000_000u64;
-
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit);
-        assert_eq!(invalid_idxs.len(), 5, "invalid_idxs: {invalid_idxs:?}");
-        assert!(invalid_idxs.contains(&1));
-        assert!(invalid_idxs.contains(&2));
-        assert!(invalid_idxs.contains(&4));
-        assert!(invalid_idxs.contains(&5));
-        assert!(invalid_idxs.contains(&6));
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -63,6 +63,23 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             );
             return false;
         }
+        // Pre-Prague safety. revm rejects any TxEip7702 with `Eip7702NotSupported`
+        // when `spec_id < PRAGUE` (revm-handler validation.rs:181-182), but
+        // `calculate_initial_tx_gas` below only adds the auth-list cost when
+        // `spec_id >= PRAGUE` (revm-interpreter gas/calc.rs:417). Without this
+        // guard a TxEip7702 with `gas_limit == 21000` in a pre-Prague OrderedBlock
+        // would pass the intrinsic check, reach the executor, and panic
+        // `lib.rs:1067-1073`. Closes the boundary called out in the acceptance
+        // design as P-2.
+        if tx.is_eip7702() && !spec_id.is_enabled_in(SpecId::PRAGUE) {
+            warn!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                spec_id=?spec_id,
+                "EIP-7702 tx in pre-Prague block"
+            );
+            return false;
+        }
         // Mirror reth pool's `ensure_intrinsic_gas` so non-pool-injected txs (e.g. consensus-side
         // mempool) cannot reach grevm with `gas_limit < initial_gas` and panic the executor.
         let access_list = tx.access_list();
@@ -551,6 +568,36 @@ mod tests {
 
         let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
         assert_eq!(invalid_idxs.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// Pre-Prague boundary (acceptance design P-2): a TxEip7702 with otherwise-fine intrinsic
+    /// gas (`gas_limit > 21_000` so the SHANGHAI calculator that ignores `auth_list_num` would
+    /// accept it) must still be discarded when `spec_id < PRAGUE`, because the executor would
+    /// otherwise reject the tx with `Eip7702NotSupported` and panic `lib.rs:1067-1073`.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_rejected_pre_prague() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+
+        // 100k gas is well above the pre-Prague intrinsic (21k flat, since the
+        // auth-list cost is gated behind PRAGUE). Without the pre-Prague guard
+        // this tx would pass the filter and panic the executor.
+        let tx = create_test_7702_transaction(0, 100_000, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::SHANGHAI);
+        assert_eq!(invalid_idxs.len(), 1, "7702 tx must be discarded when spec_id < PRAGUE");
         assert!(invalid_idxs.contains(&0));
     }
 

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -1,0 +1,504 @@
+//! Pre-execution transaction filtering.
+//!
+//! Mirrors the cheap pool-side guards that `OrderedBlock` txs skipped (nonce, balance,
+//! cumulative gas, EIP-7702 intrinsic gas floor) so non-pool-injected txs cannot reach grevm with
+//! a state that would make the executor panic.
+
+use alloy_consensus::Transaction;
+use alloy_primitives::{
+    map::{HashMap, HashSet},
+    Address, U256,
+};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use reth_ethereum_primitives::TransactionSigned;
+use reth_evm::ParallelDatabase;
+use revm::state::AccountInfo;
+use revm_primitives::hardfork::SpecId;
+use tracing::warn;
+
+/// Return the invalid transaction indexes.
+pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
+    db: DB,
+    txs: &[TransactionSigned],
+    senders: &[Address],
+    base_fee_per_gas: u64,
+    gas_limit: u64,
+    spec_id: SpecId,
+) -> HashSet<usize> {
+    let mut gas_limit_exceeded_tx_idx = txs.len();
+    let mut tx_gas_limit_sum: u64 = 0;
+    for (idx, tx) in txs.iter().enumerate() {
+        let tx_gas_limit = tx.gas_limit();
+        match tx_gas_limit_sum.checked_add(tx_gas_limit) {
+            Some(new_sum) if new_sum <= gas_limit => {
+                tx_gas_limit_sum = new_sum;
+            }
+            _ => {
+                warn!(target: "filter_invalid_txs",
+                    tx_hash=?txs[idx].hash(),
+                    sender=?senders[idx],
+                    block_gas_limit=?gas_limit,
+                    "gas limit exceeded, truncated to {}",
+                    idx,
+                );
+                gas_limit_exceeded_tx_idx = idx;
+                break;
+            }
+        }
+    }
+
+    let mut sender_idx: HashMap<&Address, Vec<usize>> = HashMap::default();
+    for (i, sender) in senders[..gas_limit_exceeded_tx_idx].iter().enumerate() {
+        sender_idx.entry(sender).or_default().push(i);
+    }
+
+    let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &mut AccountInfo| {
+        if account.nonce != tx.nonce() {
+            warn!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                nonce=?tx.nonce(),
+                account_nonce=?account.nonce,
+                "nonce mismatch"
+            );
+            return false;
+        }
+        // Mirror reth pool's `ensure_intrinsic_gas` so non-pool-injected txs (e.g. consensus-side
+        // mempool) cannot reach grevm with `gas_limit < initial_gas` and panic the executor.
+        let access_list = tx.access_list();
+        let intrinsic = revm_interpreter::gas::calculate_initial_tx_gas(
+            spec_id,
+            tx.input(),
+            tx.is_create(),
+            access_list.map(|l| l.len()).unwrap_or_default() as u64,
+            access_list
+                .map(|l| l.iter().map(|i| i.storage_keys.len()).sum::<usize>())
+                .unwrap_or_default() as u64,
+            tx.authorization_list().map(|l| l.len()).unwrap_or_default() as u64,
+        );
+        if tx.gas_limit() < intrinsic.initial_gas || tx.gas_limit() < intrinsic.floor_gas {
+            warn!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                gas_limit=?tx.gas_limit(),
+                initial_gas=?intrinsic.initial_gas,
+                floor_gas=?intrinsic.floor_gas,
+                "intrinsic gas too low"
+            );
+            return false;
+        }
+        let gas_spent = U256::from(tx.effective_gas_price(Some(base_fee_per_gas)))
+            .saturating_mul(U256::from(tx.gas_limit()));
+        let total_spent = gas_spent.saturating_add(tx.value());
+        if account.balance < total_spent {
+            warn!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                balance=?account.balance,
+                gas_spent=?gas_spent,
+                transfer_value=?tx.value(),
+                "insufficient balance"
+            );
+            return false;
+        }
+        account.balance -= total_spent;
+        account.nonce += 1;
+        true
+    };
+
+    let mut invalid_tx_idxs = sender_idx
+        .into_par_iter()
+        .flat_map(|(sender, idxs)| {
+            if let Some(mut account) = db.basic_ref(*sender).unwrap() {
+                idxs.into_iter()
+                    .filter(|&idx| !is_tx_valid(&txs[idx], sender, &mut account))
+                    .collect()
+            } else {
+                // Sender does not exist in the state trie, balance is 0
+                warn!(target: "filter_invalid_txs",
+                    tx_hash=?txs[idxs[0]].hash(),
+                    sender=?sender,
+                    "insufficient balance"
+                );
+                idxs
+            }
+        })
+        .collect::<HashSet<_>>();
+    invalid_tx_idxs.extend(gas_limit_exceeded_tx_idx..txs.len());
+    invalid_tx_idxs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{TxEip7702, TxLegacy};
+    use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+    use alloy_primitives::{Address, Signature, TxKind, B256};
+    use reth_ethereum_primitives::{Transaction, TransactionSigned};
+    use reth_revm::state::{AccountInfo, Bytecode};
+    use revm::{
+        primitives::{StorageKey, StorageValue},
+        DatabaseRef,
+    };
+    use std::collections::HashMap as StdHashMap;
+
+    // Mock database for testing
+    #[derive(Debug, Default)]
+    struct MockDatabase {
+        accounts: StdHashMap<Address, AccountInfo>,
+    }
+
+    impl MockDatabase {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn insert_account(&mut self, address: Address, account: AccountInfo) {
+            self.accounts.insert(address, account);
+        }
+    }
+
+    impl DatabaseRef for MockDatabase {
+        type Error = std::convert::Infallible;
+
+        fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(self.accounts.get(&address).cloned())
+        }
+
+        fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            unreachable!()
+        }
+
+        fn storage_ref(
+            &self,
+            _address: Address,
+            _index: StorageKey,
+        ) -> Result<StorageValue, Self::Error> {
+            unreachable!()
+        }
+
+        fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
+            unreachable!()
+        }
+    }
+
+    // Legacy `Default` is a contract-create with `to: TxKind::Create`, which under any spec has
+    // initial intrinsic gas of 53000 — too high for the 21000-gas_limit fixtures these tests use.
+    // Pin `to` to a Call so the legacy intrinsic is the flat 21000.
+    fn create_test_transaction(nonce: u64, gas_limit: u64, gas_price: u128) -> TransactionSigned {
+        TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                nonce,
+                gas_price,
+                gas_limit,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    fn create_test_transaction_with_value(
+        nonce: u64,
+        gas_limit: u64,
+        gas_price: u128,
+        value: U256,
+    ) -> TransactionSigned {
+        TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                nonce,
+                gas_price,
+                gas_limit,
+                value,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    /// EIP-7702 type-0x04 tx with N authorizations; `gas_limit` caller controls.
+    fn create_test_7702_transaction(
+        nonce: u64,
+        gas_limit: u64,
+        authorizations: usize,
+    ) -> TransactionSigned {
+        let authorization_list = (0..authorizations)
+            .map(|_| {
+                SignedAuthorization::new_unchecked(
+                    Authorization { chain_id: U256::ZERO, address: Address::ZERO, nonce: 0 },
+                    0,
+                    U256::ZERO,
+                    U256::ZERO,
+                )
+            })
+            .collect();
+        TransactionSigned::new_unhashed(
+            Transaction::Eip7702(TxEip7702 {
+                nonce,
+                gas_limit,
+                max_fee_per_gas: 1,
+                max_priority_fee_per_gas: 0,
+                authorization_list,
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_empty_input() {
+        let db = MockDatabase::new();
+        let txs = vec![];
+        let senders = vec![];
+        let base_fee_per_gas = 20_000_000_000u64; // 20 gwei
+        let gas_limit = 30_000_000u64; // 30M gas
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert!(invalid_idxs.is_empty());
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_account_not_exists() {
+        let db = MockDatabase::new();
+        let sender = Address::random();
+
+        // create a transaction, but the account does not exist
+        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+        let base_fee_per_gas = 20_000_000_000u64;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 1);
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_nonce_mismatch() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+
+        // the account exists, but the nonce does not match
+        let account = AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
+            nonce: 5,                                          // 账户 nonce 是 5
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender, account);
+
+        // the transaction nonce is 0, but the account nonce is 5
+        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+        let base_fee_per_gas = 20_000_000_000u64;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 1);
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_insufficient_balance() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+
+        // the account has insufficient balance
+        let account = AccountInfo {
+            balance: U256::from(1_000_000_000u64), // 1 Gwei
+            nonce: 0,
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender, account);
+
+        // fee = gas_price * gas_limit + value = 25_000_000_000 * 21_000 + 0 =
+        // 525_000_000_000_000
+        let tx1 = create_test_transaction(0, 21_000, 25_000_000_000);
+        let tx2 = create_test_transaction_with_value(0, 21_000, 1_000, U256::from(500_000_000u64));
+        let tx3 = create_test_transaction_with_value(0, 21_000, 1_000, U256::from(500_000_000u64));
+        let txs = vec![tx1, tx2, tx3];
+        let senders = vec![sender, sender, sender];
+        let base_fee_per_gas = 1_000;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 2);
+        assert!(invalid_idxs.contains(&0));
+        assert!(invalid_idxs.contains(&2));
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_gas_limit_exceeded() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+
+        // the account has enough balance
+        let account = AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
+            nonce: 0,
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender, account);
+
+        // create multiple transactions, the cumulative gas limit exceeds the block limit
+        let tx1 = create_test_transaction(0, 20_000_000, 25_000_000_000); // 20M gas
+        let tx2 = create_test_transaction(1, 20_000_000, 25_000_000_000); // 20M gas
+        let txs = vec![tx1, tx2];
+        let senders = vec![sender, sender];
+        let base_fee_per_gas = 20_000_000_000u64;
+        let gas_limit = 30_000_000u64; // 30M gas limit
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 1);
+        assert!(invalid_idxs.contains(&1));
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_valid_transactions() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+
+        // 账户有足够余额
+        let account = AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
+            nonce: 0,
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender, account);
+
+        // create valid transactions
+        let tx1 = create_test_transaction(0, 21_000, 25_000_000_000);
+        let tx2 = create_test_transaction(1, 21_000, 25_000_000_000);
+        let txs = vec![tx1, tx2];
+        let senders = vec![sender, sender];
+        let base_fee_per_gas = 20_000_000_000u64;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert!(invalid_idxs.is_empty());
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_mixed_scenarios() {
+        let mut db = MockDatabase::new();
+        let sender1 = Address::random();
+        let sender2 = Address::random();
+        let sender3 = Address::random();
+
+        let account1 = AccountInfo {
+            balance: U256::from(1_000_000_000u64), // 1 Gwei
+            nonce: 0,
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender1, account1);
+
+        let account2 = AccountInfo {
+            balance: U256::from(1_000_000_000u64), // 1 Gwei
+            nonce: 5,
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender2, account2);
+
+        let account3 = AccountInfo {
+            balance: U256::from(1_000_000_000u64), // 1 Gwei
+            nonce: 0,
+            code_hash: B256::default(),
+            code: None,
+        };
+        db.insert_account(sender3, account3);
+
+        // create mixed scenarios transactions
+        let tx1 = create_test_transaction(0, 21_000, 25); // sender1: valid
+        let tx2 = create_test_transaction(0, 21_000, 25); // sender1: nonce does not match
+        let tx3 = create_test_transaction(1, 21_000, 25_000_000); // sender1: insufficient balance
+        let tx4 = create_test_transaction(5, 21_000, 25); // sender2: valid
+        let tx5 = create_test_transaction(2, 21_000, 25); // sender1: nonce does not match
+        let tx6 = create_test_transaction(6, 30_000_000, 25); // sender2: gas limit exceeds
+        let tx7 = create_test_transaction(0, 21000, 25); // sender3: truncated
+        let txs = vec![tx1, tx2, tx3, tx4, tx5, tx6, tx7];
+        let senders = vec![sender1, sender1, sender1, sender2, sender2, sender2, sender3];
+        let base_fee_per_gas = 20_000_000_000u64;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 5, "invalid_idxs: {invalid_idxs:?}");
+        assert!(invalid_idxs.contains(&1));
+        assert!(invalid_idxs.contains(&2));
+        assert!(invalid_idxs.contains(&4));
+        assert!(invalid_idxs.contains(&5));
+        assert!(invalid_idxs.contains(&6));
+    }
+
+    /// Regression: a type-0x04 tx whose `gas_limit` is below `21000 + PER_EMPTY_ACCOUNT_COST * N`
+    /// must be discarded at the filter stage. Before this fix it would reach grevm and panic the
+    /// executor with `IntrinsicGasTooLow` (see gravity-audit issue #668).
+    #[test]
+    fn test_filter_invalid_txs_eip7702_intrinsic_gas_too_low_under_prague() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH — balance is fine
+                nonce: 0,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+
+        // 21000 (base) + 25000 (PER_EMPTY_ACCOUNT_COST) = 46000 is the Prague intrinsic floor for
+        // a 7702 tx with one authorization and no calldata; gas_limit 30_000 is below it.
+        let tx = create_test_7702_transaction(0, 30_000, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+        let base_fee_per_gas = 0;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 1, "intrinsic-gas-too-low 7702 tx should be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// Sanity check: same 7702 tx with a `gas_limit` at or above the floor passes the filter.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_intrinsic_gas_just_enough_under_prague() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+
+        // exactly 21000 + 25000 = 46000 — at the floor, should pass
+        let tx = create_test_7702_transaction(0, 46_000, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+        let base_fee_per_gas = 0;
+        let gas_limit = 30_000_000u64;
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        assert!(invalid_idxs.is_empty(), "got: {invalid_idxs:?}");
+    }
+}

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -501,4 +501,84 @@ mod tests {
             filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
         assert!(invalid_idxs.is_empty(), "got: {invalid_idxs:?}");
     }
+
+    /// U-1 (acceptance design §3.1): a 7702 tx with `authorization_list.len() == 2` and
+    /// `gas_limit = 21000 + 25000 * 2 + 1000 = 72000` passes the filter under Prague.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_two_auths_gas_sufficient() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+
+        let tx = create_test_7702_transaction(0, 72_000, 2);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
+        assert!(
+            invalid_idxs.is_empty(),
+            "two-auth 7702 tx with 72k gas must pass: {invalid_idxs:?}"
+        );
+    }
+
+    /// U-2 (acceptance design §3.1): a 7702 tx with three authorizations and
+    /// `gas_limit = 21_000` is discarded by the filter rather than reaching the executor.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_three_auths_gas_too_low() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+
+        let tx = create_test_7702_transaction(0, 21_000, 3);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
+        assert_eq!(invalid_idxs.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// U-3 (acceptance design §3.1): the #668 fix must not regress legacy/1559 filtering.
+    /// A non-7702 tx with `authorization_list == None` and a 21k gas limit must still
+    /// pass the filter under Prague (the auth-list count contribution to intrinsic is 0).
+    #[test]
+    fn test_filter_invalid_txs_non_eip7702_under_prague_still_passes() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: B256::default(),
+                code: None,
+            },
+        );
+
+        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
+        assert!(
+            invalid_idxs.is_empty(),
+            "legacy 21k-gas tx must not be regressed by the 7702 intrinsic fix: {invalid_idxs:?}"
+        );
+    }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -10,21 +10,37 @@ use alloy_primitives::{
     Address, U256,
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use reth_chainspec::ChainSpec;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::ParallelDatabase;
+use reth_evm_ethereum::revm_spec_by_timestamp_and_block_number;
 use revm::state::AccountInfo;
 use revm_primitives::hardfork::SpecId;
 use tracing::warn;
 
 /// Return the invalid transaction indexes.
+///
+/// `chain_spec`, `block_timestamp`, `block_number` are taken instead of a
+/// pre-computed `SpecId` because the only consumer of `spec_id` here is the
+/// intrinsic-gas / 7702 fork-gate logic, and the caller (`lib.rs`) does not
+/// know which hardforks the filter *cares about* — historically it built a
+/// truncated MERGE/SHANGHAI/PRAGUE ladder that mislabelled CANCUN-active
+/// blocks as SHANGHAI. The canonical
+/// `revm_spec_by_timestamp_and_block_number` helper is used so the same
+/// (correct) mapping that the executor sees is the one the filter is gating
+/// against — no risk of the two drifting apart on a future hardfork.
 pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     db: DB,
     txs: &[TransactionSigned],
     senders: &[Address],
     base_fee_per_gas: u64,
     gas_limit: u64,
-    spec_id: SpecId,
+    chain_spec: &ChainSpec,
+    block_timestamp: u64,
+    block_number: u64,
 ) -> HashSet<usize> {
+    let spec_id =
+        revm_spec_by_timestamp_and_block_number(chain_spec, block_timestamp, block_number);
     let mut gas_limit_exceeded_tx_idx = txs.len();
     let mut tx_gas_limit_sum: u64 = 0;
     for (idx, tx) in txs.iter().enumerate() {
@@ -151,13 +167,28 @@ mod tests {
     use alloy_consensus::{TxEip7702, TxLegacy};
     use alloy_eips::eip7702::{Authorization, SignedAuthorization};
     use alloy_primitives::{Address, Signature, TxKind, B256};
+    use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
     use reth_ethereum_primitives::{Transaction, TransactionSigned};
     use reth_revm::state::{AccountInfo, Bytecode};
     use revm::{
         primitives::{StorageKey, StorageValue},
         DatabaseRef,
     };
-    use std::collections::HashMap as StdHashMap;
+    use std::{collections::HashMap as StdHashMap, sync::Arc};
+
+    /// Chainspec with Prague active from genesis — the canonical test fixture for
+    /// every case that wants the filter to apply 7702 intrinsic-gas rules.
+    fn prague_chain_spec() -> Arc<ChainSpec> {
+        Arc::new(ChainSpecBuilder::from(&*MAINNET).prague_activated().build())
+    }
+
+    /// Chainspec with Shanghai active from genesis but Prague unset — the
+    /// `pre-Prague` test fixture. Used to pin the boundary where a TxEip7702
+    /// must be discarded by the filter (revm would otherwise reject it with
+    /// `Eip7702NotSupported` and panic the executor).
+    fn shanghai_chain_spec() -> Arc<ChainSpec> {
+        Arc::new(ChainSpecBuilder::from(&*MAINNET).shanghai_activated().build())
+    }
 
     // Mock database for testing
     #[derive(Debug, Default)]
@@ -271,8 +302,16 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64; // 20 gwei
         let gas_limit = 30_000_000u64; // 30M gas
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert!(invalid_idxs.is_empty());
     }
 
@@ -288,8 +327,16 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert_eq!(invalid_idxs.len(), 1);
         assert!(invalid_idxs.contains(&0));
     }
@@ -315,8 +362,16 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert_eq!(invalid_idxs.len(), 1);
         assert!(invalid_idxs.contains(&0));
     }
@@ -345,8 +400,16 @@ mod tests {
         let base_fee_per_gas = 1_000;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert_eq!(invalid_idxs.len(), 2);
         assert!(invalid_idxs.contains(&0));
         assert!(invalid_idxs.contains(&2));
@@ -374,8 +437,16 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64; // 30M gas limit
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert_eq!(invalid_idxs.len(), 1);
         assert!(invalid_idxs.contains(&1));
     }
@@ -402,8 +473,16 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert!(invalid_idxs.is_empty());
     }
 
@@ -451,8 +530,16 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert_eq!(invalid_idxs.len(), 5, "invalid_idxs: {invalid_idxs:?}");
         assert!(invalid_idxs.contains(&1));
         assert!(invalid_idxs.contains(&2));
@@ -486,8 +573,16 @@ mod tests {
         let base_fee_per_gas = 0;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert_eq!(invalid_idxs.len(), 1, "intrinsic-gas-too-low 7702 tx should be discarded");
         assert!(invalid_idxs.contains(&0));
     }
@@ -514,8 +609,16 @@ mod tests {
         let base_fee_per_gas = 0;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, base_fee_per_gas, gas_limit, SpecId::PRAGUE);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
         assert!(invalid_idxs.is_empty(), "got: {invalid_idxs:?}");
     }
 
@@ -539,7 +642,8 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
             invalid_idxs.is_empty(),
             "two-auth 7702 tx with 72k gas must pass: {invalid_idxs:?}"
@@ -566,7 +670,8 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(invalid_idxs.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
         assert!(invalid_idxs.contains(&0));
     }
@@ -596,7 +701,8 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::SHANGHAI);
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &shanghai_chain_spec(), 0, 0);
         assert_eq!(invalid_idxs.len(), 1, "7702 tx must be discarded when spec_id < PRAGUE");
         assert!(invalid_idxs.contains(&0));
     }
@@ -622,7 +728,8 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, SpecId::PRAGUE);
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
             invalid_idxs.is_empty(),
             "legacy 21k-gas tx must not be regressed by the 7702 intrinsic fix: {invalid_idxs:?}"

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
@@ -66,11 +66,7 @@ use reth_rpc_eth_api::{helpers::EthCall, RpcTypes};
 use reth_tracing::{
     tracing_subscriber::filter::LevelFilter, LayerInfo, LogFormat, RethTracer, Tracer,
 };
-use std::{
-    collections::BTreeMap,
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -140,10 +136,6 @@ fn authority_signer(seed: u8) -> PrivateKeySigner {
 
 fn mock_block_id(block_number: u64) -> B256 {
     B256::left_padding_from(&block_number.to_be_bytes())
-}
-
-fn now_us(_block_number: u64) -> u64 {
-    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_micros() as u64
 }
 
 fn p3_ts_us(block_number: u64) -> u64 {
@@ -675,9 +667,4 @@ fn init_panic_hook_and_tracer() {
             Some("always".to_string()),
         ))
         .init();
-}
-
-#[allow(dead_code)]
-fn _silence_unused(_: fn() -> u64) {
-    let _ = now_us;
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
@@ -1,0 +1,683 @@
+#![allow(missing_docs)]
+
+//! Integration tests for EIP-7702 (set code for EOA) on the Gravity pipe-exec-layer.
+//!
+//! Drives `MockConsensus + PipeExecLayerApi` through an in-memory chainspec
+//! built from `gravity_hardfork.json` with `pragueTime` patched to align Prague
+//! activation with block 100 (`timestamp == 2_000_000_100`) — the same scheme
+//! `gravity_eip2935_test.rs` uses. Each scenario pushes the first 99 blocks as
+//! empty pre-Prague blocks and then injects a *tx-bearing* `OrderedBlock` 100
+//! that exercises the 7702 codepath that the audit (gravity-audit#668) flagged.
+//!
+//! ## Scope
+//!
+//! Covers the highest-value cases from
+//! `_local/drafts/eip-7702/EIP-7702-acceptance-tests-2026-06-01.md`:
+//!
+//! - **P-12** filter_invalid_txs end-to-end: a low-gas 7702 tx injected through `OrderedBlock` is
+//!   discarded by `filter_invalid_txs` instead of panicking the executor at `lib.rs:1072`. Pins the
+//!   gravity-audit#668 fix at the integration boundary.
+//! - **P-13** positive control: a sufficient-gas 7702 tx with one valid authorization is included;
+//!   the authority's account code becomes the 23-byte EIP-7702 designator `0xef0100 || target`.
+//! - **P-14** executor variant smoke: P-13 is run twice — once with `disable_grevm = true`
+//!   (`WrapExecutor<BasicBlockExecutor>`) and once with `false` (`GrevmExecutor`). Both paths must
+//!   apply the authorization so the authority ends up holding the 23-byte designator. The spec's
+//!   *stronger* claim ("byte-identical state roots") is not asserted here because this codebase is
+//!   known to produce different block-level accumulators across executor variants — see
+//!   `crates/ethereum/evm/src/parallel_execute.rs:446-449`, which delegates cross-executor
+//!   equivalence to unit-level diff tests rather than e2e state-root comparison. Both state roots
+//!   are printed for forensic inspection, but the test passes as long as the user-observable
+//!   designator state is identical.
+//!
+//! Cases that primarily exercise upstream pool, revm, or grevm semantics
+//! (P-1/P-3 pool fork-gate, P-5/P-6 multi-auth + chain_id==0, P-7 re-delegation,
+//! P-8/P-9/P-10 CALL/DELEGATECALL/STATICCALL → designator, P-15..P-18 grevm
+//! BlockSTM concurrency) are out of scope for this commit — the integration
+//! contract proven here is "pipe-exec-layer-v2 + grevm reach the upstream 7702
+//! engine without panicking and the upstream engine then runs to completion".
+
+use alloy_consensus::TxEip7702;
+use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+use alloy_primitives::{address, Address, Bytes, Signature, B256, U256};
+use alloy_rpc_types_eth::TransactionRequest;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use gravity_api_types::{
+    config_storage::{BlockNumber, ConfigStorage, OnChainConfig},
+    events::contract_event::GravityEvent,
+};
+use gravity_storage::{block_view_storage::BlockViewStorage, GravityStorage};
+use reth_chainspec::ChainSpec;
+use reth_cli_commands::{launcher::FnLauncher, NodeCommand};
+use reth_cli_runner::CliRunner;
+use reth_db::DatabaseEnv;
+use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth_ethereum_primitives::{Transaction, TransactionSigned};
+use reth_node_builder::{EngineNodeLauncher, NodeBuilder, WithLaunchContext};
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_pipe_exec_layer_ext_v2::{
+    new_pipe_exec_layer_api, ExecutionArgs, OrderedBlock, PipeExecLayerApi,
+};
+use reth_provider::{
+    providers::BlockchainProvider, BlockHashReader, BlockNumReader, DatabaseProviderFactory,
+    HeaderProvider, StateProviderFactory,
+};
+use reth_rpc_eth_api::{helpers::EthCall, RpcTypes};
+use reth_tracing::{
+    tracing_subscriber::filter::LevelFilter, LayerInfo, LogFormat, RethTracer, Tracer,
+};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// chainId from `gravity_hardfork.json`. Must match the chainspec the test
+/// boots under, otherwise pool/executor reject 7702 txs with ChainIdMismatch.
+const CHAIN_ID: u64 = 7771625;
+
+/// Block N is pushed with `timestamp = (P3_TS_BASE + N) * 1_000_000` (us).
+/// `pragueTime = P3_TS_BASE + P3_ACTIVATION_BLOCK = 2_000_000_100`, so block
+/// 99 is the last pre-Prague tip and block 100 is the activation block.
+const P3_TS_BASE: u64 = 2_000_000_000;
+const P3_ACTIVATION_BLOCK: u64 = 100;
+
+/// `pragueTime` aligned to the P-3 activation block — same value the EIP-2935
+/// tests use. Passed through `gravity_prague_chainspec()` so the in-memory
+/// chainspec activates Prague exactly at block 100.
+const PRAGUE_TS_BLOCK_100: u64 = P3_TS_BASE + P3_ACTIVATION_BLOCK;
+
+/// Build a Gravity chainspec JSON string by loading `gravity_hardfork.json`
+/// at compile time and patching `config.pragueTime`. Mirrors the helper in
+/// `gravity_eip2935_test.rs` — kept inline here so the 7702 tests stay
+/// self-contained (a sibling `tests/common/mod.rs` would couple the test
+/// binaries via Cargo's tests-as-binaries model).
+///
+/// - `Some(ts)` ⇒ Prague fires at `ts` (`ForkCondition::Timestamp(ts)`).
+/// - `None` ⇒ field omitted ⇒ Prague never fires (`ForkCondition::Never`).
+///
+/// `chain_value_parser` (`crates/ethereum/cli/src/chainspec.rs`) accepts
+/// in-memory JSON for `--chain`, so no tempfile / no IO overhead.
+fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
+    let mut json: serde_json::Value =
+        serde_json::from_str(include_str!("../gravity_hardfork.json"))
+            .expect("gravity_hardfork.json must parse as JSON");
+    if let Some(ts) = prague_time {
+        json["config"]["pragueTime"] = serde_json::json!(ts);
+    }
+    json.to_string()
+}
+
+/// Anvil account 0 — pre-funded in `gravity_hardfork.json` (`0x2e51 ETH`).
+/// Used as the tx sender (wallet_B / relayer) in every 7702 scenario.
+const FUNDED_PRIVKEY_HEX: &[u8; 32] = &[
+    0xac, 0x09, 0x74, 0xbe, 0xc3, 0x9a, 0x17, 0xe3, 0x6b, 0xa4, 0xa6, 0xb4, 0xd2, 0x38, 0xff, 0x94,
+    0x4b, 0xac, 0xb4, 0x78, 0xcb, 0xed, 0x5e, 0xfc, 0xae, 0x78, 0x4d, 0x7b, 0xf4, 0xf2, 0xff, 0x80,
+];
+const FUNDED_ADDR: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+/// Delegation target for the authorization — an arbitrary address. The
+/// 7702 designator is `0xef0100 || target`; the target's code (or lack
+/// thereof) only matters if the authority is subsequently CALLed.
+const TARGET_ADDR: Address = address!("0x0000000000000000000000000000000000001234");
+
+fn funded_signer() -> PrivateKeySigner {
+    PrivateKeySigner::from_bytes(&B256::from(*FUNDED_PRIVKEY_HEX))
+        .expect("funded test key must parse")
+}
+
+/// Deterministic non-funded EOA — used as the EIP-7702 authority. The seed
+/// makes every test run hit the same address so failures reproduce.
+fn authority_signer(seed: u8) -> PrivateKeySigner {
+    let mut bytes = [0u8; 32];
+    bytes[31] = seed;
+    PrivateKeySigner::from_bytes(&B256::from(bytes)).expect("authority key must parse")
+}
+
+fn mock_block_id(block_number: u64) -> B256 {
+    B256::left_padding_from(&block_number.to_be_bytes())
+}
+
+fn now_us(_block_number: u64) -> u64 {
+    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_micros() as u64
+}
+
+fn p3_ts_us(block_number: u64) -> u64 {
+    (P3_TS_BASE + block_number) * 1_000_000
+}
+
+// ---------------------------------------------------------------------------
+// Signing helpers
+// ---------------------------------------------------------------------------
+
+/// Sign an EIP-7702 `Authorization { chain_id, address, nonce }` and wrap it
+/// in `SignedAuthorization`. Mirrors the upstream pattern from
+/// `crates/ethereum/node/tests/e2e/utils.rs:99-102`.
+fn sign_authorization(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    target: Address,
+    nonce: u64,
+) -> SignedAuthorization {
+    let auth = Authorization { chain_id: U256::from(chain_id), address: target, nonce };
+    let sig: Signature =
+        signer.sign_hash_sync(&auth.signature_hash()).expect("auth signing must succeed");
+    auth.into_signed(sig)
+}
+
+/// Build a TxEip7702 and sign it with `sender`. Returns the encoded
+/// `TransactionSigned` plus the recovered sender (so the caller can populate
+/// `OrderedBlock.senders` without going through the recovery codepath).
+fn build_signed_eip7702_tx(
+    sender: &PrivateKeySigner,
+    nonce: u64,
+    gas_limit: u64,
+    to: Address,
+    input: Bytes,
+    authorization_list: Vec<SignedAuthorization>,
+) -> (TransactionSigned, Address) {
+    use alloy_consensus::SignableTransaction;
+
+    let tx = TxEip7702 {
+        chain_id: CHAIN_ID,
+        nonce,
+        gas_limit,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        authorization_list,
+        input,
+    };
+    let sig_hash = tx.signature_hash();
+    let signature: Signature = sender.sign_hash_sync(&sig_hash).expect("tx signing must succeed");
+    let signed = tx.into_signed(signature);
+    let (tx, sig, hash) = signed.into_parts();
+    let signed_tx = TransactionSigned::new_unhashed(Transaction::Eip7702(tx), sig);
+    // Persist the precomputed hash so downstream consumers see the same tx hash as the signer did.
+    let _ = signed_tx.hash();
+    debug_assert_eq!(*signed_tx.hash(), hash);
+    (signed_tx, sender.address())
+}
+
+// ---------------------------------------------------------------------------
+// OrderedBlock helpers
+// ---------------------------------------------------------------------------
+
+fn empty_ordered_block(
+    epoch: u64,
+    block_number: u64,
+    block_id: B256,
+    parent_block_id: B256,
+    timestamp_us: u64,
+) -> OrderedBlock {
+    OrderedBlock {
+        failed_proposer_indices: vec![],
+        epoch,
+        parent_id: parent_block_id,
+        id: block_id,
+        number: block_number,
+        timestamp_us,
+        coinbase: Address::ZERO,
+        prev_randao: B256::ZERO,
+        withdrawals: Default::default(),
+        transactions: vec![],
+        senders: vec![],
+        proposer_index: Some(0),
+        extra_data: vec![],
+        randomness: U256::ZERO,
+    }
+}
+
+fn ordered_block_with_txs(
+    epoch: u64,
+    block_number: u64,
+    block_id: B256,
+    parent_block_id: B256,
+    timestamp_us: u64,
+    transactions: Vec<TransactionSigned>,
+    senders: Vec<Address>,
+) -> OrderedBlock {
+    OrderedBlock {
+        failed_proposer_indices: vec![],
+        epoch,
+        parent_id: parent_block_id,
+        id: block_id,
+        number: block_number,
+        timestamp_us,
+        coinbase: Address::ZERO,
+        prev_randao: B256::ZERO,
+        withdrawals: Default::default(),
+        transactions,
+        senders,
+        proposer_index: Some(0),
+        extra_data: vec![],
+        randomness: U256::ZERO,
+    }
+}
+
+type TimestampFn = Box<dyn Fn(u64) -> u64 + Send + Sync>;
+
+struct MockConsensus<Storage, EthApi> {
+    pipeline_api: PipeExecLayerApi<Storage, EthApi>,
+    ts_for_block: TimestampFn,
+}
+
+impl<Storage, EthApi> MockConsensus<Storage, EthApi>
+where
+    Storage: GravityStorage,
+    EthApi: EthCall,
+    EthApi::NetworkTypes: RpcTypes<TransactionRequest = TransactionRequest>,
+{
+    fn new(pipeline_api: PipeExecLayerApi<Storage, EthApi>, ts_for_block: TimestampFn) -> Self {
+        Self { pipeline_api, ts_for_block }
+    }
+
+    /// Push a single ordered block and synchronously wait for execution.
+    async fn push_one(
+        &self,
+        epoch: &mut u64,
+        block: OrderedBlock,
+    ) -> reth_pipe_exec_layer_ext_v2::ExecutionResult {
+        let block_id = block.id;
+        let block_number = block.number;
+        self.pipeline_api.push_ordered_block(block).unwrap();
+        let result = self.pipeline_api.pull_executed_block_hash().await.unwrap();
+        assert_eq!(result.block_number, block_number);
+        assert_eq!(result.block_id, block_id);
+        self.pipeline_api.commit_executed_block_hash(block_id, Some(result.block_hash)).unwrap();
+
+        for event in &result.gravity_events {
+            if let GravityEvent::NewEpoch(new_epoch, _) = event {
+                assert_eq!(*new_epoch, *epoch + 1);
+                self.pipeline_api.wait_for_block_persistence(block_number).await.unwrap();
+                // Push a stale-epoch heartbeat so the pipeline's epoch state advances. Mirrors
+                // the gravity_eip2935_test.rs pattern.
+                self.pipeline_api
+                    .push_ordered_block(empty_ordered_block(
+                        *epoch,
+                        block_number + 1,
+                        mock_block_id(block_number + 1),
+                        block_id,
+                        (self.ts_for_block)(block_number + 1),
+                    ))
+                    .unwrap();
+                *epoch = *new_epoch;
+            }
+        }
+        result
+    }
+
+    /// Push a contiguous range of empty blocks `[start, end]`.
+    async fn push_empty_range(&self, epoch: &mut u64, start: u64, end: u64) {
+        for n in start..=end {
+            let block = empty_ordered_block(
+                *epoch,
+                n,
+                mock_block_id(n),
+                mock_block_id(n - 1),
+                (self.ts_for_block)(n),
+            );
+            self.push_one(epoch, block).await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    fn into_inner(self) -> PipeExecLayerApi<Storage, EthApi> {
+        self.pipeline_api
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State assertions
+// ---------------------------------------------------------------------------
+
+fn assert_designator<P: StateProviderFactory>(
+    provider: &P,
+    block_number: u64,
+    authority: Address,
+    target: Address,
+) {
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(block_number))
+        .expect("state provider for authority code check");
+    let code = state
+        .account_code(&authority)
+        .expect("read authority code")
+        .expect("authority must hold designator code after 7702 tx");
+    let bytes = code.original_bytes();
+    assert_eq!(bytes.len(), 23, "designator must be 23 bytes, got {}", bytes.len());
+    assert_eq!(&bytes[..3], &[0xef, 0x01, 0x00], "designator prefix mismatch");
+    assert_eq!(&bytes[3..], target.as_slice(), "designator target mismatch");
+    println!(
+        "[eip7702_test] ✅ authority {authority:?} has designator → {target:?} at block {block_number}"
+    );
+}
+
+fn assert_no_authority_code<P: StateProviderFactory>(
+    provider: &P,
+    block_number: u64,
+    authority: Address,
+) {
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(block_number))
+        .expect("state provider for absent-code check");
+    let code_len = state
+        .account_code(&authority)
+        .expect("read authority code")
+        .map(|c| c.original_bytes().len())
+        .unwrap_or(0);
+    assert_eq!(
+        code_len, 0,
+        "authority {authority:?} must hold no code at block {block_number}, got {code_len}B"
+    );
+    println!(
+        "[eip7702_test] ✅ authority {authority:?} carries no code at block {block_number} (discard/no-fix path)"
+    );
+}
+
+fn read_state_root<P: HeaderProvider>(provider: &P, block_number: u64) -> B256 {
+    use alloy_consensus::BlockHeader;
+    provider
+        .header_by_number(block_number)
+        .expect("header read must succeed")
+        .expect("header must be persisted")
+        .state_root()
+}
+
+// ---------------------------------------------------------------------------
+// Common boot path
+// ---------------------------------------------------------------------------
+
+async fn boot_pipeline(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<(
+    Arc<reth_chainspec::ChainSpec>,
+    impl StateProviderFactory + HeaderProvider + BlockHashReader + BlockNumReader + Clone,
+    PipeExecLayerApi<
+        BlockViewStorage<
+            BlockchainProvider<
+                reth_node_api::NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>,
+            >,
+        >,
+        impl EthCall<NetworkTypes: RpcTypes<TransactionRequest = TransactionRequest>>,
+    >,
+    u64,
+)> {
+    let handle = builder
+        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                builder.task_executor().clone(),
+                builder.config().datadir(),
+                reth_engine_primitives::TreeConfig::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await?;
+
+    let chain_spec = handle.node.chain_spec();
+    let eth_api = handle.node.rpc_registry.eth_api().clone();
+    let provider = handle.node.provider;
+
+    let db_provider = provider.database_provider_ro().unwrap();
+    let latest_block_number = db_provider.best_block_number().unwrap();
+    let latest_block_hash = db_provider.block_hash(latest_block_number).unwrap().unwrap();
+    let latest_block_header = db_provider.header_by_number(latest_block_number).unwrap().unwrap();
+    drop(db_provider);
+
+    assert_eq!(latest_block_number, 0, "tests expect a fresh datadir");
+
+    let storage = BlockViewStorage::new(provider.clone());
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let pipeline_api = new_pipe_exec_layer_api(
+        chain_spec.clone(),
+        storage,
+        latest_block_header,
+        latest_block_hash,
+        rx,
+        eth_api,
+    );
+    tx.send(ExecutionArgs { block_number_to_block_id: BTreeMap::new() }).unwrap();
+
+    // Give the service a moment to come online — mirrors gravity_eip2935_test.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    Ok((chain_spec, provider, pipeline_api, latest_block_number))
+}
+
+// ---------------------------------------------------------------------------
+// P-13 / P-14 — happy path: designator deployment via OrderedBlock injection.
+// ---------------------------------------------------------------------------
+
+async fn run_p13_happy_path(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<B256> {
+    let (_chain_spec, provider, pipeline_api, latest_block_number) = boot_pipeline(builder).await?;
+
+    let mut epoch: u64 = pipeline_api
+        .fetch_config_bytes(OnChainConfig::Epoch, BlockNumber::Latest)
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let consensus = MockConsensus::new(pipeline_api, Box::new(p3_ts_us));
+
+    // Drive the chain through the pre-Prague window, stopping at block 99.
+    consensus.push_empty_range(&mut epoch, latest_block_number + 1, P3_ACTIVATION_BLOCK - 1).await;
+
+    // Build the activation block 100 with a single TxEip7702.
+    let sender = funded_signer();
+    let authority = authority_signer(0x42);
+    let auth = sign_authorization(&authority, CHAIN_ID, TARGET_ADDR, /* nonce = */ 0);
+    let (tx, sender_addr) = build_signed_eip7702_tx(
+        &sender,
+        /* nonce = */ 0,
+        /* gas_limit = */ 200_000,
+        /* to = */ authority.address(),
+        Bytes::new(),
+        vec![auth],
+    );
+    assert_eq!(sender_addr, FUNDED_ADDR, "funded signer must derive to anvil[0] address");
+
+    let block = ordered_block_with_txs(
+        epoch,
+        P3_ACTIVATION_BLOCK,
+        mock_block_id(P3_ACTIVATION_BLOCK),
+        mock_block_id(P3_ACTIVATION_BLOCK - 1),
+        p3_ts_us(P3_ACTIVATION_BLOCK),
+        vec![tx],
+        vec![sender_addr],
+    );
+    let result = consensus.push_one(&mut epoch, block).await;
+    let pipeline_api = consensus.into_inner();
+    pipeline_api.wait_for_block_persistence(P3_ACTIVATION_BLOCK).await.unwrap();
+
+    println!(
+        "[eip7702_test] ✅ P-13 activation block executed: block_hash = {:?}",
+        result.block_hash
+    );
+
+    assert_designator(&provider, P3_ACTIVATION_BLOCK, authority.address(), TARGET_ADDR);
+    let state_root = read_state_root(&provider, P3_ACTIVATION_BLOCK);
+    println!("[eip7702_test] ✅ P-13 state root at block 100 = {state_root:?}");
+    Ok(state_root)
+}
+
+#[test]
+fn test_p13_happy_path_grevm() {
+    let state_root = run_pipe_e2e_test(
+        &gravity_prague_chainspec(Some(PRAGUE_TS_BLOCK_100)),
+        "data/gravity_eip7702_p13_grevm_test",
+        false,
+        run_p13_happy_path,
+    );
+    println!("[eip7702_test] grevm state root = {state_root:?}");
+}
+
+#[test]
+fn test_p13_happy_path_disable_grevm() {
+    let state_root = run_pipe_e2e_test(
+        &gravity_prague_chainspec(Some(PRAGUE_TS_BLOCK_100)),
+        "data/gravity_eip7702_p13_disable_grevm_test",
+        true,
+        run_p13_happy_path,
+    );
+    println!("[eip7702_test] disable_grevm state root = {state_root:?}");
+}
+
+// ---------------------------------------------------------------------------
+// P-12 — filter_invalid_txs end-to-end: low-gas 7702 tx is discarded.
+//
+// Before the gravity-audit#668 fix the executor would panic at lib.rs:1072
+// with `Eip7702{intrinsic gas too low}` because filter_invalid_txs forwarded
+// the tx unchanged. After the fix the filter computes the 7702-aware intrinsic
+// floor itself and discards the tx, so the block executes cleanly with zero
+// user receipts and the chain keeps advancing.
+// ---------------------------------------------------------------------------
+
+async fn run_p12_filter_discard(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<B256> {
+    let (_chain_spec, provider, pipeline_api, latest_block_number) = boot_pipeline(builder).await?;
+
+    let mut epoch: u64 = pipeline_api
+        .fetch_config_bytes(OnChainConfig::Epoch, BlockNumber::Latest)
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let consensus = MockConsensus::new(pipeline_api, Box::new(p3_ts_us));
+    consensus.push_empty_range(&mut epoch, latest_block_number + 1, P3_ACTIVATION_BLOCK - 1).await;
+
+    // Build the activation block 100 with a TxEip7702 whose gas_limit (21_001)
+    // is below the Prague intrinsic floor (21_000 base + 25_000/auth).
+    let sender = funded_signer();
+    let authority = authority_signer(0x12);
+    let auth = sign_authorization(&authority, CHAIN_ID, TARGET_ADDR, 0);
+    let (tx, sender_addr) =
+        build_signed_eip7702_tx(&sender, 0, 21_001, authority.address(), Bytes::new(), vec![auth]);
+
+    let block = ordered_block_with_txs(
+        epoch,
+        P3_ACTIVATION_BLOCK,
+        mock_block_id(P3_ACTIVATION_BLOCK),
+        mock_block_id(P3_ACTIVATION_BLOCK - 1),
+        p3_ts_us(P3_ACTIVATION_BLOCK),
+        vec![tx],
+        vec![sender_addr],
+    );
+    let result = consensus.push_one(&mut epoch, block).await;
+    let pipeline_api = consensus.into_inner();
+    pipeline_api.wait_for_block_persistence(P3_ACTIVATION_BLOCK).await.unwrap();
+    println!("[eip7702_test] ✅ P-12 block executed (no panic): {:?}", result.block_hash);
+
+    // Authority must NOT have designator code — the tx never made it into the
+    // executor, so `apply_eip7702_auth_list` could not run on this account.
+    assert_no_authority_code(&provider, P3_ACTIVATION_BLOCK, authority.address());
+
+    // Push one more empty block to prove the chain keeps making progress.
+    let mut epoch_after = epoch;
+    let consensus = MockConsensus::new(pipeline_api, Box::new(p3_ts_us));
+    consensus
+        .push_empty_range(&mut epoch_after, P3_ACTIVATION_BLOCK + 1, P3_ACTIVATION_BLOCK + 1)
+        .await;
+    println!("[eip7702_test] ✅ P-12 chain progressed past activation block.");
+
+    let state_root = read_state_root(&provider, P3_ACTIVATION_BLOCK);
+    Ok(state_root)
+}
+
+#[test]
+fn test_p12_low_gas_eip7702_discarded_grevm() {
+    let _ = run_pipe_e2e_test(
+        &gravity_prague_chainspec(Some(PRAGUE_TS_BLOCK_100)),
+        "data/gravity_eip7702_p12_grevm_test",
+        false,
+        run_p12_filter_discard,
+    );
+}
+
+#[test]
+fn test_p12_low_gas_eip7702_discarded_disable_grevm() {
+    let _ = run_pipe_e2e_test(
+        &gravity_prague_chainspec(Some(PRAGUE_TS_BLOCK_100)),
+        "data/gravity_eip7702_p12_disable_grevm_test",
+        true,
+        run_p12_filter_discard,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — single entry point that boots the node CLI.
+// ---------------------------------------------------------------------------
+
+fn run_pipe_e2e_test<F, Fut, R>(
+    chain_spec: &str,
+    datadir: &'static str,
+    disable_grevm: bool,
+    run_fn: F,
+) -> R
+where
+    F: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = eyre::Result<R>> + Send + 'static,
+    R: Send + Default + 'static,
+{
+    init_panic_hook_and_tracer();
+
+    let runner = CliRunner::try_default_runtime().unwrap();
+    let mut args: Vec<&str> =
+        vec!["reth", "--chain", chain_spec, "--with-unused-ports", "--dev", "--datadir", datadir];
+    if disable_grevm {
+        args.push("--gravity.disable-grevm");
+    }
+    let command: NodeCommand<EthereumChainSpecParser> =
+        NodeCommand::try_parse_args_from(args).unwrap();
+
+    let result = Arc::new(std::sync::Mutex::new(None::<R>));
+    let result_clone = result.clone();
+    runner
+        .run_command_until_exit(|ctx| {
+            command.execute(
+                ctx,
+                FnLauncher::new::<EthereumChainSpecParser, _>(|builder, _| async move {
+                    let r = run_fn(builder).await?;
+                    *result_clone.lock().unwrap() = Some(r);
+                    Ok(())
+                }),
+            )
+        })
+        .unwrap();
+
+    std::thread::sleep(Duration::from_secs(2));
+    result.lock().unwrap().take().unwrap_or_default()
+}
+
+fn init_panic_hook_and_tracer() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        let backtrace = std::backtrace::Backtrace::capture();
+        eprintln!("Panic occurred: {panic_info}\nBacktrace:\n{backtrace}");
+        std::process::exit(1);
+    }));
+
+    let _ = RethTracer::new()
+        .with_stdout(LayerInfo::new(
+            LogFormat::Terminal,
+            LevelFilter::INFO.to_string(),
+            String::new(),
+            Some("always".to_string()),
+        ))
+        .init();
+}
+
+#[allow(dead_code)]
+fn _silence_unused(_: fn() -> u64) {
+    let _ = now_us;
+}

--- a/crates/transaction-pool/src/validate/eth.rs
+++ b/crates/transaction-pool/src/validate/eth.rs
@@ -1679,4 +1679,121 @@ mod tests {
         let outcome = validator.validate_one(TransactionOrigin::External, transaction);
         assert!(outcome.is_valid()); // Should be valid because balance check is disabled
     }
+
+    /// U-4 (acceptance design §3.2): `ensure_intrinsic_gas` for a TxEip7702 with
+    /// `authorization_list.len() == 2` and `gas_limit = 21000 + 25000 * 2 - 1 = 70_999`
+    /// (one wei below the Prague floor) must return `IntrinsicGasTooLow` when the
+    /// pool's ForkTracker has Prague active.
+    #[test]
+    fn ensure_intrinsic_gas_eip7702_below_floor_under_prague() {
+        use alloy_consensus::TxEip7702;
+        use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+        use alloy_primitives::{Signature, U256};
+        use reth_ethereum_primitives::TransactionSigned;
+        use reth_primitives_traits::Recovered;
+
+        let authorization_list = (0..2)
+            .map(|_| {
+                SignedAuthorization::new_unchecked(
+                    Authorization { chain_id: U256::ZERO, address: Default::default(), nonce: 0 },
+                    0,
+                    U256::ZERO,
+                    U256::ZERO,
+                )
+            })
+            .collect();
+
+        let tx = TxEip7702 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 70_999,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 0,
+            to: Default::default(),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            authorization_list,
+            input: Default::default(),
+        };
+
+        let signed_inner = TransactionSigned::new_unhashed(
+            reth_ethereum_primitives::Transaction::Eip7702(tx),
+            Signature::test_signature(),
+        );
+        let recovered = Recovered::new_unchecked(signed_inner, Default::default());
+        let pooled = EthPooledTransaction::new(recovered, 200);
+
+        let fork_tracker = ForkTracker {
+            shanghai: true.into(),
+            cancun: true.into(),
+            prague: true.into(),
+            osaka: false.into(),
+            max_blob_count: 0.into(),
+        };
+
+        let res = ensure_intrinsic_gas(&pooled, &fork_tracker);
+        assert!(matches!(res, Err(InvalidPoolTransactionError::IntrinsicGasTooLow)), "got {res:?}");
+    }
+
+    /// U-5 (acceptance design §3.2): when Prague is *not* activated on the pool's
+    /// ForkTracker, the same TxEip7702 is rejected by `validate_one` with
+    /// `TxTypeNotSupported` (fork gating short-circuit) and the intrinsic-gas
+    /// codepath is therefore never reached.
+    #[tokio::test]
+    async fn validate_one_eip7702_rejected_before_prague_activation() {
+        use alloy_consensus::TxEip7702;
+        use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+        use alloy_primitives::{Signature, U256};
+        use reth_ethereum_primitives::TransactionSigned;
+        use reth_primitives_traits::Recovered;
+
+        let authorization_list = (0..2)
+            .map(|_| {
+                SignedAuthorization::new_unchecked(
+                    Authorization { chain_id: U256::ZERO, address: Default::default(), nonce: 0 },
+                    0,
+                    U256::ZERO,
+                    U256::ZERO,
+                )
+            })
+            .collect();
+
+        let tx = TxEip7702 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 70_999,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 0,
+            to: Default::default(),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            authorization_list,
+            input: Default::default(),
+        };
+
+        let signed_inner = TransactionSigned::new_unhashed(
+            reth_ethereum_primitives::Transaction::Eip7702(tx),
+            Signature::test_signature(),
+        );
+        let recovered = Recovered::new_unchecked(signed_inner, Default::default());
+        let pooled = EthPooledTransaction::new(recovered, 200);
+
+        let provider = MockEthProvider::default();
+        let blob_store = InMemoryBlobStore::default();
+        let validator = EthTransactionValidatorBuilder::new(provider).no_prague().build(blob_store);
+
+        let outcome = validator.validate_one(TransactionOrigin::External, pooled);
+        match outcome {
+            TransactionValidationOutcome::Invalid(_, err) => assert!(
+                matches!(
+                    err,
+                    InvalidPoolTransactionError::Consensus(
+                        InvalidTransactionError::TxTypeNotSupported
+                    )
+                ),
+                "expected TxTypeNotSupported, got {err:?}"
+            ),
+            other => panic!("expected Invalid outcome, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fix the gravity-audit#668 finding ("filter_invalid_txs not include EIP-7702 intrinsic gas") and add the focused subset of the EIP-7702 acceptance tests that pin the fix at every layer.

- **Pre-execution filter (`crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs`)** — `filter_invalid_txs` now mirrors the reth pool's `ensure_intrinsic_gas`, including the `PER_EMPTY_ACCOUNT_COST * len(authorization_list)` term. A 7702 tx whose `gas_limit` falls below the Prague floor is discarded at the filter stage instead of reaching grevm and panicking at `lib.rs:1072`. The whole filter codepath also moves out of `lib.rs` (1829 → 1448 lines).
- **Unit tests** — three #668 regression tests in `tx_filter::tests` (two-auth sufficient, three-auth too-low, legacy-under-Prague not regressed) plus two pool-side tests in `crates/transaction-pool/src/validate/eth.rs` (`ensure_intrinsic_gas` floor enforcement for TxEip7702 + Prague=off fork-gate short-circuit through `validate_one`).
- **E2E tests** (`crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs`) — drives MockConsensus + PipeExecLayerApi through an in-memory chainspec built from `gravity_hardfork.json` with `pragueTime` patched to align Prague activation with block 100 (same scheme as the EIP-2935 tests merged in #341):
  - **P-12** low-gas TxEip7702 injected via `OrderedBlock` is discarded by the filter; block executes cleanly, chain keeps advancing. Pins the #668 fix at the integration boundary.
  - **P-13** sufficient-gas TxEip7702 with one valid `SignedAuthorization` lands on-chain; authority's account code becomes the 23-byte `0xef0100 || target` designator.
  - **P-14** P-13 is also exercised under `--gravity.disable-grevm` (`WrapExecutor<BasicBlockExecutor>` instead of `GrevmExecutor`); designator deployment is observably identical across executor variants. (The spec's stronger "byte-identical state roots" sub-claim is documented in the test header as forensic-only — this codebase already delegates cross-executor equivalence to unit-level diff tests in `crates/ethereum/evm/src/parallel_execute.rs:446-449`.)

Cases out of scope and documented in the test header as follow-ups: P-1/P-3 pool fork-gate via RPC (unit-covered here), P-5..P-10 multi-auth and CALL/DELEGATECALL/STATICCALL → designator (upstream revm semantics), P-15..P-18 grevm BlockSTM concurrency, N-1 manual smoke check.

Dev-deps added to the execute crate: `alloy-signer` and `alloy-signer-local` for signing TxEip7702 + SignedAuthorization in the e2e fixtures.

Related: gravity-audit#668.

## Test plan

- [x] `cargo nextest run -p reth-pipe-exec-layer-ext-v2 --lib tx_filter` — 12 tests pass (3 new + 9 existing).
- [x] `cargo nextest run -p reth-pipe-exec-layer-ext-v2 --test gravity_eip7702_test --test-threads=1` — 4 tests pass (P-12/P-13 × grevm/disable_grevm).
- [x] `cargo nextest run -p reth-transaction-pool --lib validate::eth::tests::ensure_intrinsic_gas_eip7702 validate::eth::tests::validate_one_eip7702` — 2 tests pass.
- [x] `cargo +nightly fmt --all --check` clean.
- [ ] Reviewer manual smoke: revert the `calculate_initial_tx_gas` check in `tx_filter::is_tx_valid` locally and rerun P-12 — should panic at `lib.rs:1072` (N-1 from the acceptance design, kept manual per spec).
