### PR TITLE
fix(filter): close gravity-audit#710 + add pipe panic smoke test

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -1,17 +1,29 @@
-//! Pre-execution transaction filtering.
+//! Pre-execution transaction filtering — Gravity's canonical tx-admission gate.
 //!
-//! Mirrors the cheap pool-side guards that `OrderedBlock` txs skipped (nonce, balance,
-//! cumulative gas, EIP-7702 intrinsic gas floor, EIP-7702 pre-Prague reject, EIP-4844 reject,
-//! EIP-3860 init-code size) so non-pool-injected txs cannot reach grevm with a state that
-//! would make the executor panic.
+//! In Gravity's consensus-orders-before-execution model the executor cannot recover from
+//! a per-tx `revm::InvalidTransaction` error (see `lib.rs:1060` panic site), and "drop
+//! the tx and continue" is not implementable without protocol-level coordination
+//! (would change the state transition function). The only viable defense is to make
+//! the executor's `EVMError` path unreachable by gating every `InvalidTransaction`
+//! variant here, before grevm sees the tx.
+//!
+//! This file is therefore intentionally a **superset** of revm's tx-level validation
+//! (`revm-handler/src/validation.rs::validate_tx_env` +
+//! `pre_execution.rs::validate_account_nonce_and_code` +
+//! `validate_against_state_and_deduct_caller`). Each guard below maps to a specific
+//! `InvalidTransaction::*` variant and cites the audit issue that motivated it. When
+//! upgrading revm, audit the `InvalidTransaction` enum for new variants and either add
+//! a matching guard or document why it is unreachable on Gravity.
+//!
+//! Closed audit issues: gravity-audit#668 / #696 / #710.
 
-use alloy_consensus::Transaction;
+use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, U256,
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use reth_chainspec::ChainSpec;
+use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::ParallelDatabase;
 use reth_evm_ethereum::revm_spec_by_timestamp_and_block_number;
@@ -30,6 +42,7 @@ use tracing::info;
 /// `revm_spec_by_timestamp_and_block_number` helper is used so the same
 /// (correct) mapping that the executor sees is the one the filter is gating
 /// against — no risk of the two drifting apart on a future hardfork.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     db: DB,
     txs: &[TransactionSigned],
@@ -69,6 +82,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         sender_idx.entry(sender).or_default().push(i);
     }
 
+    let cfg_chain_id = chain_spec.chain_id();
     let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &mut AccountInfo| {
         if account.nonce != tx.nonce() {
             info!(target: "filter_invalid_txs",
@@ -80,22 +94,81 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             );
             return false;
         }
-        // Pre-Prague safety. revm rejects any TxEip7702 with `Eip7702NotSupported`
-        // when `spec_id < PRAGUE` (revm-handler validation.rs:181-182), but
-        // `calculate_initial_tx_gas` below only adds the auth-list cost when
-        // `spec_id >= PRAGUE` (revm-interpreter gas/calc.rs:417). Without this
-        // guard a TxEip7702 with `gas_limit == 21000` in a pre-Prague OrderedBlock
-        // would pass the intrinsic check, reach the executor, and panic
-        // `lib.rs:1067-1073`. Closes the boundary called out in the acceptance
-        // design as P-2.
-        if tx.is_eip7702() && !spec_id.is_enabled_in(SpecId::PRAGUE) {
+        // Chain-id gate. revm rejects with `InvalidChainId` when a typed tx carries the
+        // wrong chain_id and with `MissingChainId` when a typed tx carries `None`. Legacy
+        // txs may legitimately have `None` (pre-EIP-155 replay-vulnerable encoding), so
+        // those are accepted here only if `tx.is_legacy()`. Closes audit#710 gap 5.
+        match tx.chain_id() {
+            Some(id) if id != cfg_chain_id => {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    sender=?sender,
+                    tx_chain_id=?id,
+                    cfg_chain_id=?cfg_chain_id,
+                    "chain id mismatch"
+                );
+                return false;
+            }
+            None if !tx.is_legacy() => {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    sender=?sender,
+                    "typed tx missing chain_id"
+                );
+                return false;
+            }
+            _ => {}
+        }
+        // Fee gates. revm rejects with `GasPriceLessThanBasefee` when the tx's max fee
+        // cap is below the prevailing base fee (this is the unified `max_fee_per_gas` —
+        // legacy `gas_price` collapses into it), and with `PriorityFeeGreaterThanMaxFee`
+        // when an EIP-1559+ tx sets `max_priority > max_fee`. Closes audit#710 gaps 1, 2.
+        if tx.max_fee_per_gas() < base_fee_per_gas as u128 {
             info!(target: "filter_invalid_txs",
                 tx_hash=?tx.hash(),
                 sender=?sender,
-                spec_id=?spec_id,
-                "EIP-7702 tx in pre-Prague block"
+                max_fee_per_gas=?tx.max_fee_per_gas(),
+                base_fee_per_gas=?base_fee_per_gas,
+                "max fee below base fee"
             );
             return false;
+        }
+        if let Some(prio) = tx.max_priority_fee_per_gas() &&
+            prio > tx.max_fee_per_gas()
+        {
+            info!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                max_priority_fee_per_gas=?prio,
+                max_fee_per_gas=?tx.max_fee_per_gas(),
+                "priority fee exceeds max fee"
+            );
+            return false;
+        }
+        // EIP-7702 gates. Pre-Prague: reject the whole tx type (revm fires
+        // `Eip7702NotSupported`; `calculate_initial_tx_gas` below also ignores auth-list
+        // cost pre-Prague, so a 21k-gas TxEip7702 would slip the intrinsic check).
+        // Post-Prague: reject empty authorization_list (revm fires
+        // `EmptyAuthorizationList`). Closes audit#696 P-2 and audit#710 gap 3.
+        if tx.is_eip7702() {
+            if !spec_id.is_enabled_in(SpecId::PRAGUE) {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    sender=?sender,
+                    spec_id=?spec_id,
+                    "EIP-7702 tx in pre-Prague block"
+                );
+                return false;
+            }
+            let auth_count = tx.authorization_list().map(|l| l.len()).unwrap_or(0);
+            if auth_count == 0 {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    sender=?sender,
+                    "EIP-7702 tx with empty authorization_list"
+                );
+                return false;
+            }
         }
         // Gravity does not support EIP-4844. revm tx-level validation can reject a type-3
         // tx with `EmptyBlobs` / `BlobVersionNotSupported` / `TooManyBlobs` /
@@ -148,20 +221,30 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             );
             return false;
         }
-        let gas_spent = U256::from(tx.effective_gas_price(Some(base_fee_per_gas)))
-            .saturating_mul(U256::from(tx.gas_limit()));
-        let total_spent = gas_spent.saturating_add(tx.value());
-        if account.balance < total_spent {
+        // Balance gate. revm's `validate_against_state_and_deduct_caller` pre-deducts
+        // `max_fee_per_gas * gas_limit + value` (worst case — the unused portion is
+        // refunded post-execution). The filter must check against the same worst-case
+        // bound, otherwise a tx where `effective < max_fee` and `balance < max * limit`
+        // would pass here and panic in revm with `LackOfFundForMaxFee`. Closes audit#710
+        // gap 4. The per-sender simulated balance is then reduced by the *effective*
+        // cost so subsequent txs from the same sender see what revm sees post-refund.
+        let max_charge =
+            U256::from(tx.max_fee_per_gas()).saturating_mul(U256::from(tx.gas_limit()));
+        let max_total = max_charge.saturating_add(tx.value());
+        if account.balance < max_total {
             info!(target: "filter_invalid_txs",
                 tx_hash=?tx.hash(),
                 sender=?sender,
                 balance=?account.balance,
-                gas_spent=?gas_spent,
+                max_charge=?max_charge,
                 transfer_value=?tx.value(),
-                "insufficient balance"
+                "insufficient balance for max fee"
             );
             return false;
         }
+        let gas_spent = U256::from(tx.effective_gas_price(Some(base_fee_per_gas)))
+            .saturating_mul(U256::from(tx.gas_limit()));
+        let total_spent = gas_spent.saturating_add(tx.value());
         account.balance -= total_spent;
         account.nonce += 1;
         true
@@ -170,19 +253,34 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     let mut invalid_tx_idxs = sender_idx
         .into_par_iter()
         .flat_map(|(sender, idxs)| {
-            if let Some(mut account) = db.basic_ref(*sender).unwrap() {
-                idxs.into_iter()
-                    .filter(|&idx| !is_tx_valid(&txs[idx], sender, &mut account))
-                    .collect()
-            } else {
+            let Some(mut account) = db.basic_ref(*sender).unwrap() else {
                 // Sender does not exist in the state trie, balance is 0
                 info!(target: "filter_invalid_txs",
                     tx_hash=?txs[idxs[0]].hash(),
                     sender=?sender,
                     "insufficient balance"
                 );
-                idxs
+                return idxs;
+            };
+            // EIP-3607 gate: a sender with non-empty code cannot originate transactions,
+            // unless the code is a valid EIP-7702 delegation designator (Pectra relaxed
+            // 3607 to permit delegated EOAs). revm fires `RejectCallerWithCode`
+            // otherwise. Per-sender, not per-tx — if the sender has unauthorised code,
+            // all its txs in this batch are invalid. Closes audit#710 gap 6.
+            if account.code_hash != KECCAK_EMPTY {
+                let bytecode =
+                    account.code.clone().or_else(|| db.code_by_hash_ref(account.code_hash).ok());
+                let is_7702_delegation = bytecode.as_ref().map(|b| b.is_eip7702()).unwrap_or(false);
+                if !is_7702_delegation {
+                    info!(target: "filter_invalid_txs",
+                        sender=?sender,
+                        code_hash=?account.code_hash,
+                        "EIP-3607: sender has non-delegation code"
+                    );
+                    return idxs;
+                }
             }
+            idxs.into_iter().filter(|&idx| !is_tx_valid(&txs[idx], sender, &mut account)).collect()
         })
         .collect::<HashSet<_>>();
     invalid_tx_idxs.extend(gas_limit_exceeded_tx_idx..txs.len());
@@ -203,6 +301,11 @@ mod tests {
         DatabaseRef,
     };
     use std::{collections::HashMap as StdHashMap, sync::Arc};
+
+    /// Mainnet chain id — pinned here because every test chainspec in this module is
+    /// built from `MAINNET`, and the filter's chain-id gate rejects any typed tx whose
+    /// `chain_id` doesn't match the chainspec.
+    const MAINNET_CHAIN_ID: u64 = 1;
 
     /// Chainspec with Prague active from genesis — the canonical test fixture for
     /// every case that wants the filter to apply 7702 intrinsic-gas rules.
@@ -293,7 +396,9 @@ mod tests {
         )
     }
 
-    /// EIP-7702 type-0x04 tx with N authorizations; `gas_limit` caller controls.
+    /// EIP-7702 type-0x04 tx with N authorizations; `gas_limit` caller controls. The
+    /// `chain_id` is pinned to `MAINNET_CHAIN_ID` to match the test chainspecs — the
+    /// filter rejects mismatches with `InvalidChainId`.
     fn create_test_7702_transaction(
         nonce: u64,
         gas_limit: u64,
@@ -311,6 +416,7 @@ mod tests {
             .collect();
         TransactionSigned::new_unhashed(
             Transaction::Eip7702(TxEip7702 {
+                chain_id: MAINNET_CHAIN_ID,
                 nonce,
                 gas_limit,
                 max_fee_per_gas: 1,
@@ -378,7 +484,7 @@ mod tests {
         let account = AccountInfo {
             balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
             nonce: 5,                                          // 账户 nonce 是 5
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender, account);
@@ -413,7 +519,7 @@ mod tests {
         let account = AccountInfo {
             balance: U256::from(1_000_000_000u64), // 1 Gwei
             nonce: 0,
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender, account);
@@ -452,7 +558,7 @@ mod tests {
         let account = AccountInfo {
             balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
             nonce: 0,
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender, account);
@@ -488,7 +594,7 @@ mod tests {
         let account = AccountInfo {
             balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
             nonce: 0,
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender, account);
@@ -524,7 +630,7 @@ mod tests {
         let account1 = AccountInfo {
             balance: U256::from(1_000_000_000u64), // 1 Gwei
             nonce: 0,
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender1, account1);
@@ -532,7 +638,7 @@ mod tests {
         let account2 = AccountInfo {
             balance: U256::from(1_000_000_000u64), // 1 Gwei
             nonce: 5,
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender2, account2);
@@ -540,7 +646,7 @@ mod tests {
         let account3 = AccountInfo {
             balance: U256::from(1_000_000_000u64), // 1 Gwei
             nonce: 0,
-            code_hash: B256::default(),
+            code_hash: KECCAK_EMPTY,
             code: None,
         };
         db.insert_account(sender3, account3);
@@ -555,7 +661,10 @@ mod tests {
         let tx7 = create_test_transaction(0, 21000, 25); // sender3: truncated
         let txs = vec![tx1, tx2, tx3, tx4, tx5, tx6, tx7];
         let senders = vec![sender1, sender1, sender1, sender2, sender2, sender2, sender3];
-        let base_fee_per_gas = 20_000_000_000u64;
+        // base_fee is 0 here because this test deliberately uses sub-gwei gas_prices to
+        // probe nonce / balance / cumulative-gas branches without entangling them with
+        // the fee-floor gate (audit#710 gap 1). Other tests cover the fee gate directly.
+        let base_fee_per_gas = 0u64;
         let gas_limit = 30_000_000u64;
 
         let invalid_idxs = filter_invalid_txs(
@@ -588,7 +697,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH — balance is fine
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -625,7 +734,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -661,7 +770,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -689,7 +798,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -717,7 +826,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -747,7 +856,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -769,6 +878,7 @@ mod tests {
     fn create_test_4844_transaction(nonce: u64, gas_limit: u64) -> TransactionSigned {
         TransactionSigned::new_unhashed(
             Transaction::Eip4844(TxEip4844 {
+                chain_id: MAINNET_CHAIN_ID,
                 nonce,
                 gas_limit,
                 max_fee_per_gas: 1,
@@ -789,6 +899,7 @@ mod tests {
         use alloy_consensus::TxEip1559;
         TransactionSigned::new_unhashed(
             Transaction::Eip1559(TxEip1559 {
+                chain_id: MAINNET_CHAIN_ID,
                 nonce,
                 gas_limit,
                 max_fee_per_gas: 1,
@@ -813,7 +924,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -842,7 +953,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -875,7 +986,7 @@ mod tests {
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::default(),
+                code_hash: KECCAK_EMPTY,
                 code: None,
             },
         );
@@ -892,6 +1003,401 @@ mod tests {
         assert!(
             invalid_idxs.is_empty(),
             "Create tx at exactly MAX_INITCODE_SIZE must pass the size gate: {invalid_idxs:?}"
+        );
+    }
+
+    // ===== audit#710 helpers =====================================================
+
+    /// 1559 envelope with caller-controlled fee fields, pinned to MAINNET chain_id.
+    fn create_test_1559_transaction(
+        nonce: u64,
+        gas_limit: u64,
+        max_fee_per_gas: u128,
+        max_priority_fee_per_gas: u128,
+    ) -> TransactionSigned {
+        use alloy_consensus::TxEip1559;
+        TransactionSigned::new_unhashed(
+            Transaction::Eip1559(TxEip1559 {
+                chain_id: MAINNET_CHAIN_ID,
+                nonce,
+                gas_limit,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    /// 1559 envelope with caller-controlled `chain_id` for chain-id gate tests.
+    fn create_test_1559_transaction_with_chain_id(
+        nonce: u64,
+        gas_limit: u64,
+        chain_id: u64,
+    ) -> TransactionSigned {
+        use alloy_consensus::TxEip1559;
+        TransactionSigned::new_unhashed(
+            Transaction::Eip1559(TxEip1559 {
+                chain_id,
+                nonce,
+                gas_limit,
+                max_fee_per_gas: 1,
+                max_priority_fee_per_gas: 0,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    /// Legacy tx with caller-controlled `chain_id` (None for pre-EIP-155).
+    fn create_test_legacy_with_chain_id(
+        nonce: u64,
+        gas_limit: u64,
+        gas_price: u128,
+        chain_id: Option<u64>,
+    ) -> TransactionSigned {
+        TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                chain_id,
+                nonce,
+                gas_price,
+                gas_limit,
+                to: TxKind::Call(Address::ZERO),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    // ===== audit#710 gap 1: max_fee < base_fee ==================================
+
+    /// Legacy tx whose `gas_price` is below the prevailing base fee must be discarded —
+    /// revm fires `GasPriceLessThanBasefee`.
+    #[test]
+    fn test_filter_invalid_txs_legacy_gas_price_less_than_basefee() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        // gas_price = 10 gwei, base_fee = 20 gwei.
+        let tx = create_test_transaction(0, 21_000, 10_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000,
+            30_000_000,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
+        assert_eq!(invalid_idxs.len(), 1, "legacy tx with gas_price < base_fee must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// 1559 tx whose `max_fee_per_gas` is below the prevailing base fee must be
+    /// discarded (same revm error class as the legacy case, unified envelope).
+    #[test]
+    fn test_filter_invalid_txs_1559_max_fee_less_than_basefee() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        // max_fee = 10 gwei, base_fee = 20 gwei.
+        let tx = create_test_1559_transaction(0, 21_000, 10_000_000_000, 0);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000,
+            30_000_000,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
+        assert_eq!(invalid_idxs.len(), 1, "1559 tx with max_fee < base_fee must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    // ===== audit#710 gap 2: priority > max =====================================
+
+    /// 1559+ tx with `max_priority_fee > max_fee` is rejected by revm with
+    /// `PriorityFeeGreaterThanMaxFee`.
+    #[test]
+    fn test_filter_invalid_txs_priority_fee_greater_than_max_fee() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        // max_fee = 10 gwei, priority = 20 gwei → inverted, must reject.
+        let tx = create_test_1559_transaction(0, 21_000, 10_000_000_000, 20_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(invalid_idxs.len(), 1, "1559 tx with prio > max must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    // ===== audit#710 gap 3: 7702 empty authorization_list ======================
+
+    /// Post-Prague TxEip7702 with `authorization_list = []` is rejected by revm with
+    /// `EmptyAuthorizationList`.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_empty_authorization_list() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        // 0 authorizations under Prague — well above intrinsic floor (21k) so the
+        // intrinsic-gas gate would not fire first.
+        let tx = create_test_7702_transaction(0, 100_000, 0);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(
+            invalid_idxs.len(),
+            1,
+            "7702 tx with empty authorization_list must be discarded"
+        );
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    // ===== audit#710 gap 4: balance must use max_fee, not effective ============
+
+    /// In the window where `effective_gas_price < max_fee_per_gas` and
+    /// `effective * gas <= balance < max_fee * gas`, the old filter passed the tx
+    /// (using effective for the check); revm would then panic the executor with
+    /// `LackOfFundForMaxFee`. The new filter must reject.
+    #[test]
+    fn test_filter_invalid_txs_balance_uses_max_fee_not_effective() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+
+        // base_fee = 10 gwei, prio = 5 gwei, max_fee = 30 gwei, gas_limit = 21_000.
+        //   effective = min(max_fee, base_fee + prio) = min(30G, 15G) = 15G
+        //   effective * gas = 15G * 21k = 315e12
+        //   max_fee   * gas = 30G * 21k = 630e12
+        // Set balance to 400e12 — covers effective but not max. Old filter would
+        // have passed; new filter must reject (LackOfFundForMaxFee class).
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(400_000_000_000_000u128),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        let tx = create_test_1559_transaction(0, 21_000, 30_000_000_000, 5_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            10_000_000_000,
+            30_000_000,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
+        assert_eq!(
+            invalid_idxs.len(),
+            1,
+            "balance covers effective but not max — must be discarded by max-fee gate"
+        );
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    // ===== audit#710 gap 5: chain_id =========================================
+
+    /// 1559 tx with `chain_id != cfg.chain_id` is rejected (revm `InvalidChainId`).
+    #[test]
+    fn test_filter_invalid_txs_invalid_chain_id_typed() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        // Chainspec is MAINNET (1), tx claims chain_id = 2.
+        let tx = create_test_1559_transaction_with_chain_id(0, 21_000, 2);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(invalid_idxs.len(), 1, "1559 tx with wrong chain_id must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// Legacy tx with explicit `chain_id` that doesn't match config is rejected.
+    #[test]
+    fn test_filter_invalid_txs_invalid_chain_id_legacy() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        let tx = create_test_legacy_with_chain_id(0, 21_000, 25_000_000_000, Some(2));
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(invalid_idxs.len(), 1, "legacy tx with chain_id=Some(2) must be discarded");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// Boundary: legacy pre-EIP-155 tx (`chain_id = None`) is accepted — matches
+    /// revm's behaviour and reth-pool's policy.
+    #[test]
+    fn test_filter_invalid_txs_legacy_pre_eip155_chain_id_none_accepted() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+            },
+        );
+
+        let tx = create_test_legacy_with_chain_id(0, 21_000, 25_000_000_000, None);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert!(
+            invalid_idxs.is_empty(),
+            "pre-EIP-155 legacy tx must pass the chain-id gate: {invalid_idxs:?}"
+        );
+    }
+
+    // ===== audit#710 gap 6: EIP-3607 (sender has code) =========================
+
+    /// EIP-3607: sender with non-empty, non-7702-delegation code cannot originate
+    /// transactions. revm fires `RejectCallerWithCode`. Per-sender — all of the
+    /// sender's txs in the batch are invalidated.
+    #[test]
+    fn test_filter_invalid_txs_sender_with_code_eip3607_rejected() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        let code = Bytecode::new_raw(Bytes::from(vec![0x60u8, 0x00, 0x60, 0x00, 0xf3]));
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                // Any non-KECCAK_EMPTY hash triggers the gate; filter resolves the
+                // actual bytecode via `account.code` first (no DB fetch needed).
+                code_hash: B256::repeat_byte(0xab),
+                code: Some(code),
+            },
+        );
+
+        // Two txs from the same sender — both must be invalidated (per-sender check).
+        let tx1 = create_test_transaction(0, 21_000, 25_000_000_000);
+        let tx2 = create_test_transaction(1, 21_000, 25_000_000_000);
+        let txs = vec![tx1, tx2];
+        let senders = vec![sender, sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(invalid_idxs.len(), 2, "all txs from coded sender must be discarded");
+        assert!(invalid_idxs.contains(&0));
+        assert!(invalid_idxs.contains(&1));
+    }
+
+    /// EIP-3607 delegation exception: sender whose code is an EIP-7702 delegation
+    /// designator (`0xef 0x01 0x00 + address`) is allowed to send txs — Pectra
+    /// relaxed 3607 precisely to permit delegated EOAs.
+    #[test]
+    fn test_filter_invalid_txs_sender_with_7702_delegation_accepted() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        let target = Address::repeat_byte(0x42);
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: B256::repeat_byte(0xcd),
+                code: Some(Bytecode::new_eip7702(target)),
+            },
+        );
+
+        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert!(
+            invalid_idxs.is_empty(),
+            "tx from EIP-7702-delegated sender must pass: {invalid_idxs:?}"
         );
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -23,13 +23,13 @@
 //! this version pin, so the filter deliberately does NOT gate them:
 //!
 //! - `AccessListNotSupported` — legacy `env.rs` validation site removed.
-//! - `MaxFeePerBlobGasNotSupported` / `BlobVersionedHashesNotSupported` /
-//!   `BlobCreateTransaction` — removed; 4844 type rejected wholesale below regardless.
-//! - `AuthorizationListNotSupported` — type-gating now flows through
-//!   `Eip7702NotSupported`, which the pre-Prague guard below pre-empts.
-//! - `AuthorizationListInvalidFields` — validation moved to 7702 auth-list
-//!   processing (during execution, after balance deduct); not raised from
-//!   `validate_tx_env` / `validate_against_state_and_deduct_caller`.
+//! - `MaxFeePerBlobGasNotSupported` / `BlobVersionedHashesNotSupported` / `BlobCreateTransaction` —
+//!   removed; 4844 type rejected wholesale below regardless.
+//! - `AuthorizationListNotSupported` — type-gating now flows through `Eip7702NotSupported`, which
+//!   the pre-Prague guard below pre-empts.
+//! - `AuthorizationListInvalidFields` — validation moved to 7702 auth-list processing (during
+//!   execution, after balance deduct); not raised from `validate_tx_env` /
+//!   `validate_against_state_and_deduct_caller`.
 //!
 //! ## Upgrade-time audit checklist
 //!
@@ -37,11 +37,11 @@
 //! below is currently unreachable but will become reachable on the listed bump and
 //! MUST be paired with a new guard at that time:
 //!
-//! - `NonceOverflowInTransaction` — re-introduced in `revm-handler 18.1.0`
-//!   (`validation.rs:232`). Bumping past `10.0.1` requires adding
-//!   `tx.nonce() != u64::MAX` plus overflow-safe `account.nonce += 1`.
-//! - `Eip7873NotSupported` / `Eip7873MissingTarget` — activates on OSAKA. Adding
-//!   Osaka requires an init-code-tx type gate.
+//! - `NonceOverflowInTransaction` — re-introduced in `revm-handler 18.1.0` (`validation.rs:232`).
+//!   Bumping past `10.0.1` requires adding `tx.nonce() != u64::MAX` plus overflow-safe
+//!   `account.nonce += 1`.
+//! - `Eip7873NotSupported` / `Eip7873MissingTarget` — activates on OSAKA. Adding Osaka requires an
+//!   init-code-tx type gate.
 //!
 //! Procedure on upgrade: `grep 'return Err(InvalidTransaction::'` in
 //! `revm-handler/src/` for the new pin, diff against the "unreachable" list above,

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -11,9 +11,42 @@
 //! (`revm-handler/src/validation.rs::validate_tx_env` +
 //! `pre_execution.rs::validate_account_nonce_and_code` +
 //! `validate_against_state_and_deduct_caller`). Each guard below maps to a specific
-//! `InvalidTransaction::*` variant and cites the audit issue that motivated it. When
-//! upgrading revm, audit the `InvalidTransaction` enum for new variants and either add
-//! a matching guard or document why it is unreachable on Gravity.
+//! `InvalidTransaction::*` variant and cites the audit issue that motivated it.
+//!
+//! ## Variants pinned as unreachable on revm 10.0.1
+//!
+//! The following `InvalidTransaction::*` variants exist in the enum (kept for
+//! ABI/back-compat with downstream `match` arms) but have **no `return Err(...)`
+//! construction site** anywhere in `revm-handler-10.0.1` /
+//! `revm-context-interface-10.2.0` — the legacy validation paths that raised them
+//! were removed upstream. revm cannot return them at runtime regardless of input on
+//! this version pin, so the filter deliberately does NOT gate them:
+//!
+//! - `AccessListNotSupported` — legacy `env.rs` validation site removed.
+//! - `MaxFeePerBlobGasNotSupported` / `BlobVersionedHashesNotSupported` /
+//!   `BlobCreateTransaction` — removed; 4844 type rejected wholesale below regardless.
+//! - `AuthorizationListNotSupported` — type-gating now flows through
+//!   `Eip7702NotSupported`, which the pre-Prague guard below pre-empts.
+//! - `AuthorizationListInvalidFields` — validation moved to 7702 auth-list
+//!   processing (during execution, after balance deduct); not raised from
+//!   `validate_tx_env` / `validate_against_state_and_deduct_caller`.
+//!
+//! ## Upgrade-time audit checklist
+//!
+//! Re-run on every revm bump (`Cargo.toml: revm = ...`). Each forward-watch entry
+//! below is currently unreachable but will become reachable on the listed bump and
+//! MUST be paired with a new guard at that time:
+//!
+//! - `NonceOverflowInTransaction` — re-introduced in `revm-handler 18.1.0`
+//!   (`validation.rs:232`). Bumping past `10.0.1` requires adding
+//!   `tx.nonce() != u64::MAX` plus overflow-safe `account.nonce += 1`.
+//! - `Eip7873NotSupported` / `Eip7873MissingTarget` — activates on OSAKA. Adding
+//!   Osaka requires an init-code-tx type gate.
+//!
+//! Procedure on upgrade: `grep 'return Err(InvalidTransaction::'` in
+//! `revm-handler/src/` for the new pin, diff against the "unreachable" list above,
+//! and either add a guard or move the variant from the unreachable list to the
+//! forward-watch list with a citation.
 //!
 //! Closed audit issues: gravity-audit#668 / #696 / #710.
 

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_pipe_panic_smoke.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_pipe_panic_smoke.rs
@@ -1,0 +1,696 @@
+#![allow(missing_docs)]
+
+//! Pipe-layer panic-smoke test — gravity-audit#710 acceptance bar.
+//!
+//! Constructs an `OrderedBlock` carrying one valid tx of each EIP envelope (legacy /
+//! EIP-2930 / EIP-1559 / EIP-7702) alongside malformed variants of each known
+//! `revm::InvalidTransaction` panic trigger (EIP-4844 empty blobs, EIP-3860 oversized
+//! init code, EIP-7702 empty auth list, EIP-7702 sub-floor intrinsic gas,
+//! `max_fee < base_fee`, `priority > max_fee`, and chain-id mismatch) and pushes it
+//! through `PipeExecLayerApi::push_ordered_block`. The acceptance bar — per the
+//! user's framing on audit#710 — is **the pipe must not panic**: any panic from
+//! `lib.rs:1060` is converted to `process::exit(1)` by the test harness's panic
+//! hook, so the test fails by aborting the process.
+//!
+//! ## Scope and limits
+//!
+//! The smoke test guards the executor's panic surface, not the per-variant filter
+//! contract. Most malformed txs in this batch use throw-away signers (zero balance)
+//! and would be rejected by the filter's "sender does not exist" branch *before*
+//! reaching the gap-specific checks — which is fine for the panic-smoke claim, but
+//! means this file alone does not prove "each gap check is the gate". Use the
+//! per-gap unit tests in `crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs`
+//! (`test_filter_invalid_txs_*`) for that contract — they exercise the gap checks
+//! in isolation against `MockDatabase`. Together: UTs pin the per-variant contract,
+//! this smoke test pins the integration boundary against future regressions where
+//! filter changes accidentally let a malformed tx reach grevm.
+//!
+//! Harness (`boot_pipeline` / `MockConsensus` / `run_pipe_e2e_test` /
+//! `init_panic_hook_and_tracer`) is duplicated from `gravity_eip7702_test.rs` —
+//! Cargo treats each `tests/*.rs` as a separate binary, so a sibling-module
+//! refactor would couple the test binaries. Dedup is tracked as future cleanup.
+
+use alloy_consensus::{TxEip1559, TxEip2930, TxEip4844, TxEip7702, TxLegacy};
+use alloy_eips::eip7702::{Authorization, SignedAuthorization};
+use alloy_primitives::{address, Address, Bytes, Signature, TxKind, B256, U256};
+use alloy_rpc_types_eth::TransactionRequest;
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use gravity_api_types::{
+    config_storage::{BlockNumber, ConfigStorage, OnChainConfig},
+    events::contract_event::GravityEvent,
+};
+use gravity_storage::{block_view_storage::BlockViewStorage, GravityStorage};
+use reth_chainspec::ChainSpec;
+use reth_cli_commands::{launcher::FnLauncher, NodeCommand};
+use reth_cli_runner::CliRunner;
+use reth_db::DatabaseEnv;
+use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth_ethereum_primitives::{Transaction, TransactionSigned};
+use reth_node_builder::{EngineNodeLauncher, NodeBuilder, WithLaunchContext};
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_pipe_exec_layer_ext_v2::{
+    new_pipe_exec_layer_api, ExecutionArgs, OrderedBlock, PipeExecLayerApi,
+};
+use reth_provider::{
+    providers::BlockchainProvider, BlockHashReader, BlockNumReader, DatabaseProviderFactory,
+    HeaderProvider, StateProviderFactory,
+};
+use reth_rpc_eth_api::{helpers::EthCall, RpcTypes};
+use reth_tracing::{
+    tracing_subscriber::filter::LevelFilter, LayerInfo, LogFormat, RethTracer, Tracer,
+};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+// ---------------------------------------------------------------------------
+// Constants — mirrored from gravity_eip7702_test.rs (intentional duplication).
+// ---------------------------------------------------------------------------
+
+const CHAIN_ID: u64 = 7771625;
+const P3_TS_BASE: u64 = 2_000_000_000;
+
+/// Push the smoke block at block 1 (not 100) — Prague is activated at this same
+/// block so the 7702 surface is reachable, but we avoid spending 99 empty-block
+/// rounds boot-warming the chain just to get there.
+const ACTIVATION_BLOCK: u64 = 1;
+const PRAGUE_TS_ACTIVATION: u64 = P3_TS_BASE + ACTIVATION_BLOCK;
+
+const FUNDED_PRIVKEY_HEX: &[u8; 32] = &[
+    0xac, 0x09, 0x74, 0xbe, 0xc3, 0x9a, 0x17, 0xe3, 0x6b, 0xa4, 0xa6, 0xb4, 0xd2, 0x38, 0xff, 0x94,
+    0x4b, 0xac, 0xb4, 0x78, 0xcb, 0xed, 0x5e, 0xfc, 0xae, 0x78, 0x4d, 0x7b, 0xf4, 0xf2, 0xff, 0x80,
+];
+const TARGET_ADDR: Address = address!("0x0000000000000000000000000000000000001234");
+
+fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
+    let mut json: serde_json::Value =
+        serde_json::from_str(include_str!("../gravity_hardfork.json"))
+            .expect("gravity_hardfork.json must parse as JSON");
+    if let Some(ts) = prague_time {
+        json["config"]["pragueTime"] = serde_json::json!(ts);
+    }
+    json.to_string()
+}
+
+fn funded_signer() -> PrivateKeySigner {
+    PrivateKeySigner::from_bytes(&B256::from(*FUNDED_PRIVKEY_HEX))
+        .expect("funded test key must parse")
+}
+
+fn authority_signer(seed: u8) -> PrivateKeySigner {
+    let mut bytes = [0u8; 32];
+    bytes[31] = seed;
+    PrivateKeySigner::from_bytes(&B256::from(bytes)).expect("authority key must parse")
+}
+
+/// Deterministic throw-away signer for malformed-tx senders. Zero balance — the
+/// filter rejects them on the "sender does not exist" branch, fine for smoke.
+fn throwaway_signer(seed: u8) -> PrivateKeySigner {
+    let mut bytes = [0u8; 32];
+    bytes[0] = 0xaa;
+    bytes[31] = seed;
+    PrivateKeySigner::from_bytes(&B256::from(bytes)).expect("throwaway key must parse")
+}
+
+fn mock_block_id(block_number: u64) -> B256 {
+    B256::left_padding_from(&block_number.to_be_bytes())
+}
+
+fn p3_ts_us(block_number: u64) -> u64 {
+    (P3_TS_BASE + block_number) * 1_000_000
+}
+
+// ---------------------------------------------------------------------------
+// Signing helpers — mirrored from gravity_eip7702_test.rs.
+// ---------------------------------------------------------------------------
+
+fn sign_authorization(
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    target: Address,
+    nonce: u64,
+) -> SignedAuthorization {
+    let auth = Authorization { chain_id: U256::from(chain_id), address: target, nonce };
+    let sig: Signature =
+        signer.sign_hash_sync(&auth.signature_hash()).expect("auth signing must succeed");
+    auth.into_signed(sig)
+}
+
+fn finalize<T>(tx: T, signer: &PrivateKeySigner) -> (TransactionSigned, Address)
+where
+    T: alloy_consensus::SignableTransaction<Signature>
+        + alloy_consensus::transaction::RlpEcdsaEncodableTx,
+    Transaction: From<T>,
+{
+    let sig_hash = tx.signature_hash();
+    let signature: Signature = signer.sign_hash_sync(&sig_hash).expect("tx signing must succeed");
+    let signed = tx.into_signed(signature);
+    let (inner, sig, _hash) = signed.into_parts();
+    let outer: Transaction = inner.into();
+    let signed_tx = TransactionSigned::new_unhashed(outer, sig);
+    let _ = signed_tx.hash();
+    (signed_tx, signer.address())
+}
+
+// ---------------------------------------------------------------------------
+// Per-envelope tx builders — one valid variant of each envelope, then malformed
+// variants of every revm `InvalidTransaction` trigger gated by `tx_filter`.
+// ---------------------------------------------------------------------------
+
+fn build_valid_legacy(signer: &PrivateKeySigner, nonce: u64) -> (TransactionSigned, Address) {
+    let tx = TxLegacy {
+        chain_id: Some(CHAIN_ID),
+        nonce,
+        gas_price: 1_000_000_000,
+        gas_limit: 21_000,
+        to: TxKind::Call(TARGET_ADDR),
+        value: U256::ZERO,
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+fn build_valid_2930(signer: &PrivateKeySigner, nonce: u64) -> (TransactionSigned, Address) {
+    let tx = TxEip2930 {
+        chain_id: CHAIN_ID,
+        nonce,
+        gas_price: 1_000_000_000,
+        gas_limit: 21_000,
+        to: TxKind::Call(TARGET_ADDR),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+fn build_valid_1559(signer: &PrivateKeySigner, nonce: u64) -> (TransactionSigned, Address) {
+    let tx = TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce,
+        gas_limit: 21_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to: TxKind::Call(TARGET_ADDR),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+fn build_valid_7702(
+    signer: &PrivateKeySigner,
+    nonce: u64,
+    auth: SignedAuthorization,
+) -> (TransactionSigned, Address) {
+    let tx = TxEip7702 {
+        chain_id: CHAIN_ID,
+        nonce,
+        gas_limit: 200_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to: Address::ZERO,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        authorization_list: vec![auth],
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#696 trigger 2 — type-3 (blob) ----------
+fn build_malformed_4844_empty_blobs(signer: &PrivateKeySigner) -> (TransactionSigned, Address) {
+    let tx = TxEip4844 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 100_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to: TARGET_ADDR,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        blob_versioned_hashes: vec![],
+        max_fee_per_blob_gas: 1,
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#696 trigger 4 — EIP-3860 oversized init code ----------
+fn build_malformed_oversized_initcode(signer: &PrivateKeySigner) -> (TransactionSigned, Address) {
+    use revm_primitives::eip3860::MAX_INITCODE_SIZE;
+    let tx = TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 30_000_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to: TxKind::Create,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: Bytes::from(vec![0u8; MAX_INITCODE_SIZE + 1]),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#710 gap 3 — 7702 empty authorization_list ----------
+fn build_malformed_7702_empty_auth(signer: &PrivateKeySigner) -> (TransactionSigned, Address) {
+    let tx = TxEip7702 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 100_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to: Address::ZERO,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        authorization_list: vec![],
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#668 — 7702 below intrinsic gas floor ----------
+fn build_malformed_7702_low_gas(signer: &PrivateKeySigner) -> (TransactionSigned, Address) {
+    let auth = sign_authorization(signer, CHAIN_ID, TARGET_ADDR, 0);
+    let tx = TxEip7702 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 21_001, // < 21_000 + 25_000 floor
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 0,
+        to: Address::ZERO,
+        value: U256::ZERO,
+        access_list: Default::default(),
+        authorization_list: vec![auth],
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#710 gap 1 — max_fee < base_fee ----------
+fn build_malformed_1559_max_fee_below_base(
+    signer: &PrivateKeySigner,
+) -> (TransactionSigned, Address) {
+    // Block base_fee on a freshly-booted devchain is ~1 gwei. Setting max_fee to 1
+    // wei guarantees `max_fee < base_fee` if the filter ever forwards this to revm.
+    let tx = TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 21_000,
+        max_fee_per_gas: 1,
+        max_priority_fee_per_gas: 0,
+        to: TxKind::Call(TARGET_ADDR),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#710 gap 2 — priority > max ----------
+fn build_malformed_1559_prio_gt_max(signer: &PrivateKeySigner) -> (TransactionSigned, Address) {
+    let tx = TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: 21_000,
+        max_fee_per_gas: 1_000_000_000,
+        max_priority_fee_per_gas: 5_000_000_000,
+        to: TxKind::Call(TARGET_ADDR),
+        value: U256::ZERO,
+        access_list: Default::default(),
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------- Malformed: audit#710 gap 5 — chain_id mismatch ----------
+fn build_malformed_legacy_wrong_chain_id(
+    signer: &PrivateKeySigner,
+) -> (TransactionSigned, Address) {
+    let tx = TxLegacy {
+        chain_id: Some(99), // != CHAIN_ID (7771625)
+        nonce: 0,
+        gas_price: 1_000_000_000,
+        gas_limit: 21_000,
+        to: TxKind::Call(TARGET_ADDR),
+        value: U256::ZERO,
+        input: Bytes::new(),
+    };
+    finalize(tx, signer)
+}
+
+// ---------------------------------------------------------------------------
+// OrderedBlock helpers — mirrored from gravity_eip7702_test.rs.
+// ---------------------------------------------------------------------------
+
+fn empty_ordered_block(
+    epoch: u64,
+    block_number: u64,
+    block_id: B256,
+    parent_block_id: B256,
+    timestamp_us: u64,
+) -> OrderedBlock {
+    OrderedBlock {
+        failed_proposer_indices: vec![],
+        epoch,
+        parent_id: parent_block_id,
+        id: block_id,
+        number: block_number,
+        timestamp_us,
+        coinbase: Address::ZERO,
+        prev_randao: B256::ZERO,
+        withdrawals: Default::default(),
+        transactions: vec![],
+        senders: vec![],
+        proposer_index: Some(0),
+        extra_data: vec![],
+        randomness: U256::ZERO,
+    }
+}
+
+fn ordered_block_with_txs(
+    epoch: u64,
+    block_number: u64,
+    block_id: B256,
+    parent_block_id: B256,
+    timestamp_us: u64,
+    transactions: Vec<TransactionSigned>,
+    senders: Vec<Address>,
+) -> OrderedBlock {
+    OrderedBlock {
+        failed_proposer_indices: vec![],
+        epoch,
+        parent_id: parent_block_id,
+        id: block_id,
+        number: block_number,
+        timestamp_us,
+        coinbase: Address::ZERO,
+        prev_randao: B256::ZERO,
+        withdrawals: Default::default(),
+        transactions,
+        senders,
+        proposer_index: Some(0),
+        extra_data: vec![],
+        randomness: U256::ZERO,
+    }
+}
+
+type TimestampFn = Box<dyn Fn(u64) -> u64 + Send + Sync>;
+
+struct MockConsensus<Storage, EthApi> {
+    pipeline_api: PipeExecLayerApi<Storage, EthApi>,
+    ts_for_block: TimestampFn,
+}
+
+impl<Storage, EthApi> MockConsensus<Storage, EthApi>
+where
+    Storage: GravityStorage,
+    EthApi: EthCall,
+    EthApi::NetworkTypes: RpcTypes<TransactionRequest = TransactionRequest>,
+{
+    fn new(pipeline_api: PipeExecLayerApi<Storage, EthApi>, ts_for_block: TimestampFn) -> Self {
+        Self { pipeline_api, ts_for_block }
+    }
+
+    async fn push_one(
+        &self,
+        epoch: &mut u64,
+        block: OrderedBlock,
+    ) -> reth_pipe_exec_layer_ext_v2::ExecutionResult {
+        let block_id = block.id;
+        let block_number = block.number;
+        self.pipeline_api.push_ordered_block(block).unwrap();
+        let result = self.pipeline_api.pull_executed_block_hash().await.unwrap();
+        assert_eq!(result.block_number, block_number);
+        assert_eq!(result.block_id, block_id);
+        self.pipeline_api.commit_executed_block_hash(block_id, Some(result.block_hash)).unwrap();
+
+        for event in &result.gravity_events {
+            if let GravityEvent::NewEpoch(new_epoch, _) = event {
+                assert_eq!(*new_epoch, *epoch + 1);
+                self.pipeline_api.wait_for_block_persistence(block_number).await.unwrap();
+                self.pipeline_api
+                    .push_ordered_block(empty_ordered_block(
+                        *epoch,
+                        block_number + 1,
+                        mock_block_id(block_number + 1),
+                        block_id,
+                        (self.ts_for_block)(block_number + 1),
+                    ))
+                    .unwrap();
+                *epoch = *new_epoch;
+            }
+        }
+        result
+    }
+
+    fn into_inner(self) -> PipeExecLayerApi<Storage, EthApi> {
+        self.pipeline_api
+    }
+}
+
+fn read_state_root<P: HeaderProvider>(provider: &P, block_number: u64) -> B256 {
+    use alloy_consensus::BlockHeader;
+    provider
+        .header_by_number(block_number)
+        .expect("header read must succeed")
+        .expect("header must be persisted")
+        .state_root()
+}
+
+// ---------------------------------------------------------------------------
+// Boot path.
+// ---------------------------------------------------------------------------
+
+async fn boot_pipeline(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<(
+    Arc<reth_chainspec::ChainSpec>,
+    impl StateProviderFactory + HeaderProvider + BlockHashReader + BlockNumReader + Clone,
+    PipeExecLayerApi<
+        BlockViewStorage<
+            BlockchainProvider<
+                reth_node_api::NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>,
+            >,
+        >,
+        impl EthCall<NetworkTypes: RpcTypes<TransactionRequest = TransactionRequest>>,
+    >,
+    u64,
+)> {
+    let handle = builder
+        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                builder.task_executor().clone(),
+                builder.config().datadir(),
+                reth_engine_primitives::TreeConfig::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await?;
+
+    let chain_spec = handle.node.chain_spec();
+    let eth_api = handle.node.rpc_registry.eth_api().clone();
+    let provider = handle.node.provider;
+
+    let db_provider = provider.database_provider_ro().unwrap();
+    let latest_block_number = db_provider.best_block_number().unwrap();
+    let latest_block_hash = db_provider.block_hash(latest_block_number).unwrap().unwrap();
+    let latest_block_header = db_provider.header_by_number(latest_block_number).unwrap().unwrap();
+    drop(db_provider);
+
+    assert_eq!(latest_block_number, 0, "tests expect a fresh datadir");
+
+    let storage = BlockViewStorage::new(provider.clone());
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let pipeline_api = new_pipe_exec_layer_api(
+        chain_spec.clone(),
+        storage,
+        latest_block_header,
+        latest_block_hash,
+        rx,
+        eth_api,
+    );
+    tx.send(ExecutionArgs { block_number_to_block_id: BTreeMap::new() }).unwrap();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    Ok((chain_spec, provider, pipeline_api, latest_block_number))
+}
+
+// ---------------------------------------------------------------------------
+// The smoke test body.
+// ---------------------------------------------------------------------------
+
+async fn run_pipe_panic_smoke(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<B256> {
+    let (_chain_spec, provider, pipeline_api, _) = boot_pipeline(builder).await?;
+
+    let mut epoch: u64 = pipeline_api
+        .fetch_config_bytes(OnChainConfig::Epoch, BlockNumber::Latest)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let consensus = MockConsensus::new(pipeline_api, Box::new(p3_ts_us));
+
+    // --- Valid txs from the funded signer (sequential nonces 0..3). All four
+    // envelopes are exercised so a regression in any tx-type decoding panics us.
+    let funded = funded_signer();
+    let authority = authority_signer(0x42);
+    let auth = sign_authorization(&authority, CHAIN_ID, TARGET_ADDR, 0);
+    let (legacy_tx, legacy_sender) = build_valid_legacy(&funded, 0);
+    let (eip2930_tx, eip2930_sender) = build_valid_2930(&funded, 1);
+    let (eip1559_tx, eip1559_sender) = build_valid_1559(&funded, 2);
+    let (eip7702_tx, eip7702_sender) = build_valid_7702(&funded, 3, auth);
+
+    // --- Malformed variants from throwaway signers (zero balance — filter
+    // rejects them on the "sender does not exist" branch; that's fine for
+    // smoke, the per-gap UTs prove the specific check fires).
+    let mal_4844 = build_malformed_4844_empty_blobs(&throwaway_signer(0x01));
+    let mal_initcode = build_malformed_oversized_initcode(&throwaway_signer(0x02));
+    let mal_7702_empty = build_malformed_7702_empty_auth(&throwaway_signer(0x03));
+    let mal_7702_lowgas = build_malformed_7702_low_gas(&throwaway_signer(0x04));
+    let mal_low_fee = build_malformed_1559_max_fee_below_base(&throwaway_signer(0x05));
+    let mal_prio_high = build_malformed_1559_prio_gt_max(&throwaway_signer(0x06));
+    let mal_chain_id = build_malformed_legacy_wrong_chain_id(&throwaway_signer(0x07));
+
+    let txs = vec![
+        legacy_tx,
+        eip2930_tx,
+        eip1559_tx,
+        eip7702_tx,
+        mal_4844.0,
+        mal_initcode.0,
+        mal_7702_empty.0,
+        mal_7702_lowgas.0,
+        mal_low_fee.0,
+        mal_prio_high.0,
+        mal_chain_id.0,
+    ];
+    let senders = vec![
+        legacy_sender,
+        eip2930_sender,
+        eip1559_sender,
+        eip7702_sender,
+        mal_4844.1,
+        mal_initcode.1,
+        mal_7702_empty.1,
+        mal_7702_lowgas.1,
+        mal_low_fee.1,
+        mal_prio_high.1,
+        mal_chain_id.1,
+    ];
+
+    let block = ordered_block_with_txs(
+        epoch,
+        ACTIVATION_BLOCK,
+        mock_block_id(ACTIVATION_BLOCK),
+        mock_block_id(ACTIVATION_BLOCK - 1),
+        p3_ts_us(ACTIVATION_BLOCK),
+        txs,
+        senders,
+    );
+
+    // The acceptance bar: we reach here without panicking. push_one drives the
+    // tx through `filter_invalid_txs` → `parallel_executor.execute(&block)` →
+    // `lib.rs:1060`. Any `EVMError` that leaks past the filter into grevm
+    // triggers the bare `panic!` at `lib.rs:1067`; the harness's panic hook
+    // converts that to `process::exit(1)`, so the test fails by aborting.
+    let result = consensus.push_one(&mut epoch, block).await;
+    let pipeline_api = consensus.into_inner();
+    pipeline_api.wait_for_block_persistence(ACTIVATION_BLOCK).await.unwrap();
+
+    println!(
+        "[panic_smoke] ✅ mixed-tx batch executed without panic at block {ACTIVATION_BLOCK}: hash={:?}",
+        result.block_hash
+    );
+    let state_root = read_state_root(&provider, ACTIVATION_BLOCK);
+    println!("[panic_smoke] ✅ state_root={state_root:?}");
+    Ok(state_root)
+}
+
+#[test]
+fn test_pipe_panic_smoke_grevm() {
+    let _ = run_pipe_e2e_test(
+        &gravity_prague_chainspec(Some(PRAGUE_TS_ACTIVATION)),
+        "data/gravity_pipe_panic_smoke_grevm",
+        false,
+        run_pipe_panic_smoke,
+    );
+}
+
+#[test]
+fn test_pipe_panic_smoke_disable_grevm() {
+    let _ = run_pipe_e2e_test(
+        &gravity_prague_chainspec(Some(PRAGUE_TS_ACTIVATION)),
+        "data/gravity_pipe_panic_smoke_disable_grevm",
+        true,
+        run_pipe_panic_smoke,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Harness — mirrored from gravity_eip7702_test.rs.
+// ---------------------------------------------------------------------------
+
+fn run_pipe_e2e_test<F, Fut, R>(
+    chain_spec: &str,
+    datadir: &'static str,
+    disable_grevm: bool,
+    run_fn: F,
+) -> R
+where
+    F: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = eyre::Result<R>> + Send + 'static,
+    R: Send + Default + 'static,
+{
+    init_panic_hook_and_tracer();
+
+    let runner = CliRunner::try_default_runtime().unwrap();
+    let mut args: Vec<&str> =
+        vec!["reth", "--chain", chain_spec, "--with-unused-ports", "--dev", "--datadir", datadir];
+    if disable_grevm {
+        args.push("--gravity.disable-grevm");
+    }
+    let command: NodeCommand<EthereumChainSpecParser> =
+        NodeCommand::try_parse_args_from(args).unwrap();
+
+    let result = Arc::new(std::sync::Mutex::new(None::<R>));
+    let result_clone = result.clone();
+    runner
+        .run_command_until_exit(|ctx| {
+            command.execute(
+                ctx,
+                FnLauncher::new::<EthereumChainSpecParser, _>(|builder, _| async move {
+                    let r = run_fn(builder).await?;
+                    *result_clone.lock().unwrap() = Some(r);
+                    Ok(())
+                }),
+            )
+        })
+        .unwrap();
+
+    std::thread::sleep(Duration::from_secs(2));
+    result.lock().unwrap().take().unwrap_or_default()
+}
+
+fn init_panic_hook_and_tracer() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        let backtrace = std::backtrace::Backtrace::capture();
+        eprintln!("Panic occurred: {panic_info}\nBacktrace:\n{backtrace}");
+        std::process::exit(1);
+    }));
+
+    let _ = RethTracer::new()
+        .with_stdout(LayerInfo::new(
+            LogFormat::Terminal,
+            LevelFilter::INFO.to_string(),
+            String::new(),
+            Some("always".to_string()),
+        ))
+        .init();
+}


### PR DESCRIPTION
## Summary

Closes the filter portion of [gravity-audit#710](https://github.com/Galxe/gravity-audit/issues/710) — auditor enumerated the `revm::InvalidTransaction` set theoretically reachable on Gravity. PR #355 (now merged) closed 2/9; this PR closes the remaining 6 active gaps, adds an integration smoke test guarding the pipe's panic surface, and inlines the rationale for which enum variants are **deliberately not gated** because revm 10.0.1 cannot raise them.

### Filter gaps closed (commit 1)

Each maps 1:1 to a `revm::InvalidTransaction` variant:

| # | Variant | Predicate added |
|---|---|---|
| 1 | `GasPriceLessThanBasefee` | `tx.max_fee_per_gas() ≥ base_fee_per_gas` (unified for legacy via accessor collapse) |
| 2 | `PriorityFeeGreaterThanMaxFee` | `max_priority_fee ≤ max_fee_per_gas` for EIP-1559+ |
| 3 | `EmptyAuthorizationList` | post-Prague TxEip7702 with non-empty `authorization_list` |
| 4 | `LackOfFundForMaxFee` | balance check uses `max_fee_per_gas * gas_limit` (revm's worst-case pre-deduction), not effective price |
| 5 | `InvalidChainId` / `MissingChainId` | typed txs must carry configured `chain_id`; legacy may have `None` (pre-EIP-155) |
| 6 | `RejectCallerWithCode` | EIP-3607 per-sender check, with exception for EIP-7702 delegation designators (Pectra) |

### Variants in the enum that the filter deliberately does NOT gate

Audit#710's table listed several variants as "potential gaps". They are **not** gaps on the current revm pin — the underlying construction sites were removed upstream. The filter does not gate them, and that is correct, but the rationale needs to be load-bearing so a future maintainer doesn't grep `tx_filter.rs` and conclude "audit#710 was incompletely fixed". Now spelled out in the module docstring (commit 3 — `docs(filter): pin revm 10.0.1 unreachable variants + upgrade audit checklist`).

| Variant | Why not gated on revm 10.0.1 |
|---|---|
| `AccessListNotSupported` | Legacy `env.rs` validation site removed in handler 10.0.1. No `return Err(...)` site exists in the dependency tree. |
| `MaxFeePerBlobGasNotSupported` / `BlobVersionedHashesNotSupported` / `BlobCreateTransaction` | Removed; the whole-type 4844 reject below pre-empts them anyway. |
| `AuthorizationListNotSupported` | Type-gating now flows through `Eip7702NotSupported`, which the pre-Prague guard already covers. |
| `AuthorizationListInvalidFields` | Validation moved to 7702 auth-list processing during execution (after balance deduct), not raised from `validate_tx_env` / `validate_against_state_and_deduct_caller`. |

**Forward-watch list** (also inlined in the module docstring — must add guards when the listed revm bump lands):

- `NonceOverflowInTransaction` — re-introduced in `revm-handler 18.1.0` (`validation.rs:232`). Bumping past `10.0.1` requires `tx.nonce() != u64::MAX` plus overflow-safe `account.nonce += 1`.
- `Eip7873NotSupported` / `Eip7873MissingTarget` — activates on OSAKA. Adding Osaka requires an init-code-tx type gate.

**Upgrade procedure** (inlined in `tx_filter.rs` doc, runs on every revm bump): `grep 'return Err(InvalidTransaction::'` in `revm-handler/src/` for the new pin, diff against the unreachable list above, and either add a guard or move the variant to the forward-watch list with a citation.

### Structural reframe

Module docstring upgraded — `tx_filter` is no longer described as a "pool guard mirror" but as **Gravity's canonical tx-admission protocol layer**. Reasoning: in Gravity's consensus-orders-before-execution model the executor cannot recover from `EVMError`, and "drop the tx and continue" is a protocol-level change (would alter the state transition function). The only practical defense is to make the `EVMError` path unreachable by gating every reachable `InvalidTransaction` variant at the filter.

### Test fixtures

- All test accounts switched from `code_hash: B256::default()` (sentinel `ZERO`) to `code_hash: KECCAK_EMPTY` — the EIP-3607 gate treats `ZERO` as "has code" because real chain state never produces it; tests must use the production-realistic empty-account marker.
- Typed-tx helpers now pin `chain_id` to `MAINNET_CHAIN_ID` to match the chainspec — previously they relied on `Default` (`0`) which now trips the chain-id gate.
- `mixed_scenarios` test's `base_fee_per_gas` lowered to `0` — it deliberately probes nonce/balance/cumulative-gas branches with sub-gwei gas_prices, and the new fee-floor gate would otherwise short-circuit them.

### Pipe-level panic smoke test (commit 2)

`crates/pipe-exec-layer-ext-v2/execute/tests/gravity_pipe_panic_smoke.rs` — addresses the explicit acceptance bar on #710: "测试通过的基准是 pipe 执行不能 panic".

A single `OrderedBlock` at the Prague activation block containing:

- **Valid** (funded signer): legacy / EIP-2930 / EIP-1559 / EIP-7702 — exercises every tx-type decoding path
- **Malformed** (throw-away signers): EIP-4844 empty blobs, EIP-1559 Create with oversized init code, EIP-7702 with empty auth, EIP-7702 sub-floor gas, EIP-1559 max_fee<base_fee, EIP-1559 prio>max, legacy chain_id mismatch

Pass criterion is **implicit reach to `Ok(state_root)`**. The harness panic hook calls `std::process::exit(1)` on any panic, so a `panic!` at `lib.rs:1060` aborts the test process before the final assertion can be observed — `catch_unwind` is intentionally not used.

Known scope limit: malformed txs use throw-away signers (zero balance) → rejected on the filter's "sender does not exist" branch *before* gap-specific checks. The per-gap UTs in `src/tx_filter.rs::tests` pin the per-variant contract; this file pins the integration boundary against future regressions.

Two variants: `_grevm` (default) and `_disable_grevm` (`BasicBlockExecutor` path). ~6s each.

## Test plan

- [x] `cargo nextest run -p reth-pipe-exec-layer-ext-v2 --lib tx_filter::` — 26/26 pass (16 pre-existing + 10 new for #710 gaps)
- [x] `cargo nextest run -p reth-pipe-exec-layer-ext-v2 --test gravity_pipe_panic_smoke` — 2/2 pass (grevm + disable_grevm)
- [x] `cargo +nightly fmt --all --check`
- [x] Clippy clean on touched files (`tx_filter.rs`, `gravity_pipe_panic_smoke.rs`); pre-existing workspace clippy debt unchanged
- [x] Re-audit against full `revm::InvalidTransaction` enum on the pinned `revm-handler-10.0.1` / `revm-context-interface-10.2.0`: every variant is gated by the filter, listed as construction-site-removed-on-this-pin, or on the forward-watch list with a specific revm bump trigger
