### PR TITLE
fix(deps): bump grevm to 3c09e7c for EIP-7702 self-auth nonce fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3379,7 +3379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?tag=v2.2.4#26b586cff564a0815c422bb2a2ac0b5a28e5dce0"
+source = "git+https://github.com/Galxe/grevm?rev=3c09e7ce5cfc904d566c89a4a60f160839890792#3c09e7ce5cfc904d566c89a4a60f160839890792"
 dependencies = [
  "ahash",
  "alloy-evm 0.21.3 (git+https://github.com/Galxe/alloy-evm?branch=v0.21.3-gravity)",
@@ -4389,6 +4389,7 @@ dependencies = [
  "revm-inspector 10.0.1 (git+https://github.com/Galxe/revm?branch=v29.0.1-gravity)",
  "revm-primitives 20.2.1 (git+https://github.com/Galxe/revm?branch=v29.0.1-gravity)",
  "revm-state 7.0.5 (git+https://github.com/Galxe/revm?branch=v29.0.1-gravity)",
+ "tracing",
 ]
 
 [[package]]
@@ -4775,7 +4776,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5219,7 +5220,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7177,7 +7178,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11878,7 +11879,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12774,7 +12775,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -476,7 +476,7 @@ reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
 reth-revm = { path = "crates/revm", default-features = false }
-grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", tag = "v2.2.4" }
+grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", rev = "3c09e7ce5cfc904d566c89a4a60f160839890792" }
 reth-rpc = { path = "crates/rpc/rpc" }
 reth-rpc-api = { path = "crates/rpc/rpc-api" }
 reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }


### PR DESCRIPTION
## Summary
- Pin `grevm` by `rev` to [`3c09e7c`](https://github.com/Galxe/grevm/commit/3c09e7ce5cfc904d566c89a4a60f160839890792) (the merge of Galxe/grevm#102), which relaxes the `StateAsyncCommit` caller-nonce assertion so EIP-7702 self-sponsored self-delegation no longer panics.
- The current pin (`tag = "v2.2.4"` → `26b586c`) crashes deterministically inside `grevm::async_commit::commit` on type-4 SetCode txs where `tx.from` is also listed as an authority. That is the bench pattern (`simple-bench` with `transfer_type = "eip7702"`) that halted Gravity testnet at block 1400868 on 2026-06-09; the same input shape is reachable on mainnet once EIP-7702 is open.

## What this rev brings in (full delta v2.2.4..3c09e7c)
- Galxe/grevm#99 — Security audit, fix security findings in grevm parallel EVM
- Galxe/grevm#101 — security audit findings round 3
- Galxe/grevm#102 — EIP-7702 self-auth nonce fix (the new one)

`v2.2.5` was tagged before #102 merged and no later tag exists yet, so a rev pin is the only way to pull the fix without waiting for a new release tag. Happy to switch to a tag once a `v2.2.6` is cut.

## Files changed
- `Cargo.toml` — single-line swap of `tag = \"v2.2.4\"` → `rev = \"3c09e7c...\"`
- `Cargo.lock` — regenerated via `cargo update -p grevm`

## Test plan
- [x] `cargo update -p grevm` — clean lock update
- [x] `cargo check -p reth-evm-ethereum` — direct grevm consumer compiles
- [x] `cargo check -p reth-pipe-exec-layer-ext-v2` — second grevm consumer compiles
- [ ] CI: full workspace lint / clippy / test
- [ ] Follow-up: replay testnet block 1400868 end-to-end to confirm the chain-halt no longer reproduces

Refs Galxe/gravity-audit#677
Refs Galxe/grevm#102