### PR TITLE
fix(executor): align disable-grevm system-tx state-clear with grevm

### DIFF
--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -310,6 +310,13 @@ where
         precompiles: Vec<(Address, DynPrecompile)>,
         tx_env: TxEnv,
     ) -> Result<ExecutionResult<HaltReason>, BlockExecutionError> {
+        // System transactions execute before the per-block `apply_pre_execution_changes`
+        // sets the EIP-161 state-clear flag, so set it here to match the parallel
+        // (grevm `ParallelState`) backend — whose state-clear is enabled by default.
+        // Without this, the serial `disable-grevm` path retains empty-touched accounts
+        // (e.g. the zero-reward coinbase) that grevm prunes, forking the state root on
+        // system-tx blocks.
+        db.set_state_clear_flag(evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON);
         let (execution_result, evm_state) = {
             let mut evm = self.evm_with_env(&mut *db, evm_env);
             for (addr, precompile) in precompiles {


### PR DESCRIPTION
`--gravity.disable-grevm` runs the reth-native serial executor instead of grevm; the two must be consensus-equivalent or a mixed cluster forks the state root.

grevm's `ParallelState` enables EIP-161 state-clear by default, but the serial `BasicBlockExecutor` is built `.without_state_clear()` and only gets the flag set later by `apply_pre_execution_changes` (user-tx phase). System transactions run **before** that, so on the serial path they committed with state-clear disabled: empty-touched accounts (e.g. the zero-reward coinbase) were retained instead of pruned, forking the state root on every system-tx block.

Fix: set the state-clear flag from the block spec in `EthEvmConfig::transact_system_txn` (the serial-only system-tx path), matching grevm.

Validated by a from-genesis disable-grevm PFN re-sync: it previously forked at the first system-tx block (block 2), and now matches the canonical grevm chain across millions of blocks and multiple epoch boundaries.
