### PR TITLE
fix(execute): decode NativeOracle NonceNotSequential; log oracle-nonce replay reverts at WARN not ERROR

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -855,14 +855,36 @@ impl<Storage: GravityStorage> Core<Storage> {
             let validator_result = SystemTxnResult { result: execution_result, txn };
 
             if !validator_result.result.is_success() {
-                error!(target: "execute_ordered_block",
-                    index=?index,
-                    is_dkg=?is_dkg,
-                    block_number=?block_number,
-                    gas_used=?validator_result.result.gas_used(),
-                    output=?validator_result.result.output(),
-                    "validator system transaction reverted"
-                );
+                // Classify the revert by severity. A recoverable revert — e.g. a duplicate
+                // oracle attestation rejected by NativeOracle's sequential-nonce replay guard
+                // (NonceNotSequential) — is expected and must log at WARN, not ERROR, so it
+                // does not look like a failure or trip alerting. Unknown/fatal reverts stay ERROR.
+                let recoverable = validator_result
+                    .result
+                    .output()
+                    .and_then(|out| onchain_config::errors::decode_revert_error(out))
+                    .is_some_and(|e| {
+                        e.severity == onchain_config::errors::ErrorSeverity::Recoverable
+                    });
+                if recoverable {
+                    warn!(target: "execute_ordered_block",
+                        index=?index,
+                        is_dkg=?is_dkg,
+                        block_number=?block_number,
+                        gas_used=?validator_result.result.gas_used(),
+                        output=?validator_result.result.output(),
+                        "validator system transaction reverted (recoverable)"
+                    );
+                } else {
+                    error!(target: "execute_ordered_block",
+                        index=?index,
+                        is_dkg=?is_dkg,
+                        block_number=?block_number,
+                        gas_used=?validator_result.result.gas_used(),
+                        output=?validator_result.result.output(),
+                        "validator system transaction reverted"
+                    );
+                }
             } else {
                 // DKG transactions may trigger epoch change
                 if is_dkg {

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/errors.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/errors.rs
@@ -53,8 +53,10 @@ sol! {
     error DKGNotInitialized();
 
     // -------------------- NativeOracle Errors --------------------
-    /// @notice Nonce must be strictly increasing for each source
-    error NonceNotIncreasing(uint32 sourceType, uint256 sourceId, uint128 currentNonce, uint128 providedNonce);
+    /// @notice Oracle nonce must be sequential (== currentNonce + 1) for each source.
+    /// Thrown by NativeOracle._updateNonce when a duplicate / already-committed
+    /// attestation is replayed; matches NativeOracle.sol (selector 0x32e429cd).
+    error NonceNotSequential(uint32 sourceType, uint256 sourceId, uint128 expectedNonce, uint128 providedNonce);
 
     /// @notice Batch arrays have mismatched lengths
     error OracleBatchArrayLengthMismatch(uint256 noncesLength, uint256 payloadsLength, uint256 gasLimitsLength);
@@ -214,13 +216,13 @@ pub fn decode_revert_error(output: &Bytes) -> Option<SystemTxnError> {
             severity: ErrorSeverity::Recoverable,
         }),
 
-        s if s == NonceNotIncreasing::SELECTOR => {
-            let err = NonceNotIncreasing::abi_decode(output).ok()?;
+        s if s == NonceNotSequential::SELECTOR => {
+            let err = NonceNotSequential::abi_decode(output).ok()?;
             Some(SystemTxnError {
-                name: "NonceNotIncreasing".into(),
+                name: "NonceNotSequential".into(),
                 details: format!(
-                    "Oracle nonce not increasing: sourceType={}, sourceId={}, current={}, provided={}",
-                    err.sourceType, err.sourceId, err.currentNonce, err.providedNonce
+                    "Oracle nonce not sequential (duplicate/replayed attestation rejected by the nonce guard): sourceType={}, sourceId={}, expected={}, provided={}",
+                    err.sourceType, err.sourceId, err.expectedNonce, err.providedNonce
                 ),
                 severity: ErrorSeverity::Recoverable,
             })
@@ -318,19 +320,21 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_nonce_not_increasing() {
-        let error = NonceNotIncreasing {
-            sourceType: 1,
-            sourceId: alloy_primitives::U256::from(42),
-            currentNonce: 10,
-            providedNonce: 5,
+    fn test_decode_nonce_not_sequential() {
+        // expected = currentNonce + 1, provided = currentNonce: the duplicate-attestation
+        // replay shape seen in production (selector 0x32e429cd, classified Recoverable).
+        let error = NonceNotSequential {
+            sourceType: 0,
+            sourceId: alloy_primitives::U256::from(1),
+            expectedNonce: 11,
+            providedNonce: 10,
         };
         let encoded = error.abi_encode();
         let result = decode_revert_error(&encoded.into());
 
         assert!(result.is_some());
         let err = result.unwrap();
-        assert_eq!(err.name, "NonceNotIncreasing");
+        assert_eq!(err.name, "NonceNotSequential");
         assert_eq!(err.severity, ErrorSeverity::Recoverable);
     }
 

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/errors.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/errors.rs
@@ -56,7 +56,14 @@ sol! {
     /// @notice Oracle nonce must be sequential (== currentNonce + 1) for each source.
     /// Thrown by NativeOracle._updateNonce when a duplicate / already-committed
     /// attestation is replayed; matches NativeOracle.sol (selector 0x32e429cd).
+    /// This is what the currently deployed contract reverts with.
     error NonceNotSequential(uint32 sourceType, uint256 sourceId, uint128 expectedNonce, uint128 providedNonce);
+
+    /// @notice Legacy oracle-nonce error (selector 0xc778b1a4). The deployed contract
+    /// no longer throws this — `NonceNotSequential` superseded it — but it is kept in
+    /// the decode table so that a node running against an older contract build still
+    /// classifies the revert as Recoverable instead of falling through to ERROR.
+    error NonceNotIncreasing(uint32 sourceType, uint256 sourceId, uint128 currentNonce, uint128 providedNonce);
 
     /// @notice Batch arrays have mismatched lengths
     error OracleBatchArrayLengthMismatch(uint256 noncesLength, uint256 payloadsLength, uint256 gasLimitsLength);
@@ -116,6 +123,26 @@ pub enum SystemTxnExecutionResult {
 /// Decode a revert output into a known error type
 ///
 /// Uses 4-byte selector matching for O(1) lookup, then decodes only the matched error.
+///
+/// Severity classification (drives the log level at the call sites — Fatal => ERROR,
+/// Recoverable => WARN). Keep this list in sync with the match arms below:
+///
+/// - **Fatal** (a real protocol violation / bug — should never happen in normal operation):
+///   - `Unauthorized` — system call from a non-system caller.
+///   - `TimestampMustAdvance` / `TimestampMustEqual` — block timestamp invariant broken.
+///   - `ValidatorIndexOutOfBounds` — validator index outside the active set.
+///   - `ReconfigurationNotInitialized` / `DKGNotInitialized` — required module not initialized.
+///   - `OracleBatchArrayLengthMismatch` — malformed oracle batch (nonces/payloads/gas mismatched).
+///
+/// - **Recoverable** (expected under benign races / replays — safe to ignore, logged at WARN):
+///   - `ReconfigurationNotInProgress` / `ReconfigurationInProgress` — epoch-transition state race.
+///   - `DKGNotInProgress` / `DKGInProgress` — DKG-session state race.
+///   - `NonceNotSequential` — duplicate/already-committed oracle attestation rejected by the
+///     sequential-nonce replay guard (current contract; selector 0x32e429cd).
+///   - `NonceNotIncreasing` — legacy form of the same oracle-nonce replay rejection, superseded
+///     by `NonceNotSequential`; kept for compatibility with older contract builds.
+///
+/// An unknown selector returns `None`, which the call sites log at ERROR.
 pub fn decode_revert_error(output: &Bytes) -> Option<SystemTxnError> {
     // Need at least 4 bytes for selector
     if output.len() < 4 {
@@ -228,6 +255,21 @@ pub fn decode_revert_error(output: &Bytes) -> Option<SystemTxnError> {
             })
         }
 
+        // Legacy oracle-nonce error. The deployed contract emits NonceNotSequential
+        // instead, but keep this arm so a node run against an older contract build
+        // still classifies the replay rejection as Recoverable.
+        s if s == NonceNotIncreasing::SELECTOR => {
+            let err = NonceNotIncreasing::abi_decode(output).ok()?;
+            Some(SystemTxnError {
+                name: "NonceNotIncreasing".into(),
+                details: format!(
+                    "Oracle nonce not increasing (legacy; superseded by NonceNotSequential): sourceType={}, sourceId={}, current={}, provided={}",
+                    err.sourceType, err.sourceId, err.currentNonce, err.providedNonce
+                ),
+                severity: ErrorSeverity::Recoverable,
+            })
+        }
+
         // Unknown selector
         _ => None,
     }
@@ -335,6 +377,24 @@ mod tests {
         assert!(result.is_some());
         let err = result.unwrap();
         assert_eq!(err.name, "NonceNotSequential");
+        assert_eq!(err.severity, ErrorSeverity::Recoverable);
+    }
+
+    #[test]
+    fn test_decode_nonce_not_increasing_legacy() {
+        // Legacy selector (0xc778b1a4), kept for older contract builds; still Recoverable.
+        let error = NonceNotIncreasing {
+            sourceType: 1,
+            sourceId: alloy_primitives::U256::from(42),
+            currentNonce: 10,
+            providedNonce: 5,
+        };
+        let encoded = error.abi_encode();
+        let result = decode_revert_error(&encoded.into());
+
+        assert!(result.is_some());
+        let err = result.unwrap();
+        assert_eq!(err.name, "NonceNotIncreasing");
         assert_eq!(err.severity, ErrorSeverity::Recoverable);
     }
 


### PR DESCRIPTION
## Problem

On mainnet, node logs carry a recurring **ERROR** that is actually benign:

```
ERROR validator system transaction reverted index=0 is_dkg=false block_number=... output=Some(0x32e429cd...)
```

`0x32e429cd` is `NativeOracle.NonceNotSequential(uint32 sourceType, uint256 sourceId, uint128 expectedNonce, uint128 providedNonce)`, thrown by `_updateNonce` when an oracle attestation's nonce `!= currentNonce + 1`. Decoding every on-chain occurrence shows the same shape: `sourceType=0` (Blockchain Events / `GBridgeReceiver`, i.e. the Ethereum→Gravity bridge), `sourceId=1`, and `provided == currentNonce` (i.e. `expected - 1`). In other words a **duplicate / already-committed bridge attestation is being replayed, and the contract's sequential-nonce guard correctly rejects it** (replay protection — prevents double-mint). The block still commits, the chain is unaffected; this has happened ~2.5×/day since genesis.

### Root cause

`decode_revert_error` only knew a stale `NonceNotIncreasing` (selector `0xc778b1a4`) that **no deployed contract throws** — the contract error was renamed to `NonceNotSequential` (selector `0x32e429cd`), but the decoder table was never updated. So the real revert fell through to the "unknown error" branch, and the validator system-tx path logged it at **ERROR** — making a benign, expected replay rejection look like a failure (and trip naive alerting).

## Changes

- **`onchain_config/errors.rs`** — replace the dead `NonceNotIncreasing` (sol definition, decode arm, unit test) with **`NonceNotSequential`** (correct signature → correct selector `0x32e429cd`), classified `Recoverable`.
- **`execute/lib.rs`** — in the validator system-tx loop, **classify the revert by severity**: recoverable reverts (the oracle nonce replay) log at **WARN**; unknown/fatal reverts stay **ERROR**. Previously all validator-txn reverts logged at ERROR regardless of severity.

## Scope / safety

- **No consensus or state-transition behavior change.** This is purely a logging-severity fix plus a revert-decoder correction. Block execution, the nonce guard, and what commits on-chain are all unchanged.
- The redundant submission itself — consensus re-proposing an attestation whose nonce is already committed (so it always reverts) — is a separate, lower-priority efficiency item tracked outside this PR (a `gravity-sdk` consensus-path change). This PR removes the misleading ERROR; that one would remove the wasted system-tx.

## Test

```
cargo test -p reth-pipe-exec-layer-ext-v2 --lib decode
# 4 passed (incl. new test_decode_nonce_not_sequential)
```

`cargo check -p reth-pipe-exec-layer-ext-v2` clean (pre-existing unrelated dead-code warnings only). Base: `main` (which includes the gravity-sdk-pinned reth commit 364b8516).