### PR TITLE
feat(persistence): gravity.persist.merge-blocks + remove unused validator-node-only flag

### DIFF
--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -316,29 +316,27 @@ where
                     metrics::histogram!("save_blocks_time", &[("process", "write_hashed_state")])
                         .record(start.elapsed());
 
-                    if !get_gravity_config().validator_node_only {
-                        let start = Instant::now();
-                        let provider_rw = inner_provider.database_provider_rw()?;
-                        let ck = Self::get_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::IndexAccountHistory,
-                            Some(block_number),
-                        )?;
-                        provider_rw.update_history_indices(block_number..=block_number)?;
-                        set_fail_point!("persistence::after_history_indices");
-                        Self::update_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::IndexAccountHistory,
-                            StageCheckpoint { block_number, ..ck },
-                        )?;
-                        provider_rw.commit()?;
-                        set_fail_point!("persistence::after_history_commit");
-                        metrics::histogram!(
-                            "save_blocks_time",
-                            &[("process", "update_history_indices")]
-                        )
-                        .record(start.elapsed());
-                    }
+                    let start = Instant::now();
+                    let provider_rw = inner_provider.database_provider_rw()?;
+                    let ck = Self::get_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::IndexAccountHistory,
+                        Some(block_number),
+                    )?;
+                    provider_rw.update_history_indices(block_number..=block_number)?;
+                    set_fail_point!("persistence::after_history_indices");
+                    Self::update_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::IndexAccountHistory,
+                        StageCheckpoint { block_number, ..ck },
+                    )?;
+                    provider_rw.commit()?;
+                    set_fail_point!("persistence::after_history_commit");
+                    metrics::histogram!(
+                        "save_blocks_time",
+                        &[("process", "update_history_indices")]
+                    )
+                    .record(start.elapsed());
                     Ok(())
                 });
                 let trie_handle = scope.spawn(|| -> Result<(), PersistenceError> {
@@ -474,9 +472,7 @@ where
         }
 
         // History indices for the whole range, once.
-        if !get_gravity_config().validator_node_only {
-            provider_rw.update_history_indices(group_first..=group_last)?;
-        }
+        provider_rw.update_history_indices(group_first..=group_last)?;
 
         // Advance every written stage's checkpoint to the group tip, then commit the group once.
         // `MerkleExecute` passes `None` (trie writes are idempotent and may resume mid-range); the
@@ -484,14 +480,7 @@ where
         let tx = provider_rw.tx_ref();
         Self::advance_checkpoint(tx, StageId::Execution, Some(group_first), group_last)?;
         Self::advance_checkpoint(tx, StageId::AccountHashing, Some(group_first), group_last)?;
-        if !get_gravity_config().validator_node_only {
-            Self::advance_checkpoint(
-                tx,
-                StageId::IndexAccountHistory,
-                Some(group_first),
-                group_last,
-            )?;
-        }
+        Self::advance_checkpoint(tx, StageId::IndexAccountHistory, Some(group_first), group_last)?;
         Self::advance_checkpoint(tx, StageId::MerkleExecute, None, group_last)?;
 
         provider_rw.static_file_provider().commit()?;

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -31,6 +31,15 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info};
 
+/// When `persist_merge_blocks` is on, close the current merged group once its accumulated
+/// `gas_used` crosses this threshold (a cheap proxy for transaction/receipt write volume).
+const MERGE_GROUP_MAX_GAS: u64 = 1_000_000_000;
+/// Also close the group once the accumulated number of changed hashed accounts crosses this
+/// threshold. This bounds the in-memory write batch and the trie/state write volume by actual
+/// state churn rather than a raw block count (mostly-empty catch-up blocks coalesce freely; a
+/// burst of state-heavy blocks closes the group sooner).
+const MERGE_GROUP_MAX_STATE: usize = 1_000_000;
+
 /// Writes parts of reth's in memory tree state to the database and static files.
 ///
 /// This is meant to be a spawned service that listens for various incoming persistence operations,
@@ -203,148 +212,12 @@ where
             let last_block_number = last_block.number();
             debug!(target: "provider::storage_writer", block_count = blocks.len(), "Writing blocks and execution data to storage");
 
-            for ExecutedBlockWithTrieUpdates {
-                block: ExecutedBlock { recovered_block, execution_output, hashed_state },
-                trie,
-                triev2,
-            } in blocks
-            {
-                let block_number = recovered_block.number();
-                let block_hash = recovered_block.hash();
-                let inner_provider = &self.provider;
-                info!(target: "persistence::save_block", block_number = block_number, "Write block updates into DB");
-
-                // Parallel execution of state and trie updates is safe because the database is
-                // split into three separate RocksDB instances: state_db (for state and history),
-                // account_db (for account trie), and storage_db (for storage trie). This allows
-                // concurrent writes and commits across different DB instances without conflicts.
-                // The `write_trie_updatesv2` implementation also parallelizes writes to account_db
-                // and storage_db internally. For fault tolerance, stage checkpoints ensure
-                // idempotency - each stage's checkpoint is verified before writing, guaranteeing
-                // exactly-once execution even if the process crashes mid-block.
-                thread::scope(|scope| -> Result<(), PersistenceError> {
-                    let state_handle = scope.spawn(|| -> Result<(), PersistenceError> {
-                        let start = Instant::now();
-                        let provider_rw = inner_provider.database_provider_rw()?;
-                        let ck = Self::get_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::Execution,
-                            Some(block_number),
-                        )?;
-                        let body_indices = provider_rw.insert_block(
-                            Arc::unwrap_or_clone(recovered_block),
-                            StorageLocation::Both,
-                        )?;
-                        set_fail_point!("persistence::after_write_state");
-                        // Write state and changesets to the database.
-                        // Must be written after blocks because of the receipt lookup.
-                        provider_rw.write_state_with_indices(
-                            &execution_output,
-                            OriginalValuesKnown::No,
-                            StorageLocation::StaticFiles,
-                            Some(vec![body_indices]),
-                        )?;
-                        Self::update_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::Execution,
-                            StageCheckpoint { block_number, ..ck },
-                        )?;
-                        provider_rw.static_file_provider().commit()?;
-                        provider_rw.commit()?;
-                        set_fail_point!("persistence::after_state_commit");
-                        metrics::histogram!("save_blocks_time", &[("process", "write_state")])
-                            .record(start.elapsed());
-
-                        let start = Instant::now();
-                        let provider_rw = inner_provider.database_provider_rw()?;
-                        let ck = Self::get_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::AccountHashing,
-                            Some(block_number),
-                        )?;
-                        // insert hashes and intermediate merkle nodes
-                        provider_rw.write_hashed_state(
-                            &Arc::unwrap_or_clone(hashed_state).into_sorted(),
-                        )?;
-                        set_fail_point!("persistence::after_hashed_state");
-                        Self::update_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::AccountHashing,
-                            StageCheckpoint { block_number, ..ck },
-                        )?;
-                        provider_rw.commit()?;
-                        set_fail_point!("persistence::after_hashed_state_commit");
-                        metrics::histogram!(
-                            "save_blocks_time",
-                            &[("process", "write_hashed_state")]
-                        )
-                        .record(start.elapsed());
-
-                        if !get_gravity_config().validator_node_only {
-                            let start = Instant::now();
-                            let provider_rw = inner_provider.database_provider_rw()?;
-                            let ck = Self::get_checkpoint(
-                                provider_rw.tx_ref(),
-                                StageId::IndexAccountHistory,
-                                Some(block_number),
-                            )?;
-                            provider_rw.update_history_indices(block_number..=block_number)?;
-                            set_fail_point!("persistence::after_history_indices");
-                            Self::update_checkpoint(
-                                provider_rw.tx_ref(),
-                                StageId::IndexAccountHistory,
-                                StageCheckpoint { block_number, ..ck },
-                            )?;
-                            provider_rw.commit()?;
-                            set_fail_point!("persistence::after_history_commit");
-                            metrics::histogram!(
-                                "save_blocks_time",
-                                &[("process", "update_history_indices")]
-                            )
-                            .record(start.elapsed());
-                        }
-                        Ok(())
-                    });
-                    let trie_handle = scope.spawn(|| -> Result<(), PersistenceError> {
-                        let start = Instant::now();
-                        let provider_rw = inner_provider.database_provider_rw()?;
-                        let ck = Self::get_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::MerkleExecute,
-                            None,
-                        )?;
-                        if ck.block_number + 1 != block_number {
-                            info!(target: "persistence::trie_update",
-                                checkpoint = ck.block_number,
-                                block_number = block_number,
-                                "Detected interrupted trie update, but trie has idempotency");
-                        }
-                        provider_rw.write_trie_updates(
-                            trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(block_hash))?,
-                        )?;
-                        provider_rw
-                            .write_trie_updatesv2(triev2.as_ref())
-                            .map_err(ProviderError::Database)?;
-                        set_fail_point!("persistence::after_trie_update");
-                        Self::update_checkpoint(
-                            provider_rw.tx_ref(),
-                            StageId::MerkleExecute,
-                            StageCheckpoint { block_number, ..ck },
-                        )?;
-                        provider_rw.commit()?;
-                        set_fail_point!("persistence::after_trie_commit");
-                        metrics::histogram!(
-                            "save_blocks_time",
-                            &[("process", "write_trie_updatesv2")]
-                        )
-                        .record(start.elapsed());
-                        Ok(())
-                    });
-                    state_handle.join().unwrap()?;
-                    trie_handle.join().unwrap()
-                })?;
-                PERSIST_BLOCK_CACHE.persist_tip(block_number);
+            if get_gravity_config().persist_merge_blocks {
+                self.save_merged_blocks(blocks)?;
+            } else {
+                self.save_blocks_per_block(blocks)?;
             }
+
             // Update pipeline progress
             let start_time = Instant::now();
             let provider_rw = self.provider.database_provider_rw()?;
@@ -361,6 +234,286 @@ where
             .save_duration_per_block_seconds
             .record(elapsed.as_secs_f64() / num_blocks as f64);
         Ok(last_block_hash_num)
+    }
+
+    /// Persist `blocks` one at a time, committing each block per stage (state / hashed / history /
+    /// trie) before moving on. This is the durable default: a crash never loses more than the
+    /// single block in flight.
+    fn save_blocks_per_block(
+        &self,
+        blocks: Vec<ExecutedBlockWithTrieUpdates<N::Primitives>>,
+    ) -> Result<(), PersistenceError> {
+        for ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock { recovered_block, execution_output, hashed_state },
+            trie,
+            triev2,
+        } in blocks
+        {
+            let block_number = recovered_block.number();
+            let block_hash = recovered_block.hash();
+            let inner_provider = &self.provider;
+            info!(target: "persistence::save_block", block_number = block_number, "Write block updates into DB");
+
+            // Parallel execution of state and trie updates is safe because the database is
+            // split into three separate RocksDB instances: state_db (for state and history),
+            // account_db (for account trie), and storage_db (for storage trie). This allows
+            // concurrent writes and commits across different DB instances without conflicts.
+            // The `write_trie_updatesv2` implementation also parallelizes writes to account_db
+            // and storage_db internally. For fault tolerance, stage checkpoints ensure
+            // idempotency - each stage's checkpoint is verified before writing, guaranteeing
+            // exactly-once execution even if the process crashes mid-block.
+            thread::scope(|scope| -> Result<(), PersistenceError> {
+                let state_handle = scope.spawn(|| -> Result<(), PersistenceError> {
+                    let start = Instant::now();
+                    let provider_rw = inner_provider.database_provider_rw()?;
+                    let ck = Self::get_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::Execution,
+                        Some(block_number),
+                    )?;
+                    let body_indices = provider_rw.insert_block(
+                        Arc::unwrap_or_clone(recovered_block),
+                        StorageLocation::Both,
+                    )?;
+                    set_fail_point!("persistence::after_write_state");
+                    // Write state and changesets to the database.
+                    // Must be written after blocks because of the receipt lookup.
+                    provider_rw.write_state_with_indices(
+                        &execution_output,
+                        OriginalValuesKnown::No,
+                        StorageLocation::StaticFiles,
+                        Some(vec![body_indices]),
+                    )?;
+                    Self::update_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::Execution,
+                        StageCheckpoint { block_number, ..ck },
+                    )?;
+                    provider_rw.static_file_provider().commit()?;
+                    provider_rw.commit()?;
+                    set_fail_point!("persistence::after_state_commit");
+                    metrics::histogram!("save_blocks_time", &[("process", "write_state")])
+                        .record(start.elapsed());
+
+                    let start = Instant::now();
+                    let provider_rw = inner_provider.database_provider_rw()?;
+                    let ck = Self::get_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::AccountHashing,
+                        Some(block_number),
+                    )?;
+                    // insert hashes and intermediate merkle nodes
+                    provider_rw
+                        .write_hashed_state(&Arc::unwrap_or_clone(hashed_state).into_sorted())?;
+                    set_fail_point!("persistence::after_hashed_state");
+                    Self::update_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::AccountHashing,
+                        StageCheckpoint { block_number, ..ck },
+                    )?;
+                    provider_rw.commit()?;
+                    set_fail_point!("persistence::after_hashed_state_commit");
+                    metrics::histogram!("save_blocks_time", &[("process", "write_hashed_state")])
+                        .record(start.elapsed());
+
+                    if !get_gravity_config().validator_node_only {
+                        let start = Instant::now();
+                        let provider_rw = inner_provider.database_provider_rw()?;
+                        let ck = Self::get_checkpoint(
+                            provider_rw.tx_ref(),
+                            StageId::IndexAccountHistory,
+                            Some(block_number),
+                        )?;
+                        provider_rw.update_history_indices(block_number..=block_number)?;
+                        set_fail_point!("persistence::after_history_indices");
+                        Self::update_checkpoint(
+                            provider_rw.tx_ref(),
+                            StageId::IndexAccountHistory,
+                            StageCheckpoint { block_number, ..ck },
+                        )?;
+                        provider_rw.commit()?;
+                        set_fail_point!("persistence::after_history_commit");
+                        metrics::histogram!(
+                            "save_blocks_time",
+                            &[("process", "update_history_indices")]
+                        )
+                        .record(start.elapsed());
+                    }
+                    Ok(())
+                });
+                let trie_handle = scope.spawn(|| -> Result<(), PersistenceError> {
+                    let start = Instant::now();
+                    let provider_rw = inner_provider.database_provider_rw()?;
+                    let ck =
+                        Self::get_checkpoint(provider_rw.tx_ref(), StageId::MerkleExecute, None)?;
+                    if ck.block_number + 1 != block_number {
+                        info!(target: "persistence::trie_update",
+                            checkpoint = ck.block_number,
+                            block_number = block_number,
+                            "Detected interrupted trie update, but trie has idempotency");
+                    }
+                    provider_rw.write_trie_updates(
+                        trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(block_hash))?,
+                    )?;
+                    provider_rw
+                        .write_trie_updatesv2(triev2.as_ref())
+                        .map_err(ProviderError::Database)?;
+                    set_fail_point!("persistence::after_trie_update");
+                    Self::update_checkpoint(
+                        provider_rw.tx_ref(),
+                        StageId::MerkleExecute,
+                        StageCheckpoint { block_number, ..ck },
+                    )?;
+                    provider_rw.commit()?;
+                    set_fail_point!("persistence::after_trie_commit");
+                    metrics::histogram!("save_blocks_time", &[("process", "write_trie_updatesv2")])
+                        .record(start.elapsed());
+                    Ok(())
+                });
+                state_handle.join().unwrap()?;
+                trie_handle.join().unwrap()
+            })?;
+            PERSIST_BLOCK_CACHE.persist_tip(block_number);
+        }
+        Ok(())
+    }
+
+    /// Persist `blocks` as a sequence of merged groups, each committed once. Groups are bounded by
+    /// [`MERGE_GROUP_MAX_GAS`] and [`MERGE_GROUP_MAX_STATE`] so the in-flight write batch and the
+    /// crash-replay window stay bounded.
+    fn save_merged_blocks(
+        &self,
+        blocks: Vec<ExecutedBlockWithTrieUpdates<N::Primitives>>,
+    ) -> Result<(), PersistenceError> {
+        let mut group: Vec<ExecutedBlockWithTrieUpdates<N::Primitives>> = Vec::new();
+        let mut group_gas = 0u64;
+        let mut group_state = 0usize;
+        for block in blocks {
+            let gas = block.recovered_block().header().gas_used();
+            let state = block.hashed_state().accounts.len();
+            // Close the current (non-empty) group before it would cross a bound; a single block
+            // that alone exceeds a bound becomes its own group.
+            if !group.is_empty() &&
+                (group_gas.saturating_add(gas) > MERGE_GROUP_MAX_GAS ||
+                    group_state.saturating_add(state) > MERGE_GROUP_MAX_STATE)
+            {
+                self.commit_block_group(std::mem::take(&mut group))?;
+                group_gas = 0;
+                group_state = 0;
+            }
+            group_gas = group_gas.saturating_add(gas);
+            group_state = group_state.saturating_add(state);
+            group.push(block);
+        }
+        self.commit_block_group(group)
+    }
+
+    /// Write one contiguous group of executed blocks and commit it once.
+    ///
+    /// The whole group is written into a single transaction and committed together, so the
+    /// per-commit fsync is paid once per group instead of once per block. The group is atomic: a
+    /// crash before the commit rolls it back and recovery re-executes it idempotently from the
+    /// stage checkpoints, with consensus re-supplying anything past the persisted tip. Batching the
+    /// per-block `write_*` calls is safe because state/hashed/trie writes are last-writer-wins puts
+    /// and receipts use the indices returned by `insert_blocks`, so none of them depends on
+    /// observing earlier uncommitted writes within the transaction.
+    fn commit_block_group(
+        &self,
+        group: Vec<ExecutedBlockWithTrieUpdates<N::Primitives>>,
+    ) -> Result<(), PersistenceError> {
+        let Some(first) = group.first() else { return Ok(()) };
+        let group_first = first.recovered_block().number();
+        let group_last = group.last().unwrap().recovered_block().number();
+        let block_count = group.len() as u32;
+        info!(target: "persistence::save_block", group_first, group_last, count = block_count, "Write merged block group into DB");
+        let start = Instant::now();
+
+        // Split the group into the per-stage artifacts each writer consumes.
+        let mut recovered_blocks = Vec::with_capacity(group.len());
+        let mut execution_outputs = Vec::with_capacity(group.len());
+        let mut hashed_states = Vec::with_capacity(group.len());
+        let mut trie_updates = Vec::with_capacity(group.len());
+        for ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock { recovered_block, execution_output, hashed_state },
+            trie,
+            triev2,
+        } in group
+        {
+            let block_hash = recovered_block.hash();
+            recovered_blocks.push(Arc::unwrap_or_clone(recovered_block));
+            execution_outputs.push(execution_output);
+            hashed_states.push(hashed_state);
+            trie_updates.push((trie, triev2, block_hash));
+        }
+
+        let provider_rw = self.provider.database_provider_rw()?;
+
+        // Headers / bodies / senders / tx lookups for the whole group (transaction numbers threaded
+        // across the batch in memory by `insert_blocks`).
+        let body_indices = provider_rw.insert_blocks(recovered_blocks, StorageLocation::Both)?;
+
+        // Receipts, state changesets and hashed state, per block.
+        for ((execution_output, hashed_state), body_index) in
+            execution_outputs.into_iter().zip(hashed_states).zip(body_indices)
+        {
+            provider_rw.write_state_with_indices(
+                &execution_output,
+                OriginalValuesKnown::No,
+                StorageLocation::StaticFiles,
+                Some(vec![body_index]),
+            )?;
+            provider_rw.write_hashed_state(&Arc::unwrap_or_clone(hashed_state).into_sorted())?;
+        }
+
+        // Trie updates, per block.
+        for (trie, triev2, block_hash) in &trie_updates {
+            provider_rw.write_trie_updates(
+                trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(*block_hash))?,
+            )?;
+            provider_rw.write_trie_updatesv2(triev2.as_ref()).map_err(ProviderError::Database)?;
+        }
+
+        // History indices for the whole range, once.
+        if !get_gravity_config().validator_node_only {
+            provider_rw.update_history_indices(group_first..=group_last)?;
+        }
+
+        // Advance every written stage's checkpoint to the group tip, then commit the group once.
+        // `MerkleExecute` passes `None` (trie writes are idempotent and may resume mid-range); the
+        // rest assert checkpoint continuity from `group_first`.
+        let tx = provider_rw.tx_ref();
+        Self::advance_checkpoint(tx, StageId::Execution, Some(group_first), group_last)?;
+        Self::advance_checkpoint(tx, StageId::AccountHashing, Some(group_first), group_last)?;
+        if !get_gravity_config().validator_node_only {
+            Self::advance_checkpoint(
+                tx,
+                StageId::IndexAccountHistory,
+                Some(group_first),
+                group_last,
+            )?;
+        }
+        Self::advance_checkpoint(tx, StageId::MerkleExecute, None, group_last)?;
+
+        provider_rw.static_file_provider().commit()?;
+        provider_rw.commit()?;
+        PERSIST_BLOCK_CACHE.persist_tip(group_last);
+
+        metrics::histogram!("save_blocks_time", &[("process", "merge_block")])
+            .record(start.elapsed() / block_count);
+        Ok(())
+    }
+
+    /// Read `stage_id`'s checkpoint (asserting continuity when `check_next` is set) and re-write it
+    /// at block `to`. Lets [`commit_block_group`](Self::commit_block_group) advance every stage to
+    /// the group tip within the single group commit.
+    fn advance_checkpoint<TX: DbTx + DbTxMut>(
+        tx: &TX,
+        stage_id: StageId,
+        check_next: Option<u64>,
+        to: u64,
+    ) -> Result<(), ProviderError> {
+        let ck = Self::get_checkpoint(tx, stage_id, check_next)?;
+        Self::update_checkpoint(tx, stage_id, StageCheckpoint { block_number: to, ..ck })
     }
 }
 

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -38,7 +38,7 @@ const MERGE_GROUP_MAX_GAS: u64 = 1_000_000_000;
 /// threshold. This bounds the in-memory write batch and the trie/state write volume by actual
 /// state churn rather than a raw block count (mostly-empty catch-up blocks coalesce freely; a
 /// burst of state-heavy blocks closes the group sooner).
-const MERGE_GROUP_MAX_STATE: usize = 1_000_000;
+const MERGE_GROUP_MAX_STATE: usize = 10_000;
 
 /// Writes parts of reth's in memory tree state to the database and static files.
 ///

--- a/crates/engine/tree/src/recovery.rs
+++ b/crates/engine/tree/src/recovery.rs
@@ -7,7 +7,6 @@
 
 use alloy_consensus::BlockHeader;
 use alloy_primitives::BlockNumber;
-use gravity_primitives::get_gravity_config;
 use reth_db::{
     tables,
     transaction::{DbTx, DbTxMut},
@@ -130,9 +129,7 @@ impl<'a, N: ProviderNodeTypes> StorageRecoveryHelper<'a, N> {
         self.recover_merkle(recover_block_number)?;
 
         // Stage 3: Recover IndexAccountHistory
-        if !get_gravity_config().validator_node_only {
-            self.recover_history_indices(recover_block_number)?;
-        }
+        self.recover_history_indices(recover_block_number)?;
 
         let provider_rw = self.factory.database_provider_rw()?;
         provider_rw.update_pipeline_stages(recover_block_number, false)?;
@@ -281,7 +278,6 @@ mod tests {
                 cache_capacity: 2_000_000,
                 report_db_metrics: false,
                 trie_parallel_levels: 1,
-                validator_node_only: false,
             });
         });
     }

--- a/crates/engine/tree/src/recovery.rs
+++ b/crates/engine/tree/src/recovery.rs
@@ -273,7 +273,7 @@ mod tests {
             init_gravity_config(GravityConfig {
                 disable_pipe_execution: false,
                 disable_grevm: false,
-                cache_max_persist_gap: 64,
+                cache_max_persist_gap: 128,
                 persist_merge_blocks: false,
                 cache_capacity: 2_000_000,
                 report_db_metrics: false,

--- a/crates/engine/tree/src/recovery.rs
+++ b/crates/engine/tree/src/recovery.rs
@@ -277,6 +277,7 @@ mod tests {
                 disable_pipe_execution: false,
                 disable_grevm: false,
                 cache_max_persist_gap: 64,
+                persist_merge_blocks: false,
                 cache_capacity: 2_000_000,
                 report_db_metrics: false,
                 trie_parallel_levels: 1,

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1792,10 +1792,18 @@ where
             .all(|block| block.trie_updates().is_some());
 
         let target_number = if all_blocks_have_trie_updates {
-            // Persist only up to block buffer target if all blocks have trie updates
+            // Persist only up to block buffer target if all blocks have trie updates.
+            // With merged-block persistence, drain more blocks per cycle (bounded by
+            // `cache_max_persist_gap`) so each merged group is large enough to amortize its commit.
+            let cfg = get_gravity_config();
+            let max_blocks_to_persist = if cfg.persist_merge_blocks {
+                cfg.cache_max_persist_gap.max(MAX_BLOCKS_TO_PERSIST)
+            } else {
+                MAX_BLOCKS_TO_PERSIST
+            };
             canonical_head_number
                 .saturating_sub(self.config.memory_block_buffer_target())
-                .min(last_persisted_number + MAX_BLOCKS_TO_PERSIST)
+                .min(last_persisted_number + max_blocks_to_persist)
         } else {
             // Persist all blocks if any block is missing trie updates
             canonical_head_number

--- a/crates/gravity-primitives/src/config.rs
+++ b/crates/gravity-primitives/src/config.rs
@@ -42,7 +42,7 @@ pub fn get_gravity_config() -> &'static Config {
     GLOBAL_CONFIG.get_or_init(|| Config {
         disable_pipe_execution: std::env::var("GRETH_DISABLE_PIPE_EXECUTION").is_ok(),
         disable_grevm: std::env::var("GRETH_DISABLE_GREVM").is_ok(),
-        cache_max_persist_gap: 64,
+        cache_max_persist_gap: 128,
         persist_merge_blocks: false,
         cache_capacity: 2_000_000,
         report_db_metrics: false,

--- a/crates/gravity-primitives/src/config.rs
+++ b/crates/gravity-primitives/src/config.rs
@@ -27,8 +27,6 @@ pub struct Config {
     pub report_db_metrics: bool,
     /// Max parallel levels in nested hash
     pub trie_parallel_levels: u64,
-    /// Worker as a validator node only, not supply history service.
-    pub validator_node_only: bool,
 }
 
 /// Global configuration instance, initialized once.
@@ -49,6 +47,5 @@ pub fn get_gravity_config() -> &'static Config {
         cache_capacity: 2_000_000,
         report_db_metrics: false,
         trie_parallel_levels: 1,
-        validator_node_only: false,
     })
 }

--- a/crates/gravity-primitives/src/config.rs
+++ b/crates/gravity-primitives/src/config.rs
@@ -18,6 +18,9 @@ pub struct Config {
     pub disable_grevm: bool,
     /// The max block height between merged and pesist block height.
     pub cache_max_persist_gap: u64,
+    /// Persist consecutive blocks as one merged commit per group (amortizes the per-commit
+    /// fsync, much faster catch-up) instead of committing every block. default false.
+    pub persist_merge_blocks: bool,
     /// The max size of cached items
     pub cache_capacity: u64,
     /// Report db metrics
@@ -42,6 +45,7 @@ pub fn get_gravity_config() -> &'static Config {
         disable_pipe_execution: std::env::var("GRETH_DISABLE_PIPE_EXECUTION").is_ok(),
         disable_grevm: std::env::var("GRETH_DISABLE_GREVM").is_ok(),
         cache_max_persist_gap: 64,
+        persist_merge_blocks: false,
         cache_capacity: 2_000_000,
         report_db_metrics: false,
         trie_parallel_levels: 1,

--- a/crates/node/core/src/args/gravity.rs
+++ b/crates/node/core/src/args/gravity.rs
@@ -15,7 +15,7 @@ pub struct GravityArgs {
     pub disable_grevm: bool,
 
     /// The max block height between merged and pesist block height.
-    #[arg(long = "gravity.cache.max-persist-gap", default_value_t = 64)]
+    #[arg(long = "gravity.cache.max-persist-gap", default_value_t = 128)]
     pub cache_max_persist_gap: u64,
 
     /// Persist consecutive blocks as one merged commit per group to amortize the per-commit
@@ -41,7 +41,7 @@ impl Default for GravityArgs {
         Self {
             disable_pipe_execution: false,
             disable_grevm: false,
-            cache_max_persist_gap: 64,
+            cache_max_persist_gap: 128,
             persist_merge_blocks: false,
             cache_capacity: 2_000_000,
             report_db_metrics: false,

--- a/crates/node/core/src/args/gravity.rs
+++ b/crates/node/core/src/args/gravity.rs
@@ -18,6 +18,11 @@ pub struct GravityArgs {
     #[arg(long = "gravity.cache.max-persist-gap", default_value_t = 64)]
     pub cache_max_persist_gap: u64,
 
+    /// Persist consecutive blocks as one merged commit per group to amortize the per-commit
+    /// fsync (much faster from-genesis catch-up). default false.
+    #[arg(long = "gravity.persist.merge-blocks", default_value = "false")]
+    pub persist_merge_blocks: bool,
+
     /// The max size of cached items
     #[arg(long = "gravity.cache.capacity", default_value_t = 2_000_000, value_parser = clap::value_parser!(u64).range(1_000..=100_000_000))]
     pub cache_capacity: u64,
@@ -41,6 +46,7 @@ impl Default for GravityArgs {
             disable_pipe_execution: false,
             disable_grevm: false,
             cache_max_persist_gap: 64,
+            persist_merge_blocks: false,
             cache_capacity: 2_000_000,
             report_db_metrics: false,
             trie_parallel_levels: 1,
@@ -56,6 +62,7 @@ impl GravityArgs {
             disable_pipe_execution: self.disable_pipe_execution,
             disable_grevm: self.disable_grevm,
             cache_max_persist_gap: self.cache_max_persist_gap,
+            persist_merge_blocks: self.persist_merge_blocks,
             cache_capacity: self.cache_capacity,
             report_db_metrics: self.report_db_metrics,
             trie_parallel_levels: self.trie_parallel_levels,

--- a/crates/node/core/src/args/gravity.rs
+++ b/crates/node/core/src/args/gravity.rs
@@ -34,10 +34,6 @@ pub struct GravityArgs {
     /// Max parallel level in nested hash
     #[arg(long = "gravity.trie.parallel-level", default_value_t = 1, value_parser = clap::value_parser!(u64).range(1..=64))]
     pub trie_parallel_levels: u64,
-
-    /// Worker as a validator node only, not supply history service.
-    #[arg(long = "gravity.validator-node-only", default_value = "false")]
-    pub validator_node_only: bool,
 }
 
 impl Default for GravityArgs {
@@ -50,7 +46,6 @@ impl Default for GravityArgs {
             cache_capacity: 2_000_000,
             report_db_metrics: false,
             trie_parallel_levels: 1,
-            validator_node_only: false,
         }
     }
 }
@@ -66,7 +61,6 @@ impl GravityArgs {
             cache_capacity: self.cache_capacity,
             report_db_metrics: self.report_db_metrics,
             trie_parallel_levels: self.trie_parallel_levels,
-            validator_node_only: self.validator_node_only,
         }
     }
 }

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -16,7 +16,6 @@ use alloy_eips::{
 };
 use alloy_primitives::{Address, BlockHash, BlockNumber, Sealable, TxHash, TxNumber, B256, U256};
 use alloy_rpc_types_engine::ForkchoiceState;
-use gravity_primitives::get_gravity_config;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
     MemoryOverlayStateProvider,
@@ -512,22 +511,12 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
         // use latest state provider if the head state exists
         if let Some(state) = self.canonical_in_memory_state.head_state() {
             trace!(target: "providers::blockchain", "Using head state for latest state provider");
-            if get_gravity_config().validator_node_only {
-                // Only supply latest view if current node is a validator
-                let latest_historical = self.database.latest()?;
-                Ok(state.state_provider(latest_historical).boxed())
-            } else {
-                Ok(self.block_state_provider(&state)?.boxed())
-            }
+            Ok(self.block_state_provider(&state)?.boxed())
         } else {
             trace!(target: "providers::blockchain", "Using database state for latest state provider");
-            if get_gravity_config().validator_node_only {
-                self.database.latest()
-            } else {
-                // Always return historical provider in Rocksdb
-                let best_block_number = self.database.best_block_number()?;
-                self.database.history_by_block_number(best_block_number)
-            }
+            // Always return historical provider in Rocksdb
+            let best_block_number = self.database.best_block_number()?;
+            self.database.history_by_block_number(best_block_number)
         }
     }
 

--- a/crates/storage/provider/src/providers/database/metrics.rs
+++ b/crates/storage/provider/src/providers/database/metrics.rs
@@ -41,14 +41,8 @@ pub(crate) enum Action {
     InsertHashes,
     InsertHistoryIndices,
     UpdatePipelineStages,
-    InsertCanonicalHeaders,
-    InsertHeaders,
-    InsertHeaderNumbers,
-    InsertHeaderTerminalDifficulties,
     InsertBlockBodyIndices,
     InsertTransactionBlocks,
-    GetNextTxNum,
-    GetParentTD,
 }
 
 /// Database provider metrics
@@ -65,22 +59,10 @@ struct DatabaseProviderMetrics {
     insert_history_indices: Histogram,
     /// Duration of update pipeline stages
     update_pipeline_stages: Histogram,
-    /// Duration of insert canonical headers
-    insert_canonical_headers: Histogram,
-    /// Duration of insert headers
-    insert_headers: Histogram,
-    /// Duration of insert header numbers
-    insert_header_numbers: Histogram,
-    /// Duration of insert header TD
-    insert_header_td: Histogram,
     /// Duration of insert block body indices
     insert_block_body_indices: Histogram,
     /// Duration of insert transaction blocks
     insert_tx_blocks: Histogram,
-    /// Duration of get next tx num
-    get_next_tx_num: Histogram,
-    /// Duration of get parent TD
-    get_parent_td: Histogram,
 }
 
 impl DatabaseProviderMetrics {
@@ -92,14 +74,8 @@ impl DatabaseProviderMetrics {
             Action::InsertHashes => self.insert_hashes.record(duration),
             Action::InsertHistoryIndices => self.insert_history_indices.record(duration),
             Action::UpdatePipelineStages => self.update_pipeline_stages.record(duration),
-            Action::InsertCanonicalHeaders => self.insert_canonical_headers.record(duration),
-            Action::InsertHeaders => self.insert_headers.record(duration),
-            Action::InsertHeaderNumbers => self.insert_header_numbers.record(duration),
-            Action::InsertHeaderTerminalDifficulties => self.insert_header_td.record(duration),
             Action::InsertBlockBodyIndices => self.insert_block_body_indices.record(duration),
             Action::InsertTransactionBlocks => self.insert_tx_blocks.record(duration),
-            Action::GetNextTxNum => self.get_next_tx_num.record(duration),
-            Action::GetParentTD => self.get_parent_td.record(duration),
         }
     }
 }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -2808,76 +2808,88 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider + 'static> BlockWrite
         block: RecoveredBlock<Self::Block>,
         write_to: StorageLocation,
     ) -> ProviderResult<StoredBlockBodyIndices> {
-        let block_number = block.number();
+        Ok(self
+            .insert_blocks(vec![block], write_to)?
+            .pop()
+            .expect("insert_blocks yields one entry per input block"))
+    }
 
-        let mut durations_recorder = metrics::DurationsRecorder::default();
-
-        // total difficulty
-        let ttd = if block_number == 0 {
-            block.header().difficulty()
-        } else {
-            let parent_block_number = block_number - 1;
-            let parent_ttd = self.header_td_by_number(parent_block_number)?.unwrap_or_default();
-            durations_recorder.record_relative(metrics::Action::GetParentTD);
-            parent_ttd + block.header().difficulty()
-        };
-
-        if write_to.database() {
-            self.tx.put::<tables::CanonicalHeaders>(block_number, block.hash())?;
-            durations_recorder.record_relative(metrics::Action::InsertCanonicalHeaders);
-
-            // Put header with canonical hashes.
-            self.tx.put::<tables::Headers<HeaderTy<N>>>(block_number, block.header().clone())?;
-            durations_recorder.record_relative(metrics::Action::InsertHeaders);
-
-            self.tx.put::<tables::HeaderTerminalDifficulties>(block_number, ttd.into())?;
-            durations_recorder.record_relative(metrics::Action::InsertHeaderTerminalDifficulties);
+    fn insert_blocks(
+        &self,
+        blocks: Vec<RecoveredBlock<Self::Block>>,
+        write_to: StorageLocation,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        if blocks.is_empty() {
+            return Ok(Vec::new());
         }
 
-        if write_to.static_files() {
-            let mut writer =
-                self.static_file_provider.get_writer(block_number, StaticFileSegment::Headers)?;
-            writer.append_header(block.header(), ttd, &block.hash())?;
-        }
-
-        self.tx.put::<tables::HeaderNumbers>(block.hash(), block_number)?;
-        durations_recorder.record_relative(metrics::Action::InsertHeaderNumbers);
-
+        // Seed the running transaction number and parent total difficulty once from committed
+        // state, then thread both across the batch in memory. A provider transaction is backed by
+        // a RocksDB `WriteBatch`, which does not surface its own pending writes to later reads, so
+        // re-reading `TransactionBlocks` / `HeaderTerminalDifficulties` per block would return the
+        // stale pre-batch value for every block and collapse them onto the same tx number.
         let mut next_tx_num = self
             .tx
             .cursor_read::<tables::TransactionBlocks>()?
             .last()?
             .map(|(n, _)| n + 1)
             .unwrap_or_default();
-        durations_recorder.record_relative(metrics::Action::GetNextTxNum);
-        let first_tx_num = next_tx_num;
+        let first_number = blocks[0].number();
+        let mut parent_ttd = if first_number == 0 {
+            U256::ZERO
+        } else {
+            self.header_td_by_number(first_number - 1)?.unwrap_or_default()
+        };
 
-        let tx_count = block.body().transaction_count() as u64;
+        let mut indices = Vec::with_capacity(blocks.len());
+        let mut bodies = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            let block_number = block.number();
+            let ttd = parent_ttd + block.header().difficulty();
 
-        // Ensures we have all the senders for the block's transactions.
-        for (transaction, sender) in block.body().transactions_iter().zip(block.senders_iter()) {
-            let hash = transaction.tx_hash();
-
-            if self.prune_modes.sender_recovery.as_ref().is_none_or(|m| !m.is_full()) {
-                self.tx.put::<tables::TransactionSenders>(next_tx_num, *sender)?;
+            if write_to.database() {
+                self.tx.put::<tables::CanonicalHeaders>(block_number, block.hash())?;
+                self.tx
+                    .put::<tables::Headers<HeaderTy<N>>>(block_number, block.header().clone())?;
+                self.tx.put::<tables::HeaderTerminalDifficulties>(block_number, ttd.into())?;
             }
 
-            if self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full()) {
-                self.tx.put::<tables::TransactionHashNumbers>(*hash, next_tx_num)?;
+            if write_to.static_files() {
+                let mut writer = self
+                    .static_file_provider
+                    .get_writer(block_number, StaticFileSegment::Headers)?;
+                writer.append_header(block.header(), ttd, &block.hash())?;
             }
-            next_tx_num += 1;
+
+            self.tx.put::<tables::HeaderNumbers>(block.hash(), block_number)?;
+
+            // `TransactionSenders` / `TransactionHashNumbers` are keyed by transaction number;
+            // advance the running counter so each block gets a distinct, contiguous tx range.
+            let first_tx_num = next_tx_num;
+            let tx_count = block.body().transaction_count() as u64;
+            for (transaction, sender) in block.body().transactions_iter().zip(block.senders_iter())
+            {
+                let hash = transaction.tx_hash();
+                if self.prune_modes.sender_recovery.as_ref().is_none_or(|m| !m.is_full()) {
+                    self.tx.put::<tables::TransactionSenders>(next_tx_num, *sender)?;
+                }
+                if self.prune_modes.transaction_lookup.is_none_or(|m| !m.is_full()) {
+                    self.tx.put::<tables::TransactionHashNumbers>(*hash, next_tx_num)?;
+                }
+                next_tx_num += 1;
+            }
+
+            indices.push(StoredBlockBodyIndices { first_tx_num, tx_count });
+            parent_ttd = ttd;
+            bodies.push((block_number, Some(block.into_body())));
         }
 
-        self.append_block_bodies(vec![(block_number, Some(block.into_body()))], write_to)?;
+        // Write every body in one call: `append_block_bodies` derives its tx counter from the same
+        // committed `TransactionBlocks` value and threads it across `bodies`, producing tx numbers
+        // identical to the senders / lookups written above.
+        self.append_block_bodies(bodies, write_to)?;
 
-        debug!(
-            target: "providers::db",
-            ?block_number,
-            actions = ?durations_recorder.actions,
-            "Inserted block"
-        );
-
-        Ok(StoredBlockBodyIndices { first_tx_num, tx_count })
+        Ok(indices)
     }
 
     fn append_block_bodies(

--- a/crates/storage/storage-api/src/block_writer.rs
+++ b/crates/storage/storage-api/src/block_writer.rs
@@ -76,6 +76,24 @@ pub trait BlockWriter: Send + Sync {
         write_to: StorageLocation,
     ) -> ProviderResult<StoredBlockBodyIndices>;
 
+    /// Insert a batch of consecutive blocks in one transaction, returning the
+    /// [`StoredBlockBodyIndices`] of each block in order.
+    ///
+    /// Unlike calling [`insert_block`](Self::insert_block) in a loop, this threads the running
+    /// transaction number through the batch in memory rather than re-reading it from the database
+    /// between blocks. The numbering therefore stays correct even when the whole batch is committed
+    /// only once and the backend does not observe its own uncommitted writes within a transaction
+    /// (e.g. a RocksDB `WriteBatch`).
+    ///
+    /// The default implementation inserts each block in turn.
+    fn insert_blocks(
+        &self,
+        blocks: Vec<RecoveredBlock<Self::Block>>,
+        write_to: StorageLocation,
+    ) -> ProviderResult<Vec<StoredBlockBodyIndices>> {
+        blocks.into_iter().map(|block| self.insert_block(block, write_to)).collect()
+    }
+
     /// Appends a batch of block bodies extending the canonical chain. This is invoked during
     /// `Bodies` stage and does not write to `TransactionHashNumbers` and `TransactionSenders`
     /// tables which are populated on later stages.

--- a/crates/storage/storage-api/src/block_writer.rs
+++ b/crates/storage/storage-api/src/block_writer.rs
@@ -83,7 +83,7 @@ pub trait BlockWriter: Send + Sync {
     /// transaction number through the batch in memory rather than re-reading it from the database
     /// between blocks. The numbering therefore stays correct even when the whole batch is committed
     /// only once and the backend does not observe its own uncommitted writes within a transaction
-    /// (e.g. a RocksDB `WriteBatch`).
+    /// (e.g. a `RocksDB` `WriteBatch`).
     ///
     /// The default implementation inserts each block in turn.
     fn insert_blocks(


### PR DESCRIPTION
Two independent changes, one per commit.

## 1. `gravity.persist.merge-blocks` (opt-in, default off)

From-genesis catch-up on a PFN is fsync-bound: the per-block persistence path commits each block per stage (state / hashed / history / trie) and fsyncs every commit, so throughput is capped regardless of CPU. This flag coalesces consecutive blocks into gas/state-bounded groups (`MERGE_GROUP_MAX_GAS` = 1e9, `MERGE_GROUP_MAX_STATE` = 1e6 changed accounts) and commits each group once, amortizing the fsync.

- `BlockWriter::insert_block` now delegates to a new `insert_blocks(Vec<…>)`; the batched impl seeds the tx number + parent TD once and threads them in memory (a RocksDB `WriteBatch` has no read-your-writes), so numbering stays correct with no duplicated insert logic.
- `on_save_blocks` dispatches to the unchanged per-block path or `commit_block_group` (one `insert_blocks`, per-block state/hashed/trie puts, history + checkpoints once, single commit). Groups are atomic — a crash rolls back and recovery re-executes idempotently from the stage checkpoints.
- Flag off ⇒ per-block path byte-for-byte unchanged.

## 2. Remove unused `--gravity.validator-node-only`

It gated a history-service-skipping DB path that was never enabled in production. Flag, config field, and all guards removed; nodes always serve history now.

Validated by a from-genesis PFN re-sync to multiple millions of blocks.
