### PR TITLE
[draft][hardfork] gas-exempt system txs + zero-balance SYSTEM_CALLER (Epsilon)

### DIFF
--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -13,5 +13,9 @@ hardfork!(
         Gamma,
         /// Delta hardfork: activate Governance contract by setting Ownable._owner
         Delta,
+        /// Epsilon hardfork: system transactions become gas-exempt (no base-fee charge and no
+        /// balance requirement on `SYSTEM_CALLER`; gas is still metered) and the `SYSTEM_CALLER`
+        /// sentinel genesis balance is zeroed. See gravity-reth#364 / gravity-audit#720.
+        Epsilon,
     }
 );

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -768,6 +768,12 @@ impl From<Genesis> for ChainSpec {
             gravity_hardforks
                 .push((GravityHardfork::Alpha.boxed(), ForkCondition::Timestamp(alpha_time)));
         }
+        if let Some(epsilon_time) =
+            genesis.config.extra_fields.get("epsilonTime").and_then(|v| v.as_u64())
+        {
+            gravity_hardforks
+                .push((GravityHardfork::Epsilon.boxed(), ForkCondition::Timestamp(epsilon_time)));
+        }
 
         let gravity_hardfork_opts = [
             (
@@ -2379,6 +2385,28 @@ Post-merge hard forks (timestamp based):
         assert_eq!(got_forkid, expected_forkid);
         // Check that paris block and final difficulty are set correctly
         assert_eq!(chainspec.paris_block_and_final_difficulty, Some((72, U256::from(9454784))));
+    }
+
+    #[test]
+    fn test_gravity_epsilon_hardfork_from_genesis() {
+        // `epsilonTime` in genesis config activates GravityHardfork::Epsilon at that timestamp,
+        // mirroring `alphaTime`. Guards the gas-exempt + balance-zero gating (gravity-reth#364).
+        let s = r#"{"config":{"chainId":127001,"epsilonTime":1000},"alloc":{}}"#;
+        let spec = ChainSpec::from(serde_json::from_str::<Genesis>(s).unwrap());
+        let gh = spec.gravity_hardforks();
+        assert!(!gh.is_fork_active_at_timestamp(GravityHardfork::Epsilon, 999));
+        assert!(gh.is_fork_active_at_timestamp(GravityHardfork::Epsilon, 1000));
+        assert!(gh.is_fork_active_at_timestamp(GravityHardfork::Epsilon, 1001));
+        // transition fires exactly on the activation block, not the block after.
+        assert!(gh.fork(GravityHardfork::Epsilon).transitions_at_timestamp(1000, 999));
+        assert!(!gh.fork(GravityHardfork::Epsilon).transitions_at_timestamp(1001, 1000));
+        // absent `epsilonTime` ⇒ never active.
+        let none = ChainSpec::from(
+            serde_json::from_str::<Genesis>(r#"{"config":{"chainId":127001},"alloc":{}}"#).unwrap(),
+        );
+        assert!(!none
+            .gravity_hardforks()
+            .is_fork_active_at_timestamp(GravityHardfork::Epsilon, u64::MAX));
     }
 
     #[test]

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -317,18 +317,21 @@ where
         // (e.g. the zero-reward coinbase) that grevm prunes, forking the state root on
         // system-tx blocks.
         db.set_state_clear_flag(evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON);
-        // Epsilon: system transactions are gas-exempt — no base-fee charge and no balance
-        // requirement on SYSTEM_CALLER (gas is still metered). This stops burning base fee
-        // from SYSTEM_CALLER's sentinel balance. MUST mirror the grevm path
-        // (`GrevmExecutor::transact_system_txn`) exactly, or system-tx blocks fork the state root.
+        // Epsilon: system transactions become gas-exempt. A zero gas price (plus letting it sit
+        // below the base fee) makes the system tx pay nothing — so it needs no balance and burns
+        // nothing, which is the whole point: stop draining SYSTEM_CALLER's sentinel balance. Gas
+        // is still metered. MUST mirror the grevm path (`GrevmExecutor::transact_system_txn`)
+        // exactly, or system-tx blocks fork the state root. (revm's `CfgEnv` has no
+        // `disable_balance_check`; a zero price makes it unnecessary.)
         let mut evm_env = evm_env;
-        if self
-            .chain_spec()
-            .gravity_hardforks()
-            .is_fork_active_at_timestamp(GravityHardfork::Epsilon, evm_env.block_env.timestamp)
-        {
+        let mut tx_env = tx_env;
+        if self.chain_spec().gravity_hardforks().is_fork_active_at_timestamp(
+            GravityHardfork::Epsilon,
+            evm_env.block_env.timestamp.saturating_to(),
+        ) {
             evm_env.cfg_env.disable_base_fee = true;
-            evm_env.cfg_env.disable_balance_check = true;
+            tx_env.gas_price = 0;
+            tx_env.gas_priority_fee = None;
         }
         let (execution_result, evm_state) = {
             let mut evm = self.evm_with_env(&mut *db, evm_env);

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -31,7 +31,7 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_types_engine::ExecutionData;
 use core::{convert::Infallible, fmt::Debug};
 use gravity_primitives::get_gravity_config;
-use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, MAINNET};
+use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, GravityHardfork, MAINNET};
 use reth_ethereum_primitives::{Block, EthPrimitives};
 use reth_evm::{
     execute::{BasicBlockExecutor, BlockExecutionError},
@@ -317,6 +317,19 @@ where
         // (e.g. the zero-reward coinbase) that grevm prunes, forking the state root on
         // system-tx blocks.
         db.set_state_clear_flag(evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON);
+        // Epsilon: system transactions are gas-exempt — no base-fee charge and no balance
+        // requirement on SYSTEM_CALLER (gas is still metered). This stops burning base fee
+        // from SYSTEM_CALLER's sentinel balance. MUST mirror the grevm path
+        // (`GrevmExecutor::transact_system_txn`) exactly, or system-tx blocks fork the state root.
+        let mut evm_env = evm_env;
+        if self
+            .chain_spec()
+            .gravity_hardforks()
+            .is_fork_active_at_timestamp(GravityHardfork::Epsilon, evm_env.block_env.timestamp)
+        {
+            evm_env.cfg_env.disable_base_fee = true;
+            evm_env.cfg_env.disable_balance_check = true;
+        }
         let (execution_result, evm_state) = {
             let mut evm = self.evm_with_env(&mut *db, evm_env);
             for (addr, precompile) in precompiles {

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -269,6 +269,19 @@ where
         precompiles: Vec<(Address, DynPrecompile)>,
         tx_env: TxEnv,
     ) -> Result<ExecutionResult<HaltReason>, Self::Error> {
+        // Epsilon: system transactions are gas-exempt — no base-fee charge and no balance
+        // requirement on SYSTEM_CALLER (gas is still metered). This is the exact mirror of the
+        // serial `EthEvmConfig::transact_system_txn`; the two MUST stay in lockstep or system-tx
+        // blocks fork the state root. Compute the gate before borrowing `self.state` mutably.
+        let mut evm_env = evm_env;
+        if self
+            .chain_spec
+            .gravity_hardforks()
+            .is_fork_active_at_timestamp(GravityHardfork::Epsilon, evm_env.block_env.timestamp)
+        {
+            evm_env.cfg_env.disable_base_fee = true;
+            evm_env.cfg_env.disable_balance_check = true;
+        }
         let state = self.state.as_mut().unwrap();
         // Phase 1: execute with WrapDatabaseRef(state).
         let (execution_result, evm_state) = {

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -274,13 +274,14 @@ where
         // serial `EthEvmConfig::transact_system_txn`; the two MUST stay in lockstep or system-tx
         // blocks fork the state root. Compute the gate before borrowing `self.state` mutably.
         let mut evm_env = evm_env;
-        if self
-            .chain_spec
-            .gravity_hardforks()
-            .is_fork_active_at_timestamp(GravityHardfork::Epsilon, evm_env.block_env.timestamp)
-        {
+        let mut tx_env = tx_env;
+        if self.chain_spec.gravity_hardforks().is_fork_active_at_timestamp(
+            GravityHardfork::Epsilon,
+            evm_env.block_env.timestamp.saturating_to(),
+        ) {
             evm_env.cfg_env.disable_base_fee = true;
-            evm_env.cfg_env.disable_balance_check = true;
+            tx_env.gas_price = 0;
+            tx_env.gas_priority_fee = None;
         }
         let state = self.state.as_mut().unwrap();
         // Phase 1: execute with WrapDatabaseRef(state).

--- a/crates/pipe-exec-layer-ext-v2/execute/src/epsilon.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/epsilon.rs
@@ -1,0 +1,68 @@
+//! Epsilon (Gravity) — zero `SYSTEM_CALLER`'s sentinel balance.
+//!
+//! `SYSTEM_CALLER` (`0x…01625f0000`) is pre-funded in genesis with a sentinel "infinite" balance
+//! so it could pay the base fee of the per-block system transactions. Once the Epsilon hardfork
+//! makes system transactions gas-exempt (`EthEvmConfig::transact_system_txn` /
+//! `GrevmExecutor::transact_system_txn`), that balance is unused — and the sentinel is a
+//! supply-accounting wart plus an unbounded-mint footgun. Zero it on the Epsilon activation block.
+//!
+//! Mirrors `eip_2935`: a one-time irregular state change applied via the executor's
+//! backend-agnostic [`ParallelExecutor::apply_state_change`], gated by `transitions_at_timestamp`
+//! so it fires exactly once and is reorg-safe. See gravity-reth#364 / gravity-audit#720.
+
+use crate::onchain_config::SYSTEM_CALLER;
+use alloy_primitives::U256;
+use reth_chainspec::{ChainSpec, EthChainSpec, GravityHardfork, Hardforks};
+use reth_evm::{execute::BlockExecutionError, parallel_execute::ParallelExecutor};
+use reth_primitives::EthPrimitives;
+use revm::state::{Account, AccountInfo, AccountStatus, EvmState};
+use tracing::info;
+
+type Executor<'a> =
+    &'a mut dyn ParallelExecutor<Primitives = EthPrimitives, Error = BlockExecutionError>;
+
+/// Zero `SYSTEM_CALLER`'s balance on the Epsilon activation block.
+///
+/// `system_caller_nonce` is `SYSTEM_CALLER`'s nonce at the start of this block (before the system
+/// transactions run); it is preserved so the account stays non-empty (nonce > 0 → not pruned by
+/// EIP-161 state-clear) and its transaction sequence continues unbroken. The account has no code
+/// and no storage, so a full replacement with `balance = 0` is exact.
+///
+/// Idempotency/reorg-safety comes from `transitions_at_timestamp` (a parent below the fork time is
+/// history-immutable), so the zeroing fires exactly on the activation block.
+pub(crate) fn apply_state_changes_for_block(
+    executor: Executor<'_>,
+    chain_spec: &ChainSpec,
+    current_ts: u64,
+    parent_ts: u64,
+    system_caller_nonce: u64,
+    block_number: u64,
+) {
+    if chain_spec
+        .gravity_hardforks()
+        .fork(GravityHardfork::Epsilon)
+        .transitions_at_timestamp(current_ts, parent_ts)
+    {
+        let mut state_diff = EvmState::default();
+        state_diff.insert(
+            SYSTEM_CALLER,
+            Account {
+                info: AccountInfo {
+                    nonce: system_caller_nonce,
+                    balance: U256::ZERO,
+                    ..Default::default()
+                },
+                storage: Default::default(),
+                status: AccountStatus::Touched,
+                transaction_id: 0,
+            },
+        );
+        executor.apply_state_change(state_diff).unwrap_or_else(|e| {
+            panic!("zeroing SYSTEM_CALLER balance failed at Epsilon activation: {e:?}")
+        });
+        info!(target: "execute_ordered_block",
+            number=?block_number,
+            "zeroed SYSTEM_CALLER balance on Epsilon activation block"
+        );
+    }
+}

--- a/crates/pipe-exec-layer-ext-v2/execute/src/epsilon.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/epsilon.rs
@@ -12,7 +12,7 @@
 
 use crate::onchain_config::SYSTEM_CALLER;
 use alloy_primitives::U256;
-use reth_chainspec::{ChainSpec, EthChainSpec, GravityHardfork, Hardforks};
+use reth_chainspec::{ChainSpec, EthChainSpec, GravityHardfork};
 use reth_evm::{execute::BlockExecutionError, parallel_execute::ParallelExecutor};
 use reth_primitives::EthPrimitives;
 use revm::state::{Account, AccountInfo, AccountStatus, EvmState};

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -3,6 +3,7 @@
 mod channel;
 pub mod bls_precompile;
 mod eip_2935;
+mod epsilon;
 mod metrics;
 pub mod mint_precompile;
 pub mod onchain_config;
@@ -1064,6 +1065,18 @@ impl<Storage: GravityStorage> Core<Storage> {
             &self.chain_spec,
             ordered_block.timestamp_us / 1_000_000,
             parent_header.timestamp,
+            block_number,
+        );
+
+        // Epsilon (Gravity) boundary state change: zero SYSTEM_CALLER's sentinel balance on the
+        // Epsilon activation block. `initial_nonce` is SYSTEM_CALLER's nonce before the system
+        // txns run; gated by `transitions_at_timestamp` so it fires exactly once. See `epsilon`.
+        epsilon::apply_state_changes_for_block(
+            &mut *executor,
+            &self.chain_spec,
+            ordered_block.timestamp_us / 1_000_000,
+            parent_header.timestamp,
+            initial_nonce,
             block_number,
         );
 

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_epsilon_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_epsilon_test.rs
@@ -1,0 +1,341 @@
+#![allow(missing_docs)]
+
+//! Integration test for the **Epsilon** Gravity hardfork (gravity-reth#364 / gravity-audit#720).
+//!
+//! Boots a single reth node from `gravity_hardfork.json` patched with a per-test `epsilonTime`,
+//! drives `MockConsensus + PipeExecLayerApi` across the activation boundary, and asserts that
+//! `SYSTEM_CALLER`'s sentinel balance is positive pre-fork and exactly **zero** from the activation
+//! block onward, with its nonce preserved (the account survives as an identity). Run on BOTH the
+//! grevm and the serial (`WrapExecutor`) backends — they must agree.
+
+use alloy_primitives::{address, Address, B256, U256};
+use alloy_rpc_types_eth::TransactionRequest;
+use gravity_api_types::{
+    config_storage::{BlockNumber, ConfigStorage, OnChainConfig},
+    events::contract_event::GravityEvent,
+};
+use gravity_storage::{block_view_storage::BlockViewStorage, GravityStorage};
+use reth_chainspec::{ChainSpec, EthChainSpec, GravityHardfork};
+use reth_cli_commands::{launcher::FnLauncher, NodeCommand};
+use reth_cli_runner::CliRunner;
+use reth_db::DatabaseEnv;
+use reth_ethereum_cli::chainspec::EthereumChainSpecParser;
+use reth_node_builder::{EngineNodeLauncher, NodeBuilder, WithLaunchContext};
+use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
+use reth_pipe_exec_layer_ext_v2::{
+    new_pipe_exec_layer_api, ExecutionArgs, OrderedBlock, PipeExecLayerApi,
+};
+use reth_provider::{
+    providers::BlockchainProvider, BlockHashReader, BlockNumReader, DatabaseProviderFactory,
+    HeaderProvider, StateProviderFactory,
+};
+use reth_rpc_eth_api::{helpers::EthCall, RpcTypes};
+use reth_tracing::{
+    tracing_subscriber::filter::LevelFilter, LayerInfo, LogFormat, RethTracer, Tracer,
+};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+/// SYSTEM_CALLER — the system-transaction sender, funded with a sentinel balance in genesis.
+const SYSTEM_CALLER: Address = address!("00000000000000000000000000000001625f0000");
+
+/// Block N is pushed with `timestamp = TS_BASE + N` (seconds), so `epsilonTime = TS_BASE +
+/// ACTIVATION_BLOCK` makes block `ACTIVATION_BLOCK` the activation block (its parent's ts is
+/// `epsilonTime - 1`, its own ts is `epsilonTime` ⇒ `transitions_at_timestamp` fires once).
+const TS_BASE: u64 = 2_000_000_000;
+const ACTIVATION_BLOCK: u64 = 10;
+const EPSILON_TS: u64 = TS_BASE + ACTIVATION_BLOCK;
+/// Drive a few blocks past the boundary to prove the balance stays zero (gas-exempt).
+const TARGET_BLOCK_COUNT: u64 = ACTIVATION_BLOCK + 4;
+
+/// Load `gravity_hardfork.json` and patch `config.epsilonTime`. SYSTEM_CALLER is already funded
+/// with the sentinel balance in that genesis, so nothing else needs preloading.
+fn gravity_epsilon_chainspec(epsilon_time: Option<u64>) -> String {
+    let mut json: serde_json::Value =
+        serde_json::from_str(include_str!("../gravity_hardfork.json"))
+            .expect("gravity_hardfork.json must parse as JSON");
+    if let Some(ts) = epsilon_time {
+        json["config"]["epsilonTime"] = serde_json::json!(ts);
+    }
+    json.to_string()
+}
+
+fn mock_block_id(block_number: u64) -> B256 {
+    B256::left_padding_from(&block_number.to_be_bytes())
+}
+
+fn ts_for_block(block_number: u64) -> u64 {
+    (TS_BASE + block_number) * 1_000_000
+}
+
+fn new_ordered_block(
+    epoch: u64,
+    block_number: u64,
+    block_id: B256,
+    parent_block_id: B256,
+    timestamp_us: u64,
+) -> OrderedBlock {
+    OrderedBlock {
+        failed_proposer_indices: vec![],
+        epoch,
+        parent_id: parent_block_id,
+        id: block_id,
+        number: block_number,
+        timestamp_us,
+        coinbase: Address::ZERO,
+        prev_randao: B256::ZERO,
+        withdrawals: Default::default(),
+        transactions: vec![],
+        senders: vec![],
+        proposer_index: Some(0),
+        extra_data: vec![],
+        randomness: U256::ZERO,
+    }
+}
+
+type TimestampFn = Box<dyn Fn(u64) -> u64 + Send + Sync>;
+
+struct MockConsensus<Storage, EthApi> {
+    pipeline_api: PipeExecLayerApi<Storage, EthApi>,
+    target_block_count: u64,
+    ts_for_block: TimestampFn,
+}
+
+impl<Storage, EthApi> MockConsensus<Storage, EthApi>
+where
+    Storage: GravityStorage,
+    EthApi: EthCall,
+    EthApi::NetworkTypes: RpcTypes<TransactionRequest = TransactionRequest>,
+{
+    fn new(
+        pipeline_api: PipeExecLayerApi<Storage, EthApi>,
+        target_block_count: u64,
+        ts_for_block: TimestampFn,
+    ) -> Self {
+        Self { pipeline_api, target_block_count, ts_for_block }
+    }
+
+    async fn run(self, latest_block_number: u64) {
+        let Self { pipeline_api, target_block_count, ts_for_block } = self;
+        let mut epoch: u64 = pipeline_api
+            .fetch_config_bytes(OnChainConfig::Epoch, BlockNumber::Latest)
+            .unwrap()
+            .try_into()
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let target_block = latest_block_number + target_block_count;
+        for block_number in latest_block_number + 1..=target_block {
+            let block_id = mock_block_id(block_number);
+            let parent_block_id = mock_block_id(block_number - 1);
+            let timestamp_us = ts_for_block(block_number);
+            pipeline_api
+                .push_ordered_block(new_ordered_block(
+                    epoch,
+                    block_number,
+                    block_id,
+                    parent_block_id,
+                    timestamp_us,
+                ))
+                .unwrap();
+            let result = pipeline_api.pull_executed_block_hash().await.unwrap();
+            assert_eq!(result.block_number, block_number);
+            assert_eq!(result.block_id, block_id);
+            pipeline_api.commit_executed_block_hash(block_id, Some(result.block_hash)).unwrap();
+
+            // Bump epoch on NewEpoch events so the pipeline stays live (mirrors the other
+            // hardfork integration tests).
+            for event in &result.gravity_events {
+                if let GravityEvent::NewEpoch(new_epoch, _) = event {
+                    assert_eq!(*new_epoch, epoch + 1);
+                    pipeline_api.wait_for_block_persistence(block_number).await.unwrap();
+                    pipeline_api
+                        .push_ordered_block(new_ordered_block(
+                            epoch,
+                            block_number + 1,
+                            mock_block_id(block_number + 1),
+                            block_id,
+                            ts_for_block(block_number + 1),
+                        ))
+                        .unwrap();
+                    epoch = *new_epoch;
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+}
+
+fn system_caller_account<P: StateProviderFactory>(
+    provider: &P,
+    block_number: u64,
+) -> (U256, u64) {
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(block_number))
+        .expect("state provider for SYSTEM_CALLER");
+    state
+        .basic_account(&SYSTEM_CALLER)
+        .expect("read basic_account")
+        .map(|a| (a.balance, a.nonce))
+        .unwrap_or((U256::ZERO, 0))
+}
+
+async fn run_pipe_epsilon(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<()> {
+    let handle = builder
+        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+        .with_components(EthereumNode::components())
+        .with_add_ons(EthereumAddOns::default())
+        .launch_with_fn(|builder| {
+            let launcher = EngineNodeLauncher::new(
+                builder.task_executor().clone(),
+                builder.config().datadir(),
+                reth_engine_primitives::TreeConfig::default(),
+            );
+            builder.launch_with(launcher)
+        })
+        .await?;
+
+    let chain_spec = handle.node.chain_spec();
+
+    // epsilonTime parsed ⇒ Epsilon transitions exactly on ACTIVATION_BLOCK's timestamp.
+    assert!(
+        chain_spec
+            .gravity_hardforks()
+            .fork(GravityHardfork::Epsilon)
+            .transitions_at_timestamp(EPSILON_TS, EPSILON_TS - 1),
+        "Epsilon must transition at epsilonTime={EPSILON_TS}"
+    );
+
+    let eth_api = handle.node.rpc_registry.eth_api().clone();
+    let provider = handle.node.provider;
+
+    let db_provider = provider.database_provider_ro().unwrap();
+    let latest_block_number = db_provider.best_block_number().unwrap();
+    let latest_block_hash = db_provider.block_hash(latest_block_number).unwrap().unwrap();
+    let latest_block_header = db_provider.header_by_number(latest_block_number).unwrap().unwrap();
+    drop(db_provider);
+
+    let storage = BlockViewStorage::new(provider.clone());
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let pipeline_api = new_pipe_exec_layer_api(
+        chain_spec,
+        storage,
+        latest_block_header,
+        latest_block_hash,
+        rx,
+        eth_api,
+    );
+    tx.send(ExecutionArgs { block_number_to_block_id: BTreeMap::new() }).unwrap();
+
+    let consensus = MockConsensus::new(pipeline_api, TARGET_BLOCK_COUNT, Box::new(ts_for_block));
+    consensus.run(latest_block_number).await;
+
+    let before = ACTIVATION_BLOCK - 1;
+    let after = ACTIVATION_BLOCK + 4;
+    let (bal_before, _) = system_caller_account(&provider, before);
+    let (bal_at, nonce_at) = system_caller_account(&provider, ACTIVATION_BLOCK);
+    let (bal_after, _) = system_caller_account(&provider, after);
+
+    println!(
+        "[epsilon_test] SYSTEM_CALLER balance: block {before}={bal_before}, block {ACTIVATION_BLOCK}={bal_at}, block {after}={bal_after}; nonce@{ACTIVATION_BLOCK}={nonce_at}"
+    );
+
+    assert!(
+        bal_before > U256::ZERO,
+        "SYSTEM_CALLER must be funded pre-fork at block {before}, got {bal_before}"
+    );
+    assert_eq!(
+        bal_at,
+        U256::ZERO,
+        "SYSTEM_CALLER balance must be zeroed at Epsilon activation block {ACTIVATION_BLOCK}, got {bal_at}"
+    );
+    assert_eq!(
+        bal_after,
+        U256::ZERO,
+        "SYSTEM_CALLER must stay zero post-fork at block {after}, got {bal_after}"
+    );
+    assert!(
+        nonce_at > 0,
+        "SYSTEM_CALLER nonce must be preserved (>0) at block {ACTIVATION_BLOCK} — kept as identity"
+    );
+
+    println!(
+        "[epsilon_test] ✅ SYSTEM_CALLER zeroed at Epsilon activation, stayed zero post-fork, nonce preserved."
+    );
+    Ok(())
+}
+
+#[test]
+fn test_epsilon_zeroes_system_caller_grevm() {
+    run_pipe_e2e_test(
+        &gravity_epsilon_chainspec(Some(EPSILON_TS)),
+        "data/gravity_epsilon_grevm_test",
+        false,
+        run_pipe_epsilon,
+    );
+}
+
+#[test]
+fn test_epsilon_zeroes_system_caller_disable_grevm() {
+    run_pipe_e2e_test(
+        &gravity_epsilon_chainspec(Some(EPSILON_TS)),
+        "data/gravity_epsilon_disable_grevm_test",
+        true,
+        run_pipe_epsilon,
+    );
+}
+
+// `run_pipe_e2e_test` is the single entry point each #[test] dispatches through: it builds the
+// NodeCommand CLI args, optionally appending `--gravity.disable-grevm`, and drives the CliRunner —
+// so each case is sampled twice, once on the grevm path and once on the WrapExecutor path. The
+// datadir is wiped first so re-runs are deterministic.
+fn run_pipe_e2e_test<F, Fut>(chain_spec: &str, datadir: &'static str, disable_grevm: bool, run_fn: F)
+where
+    F: FnOnce(WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>) -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = eyre::Result<()>> + Send + 'static,
+{
+    init_panic_hook_and_tracer();
+    let _ = std::fs::remove_dir_all(datadir);
+
+    let runner = CliRunner::try_default_runtime().unwrap();
+    let mut args: Vec<&str> =
+        vec!["reth", "--chain", chain_spec, "--with-unused-ports", "--dev", "--datadir", datadir];
+    if disable_grevm {
+        args.push("--gravity.disable-grevm");
+    }
+    let command: NodeCommand<EthereumChainSpecParser> =
+        NodeCommand::try_parse_args_from(args).unwrap();
+
+    runner
+        .run_command_until_exit(|ctx| {
+            command.execute(
+                ctx,
+                FnLauncher::new::<EthereumChainSpecParser, _>(|builder, _| async move {
+                    run_fn(builder).await
+                }),
+            )
+        })
+        .unwrap();
+
+    std::thread::sleep(Duration::from_secs(2));
+}
+
+fn init_panic_hook_and_tracer() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        let backtrace = std::backtrace::Backtrace::capture();
+        eprintln!("Panic occurred: {panic_info}\nBacktrace:\n{backtrace}");
+        std::process::exit(1);
+    }));
+
+    let _ = RethTracer::new()
+        .with_stdout(LayerInfo::new(
+            LogFormat::Terminal,
+            LevelFilter::INFO.to_string(),
+            String::new(),
+            Some("always".to_string()),
+        ))
+        .init();
+}

--- a/docs/design/system-tx-gas-exempt.md
+++ b/docs/design/system-tx-gas-exempt.md
@@ -60,26 +60,30 @@ skipped. Reuses the revm cfg flags already used in `rpc-eth-api` (eth_call / est
 At the Epsilon activation block, perform a deterministic state write `SYSTEM_CALLER.balance = 0`.
 The nonce is preserved (> 0 → not empty → not pruned by EIP-161 state-clear).
 
-**Status: TODO** — apply alongside the existing Gravity hardfork-transition mechanism
-(`crates/ethereum/evm/src/hardfork/common.rs::apply_hardfork_upgrades`, invoked from
-`apply_post_execution_changes`), or a dedicated pre-execution hook at the transition block. Must be
-applied identically in the serial and grevm pre/post-execution paths.
+**Status: implemented** — `crates/pipe-exec-layer-ext-v2/execute/src/epsilon.rs`, applied via the
+backend-agnostic `ParallelExecutor::apply_state_change` in `execute_ordered_block` (right after the
+EIP-2935 boundary change it mirrors). One call site → serial (`WrapExecutor`) and grevm get the
+identical change, no per-backend duplication. The activation time is parsed from genesis
+`epsilonTime` → `GravityHardfork::Epsilon` (`crates/chainspec/src/spec.rs`).
 
 ## Correctness checklist
 
 - [x] serial + grevm `transact_system_txn` gas-exempt gate (Epsilon) — kept in lockstep (cf. #363)
-- [ ] zero `SYSTEM_CALLER.balance` at the Epsilon transition block (both backends)
+- [x] zero `SYSTEM_CALLER.balance` at the Epsilon transition block (single backend-agnostic call)
+- [x] `epsilonTime` genesis wiring → `GravityHardfork::Epsilon` (unit-tested) — else fork is inert
+- [x] nonce preserved (account stays non-empty / EIP-161), no code/storage on the account
 - [ ] confirm no contract/logic depends on `SYSTEM_CALLER`'s balance (it is an identity /
       `msg.sender`, not funds)
-- [ ] nonce sequence preserved, receipts unchanged
-- [ ] coinbase unaffected (already no tip)
-- [ ] gas limit still enforced (free != unbounded)
-- [ ] fork-gated; pre-fork behavior unchanged
+- [ ] coinbase unaffected (already no tip) — confirm in e2e
+- [ ] gas limit still enforced (free != unbounded) — confirm in e2e
+- [x] fork-gated; pre-fork behavior unchanged (gates default false with no `epsilonTime`)
 
 ## Test & rollout
 
-- [ ] e2e (testnet first): after fork — balance stays 0, system txs execute with correct receipts,
-      no base fee burned, **serial == grevm state root**, nonce continuity, deterministic balance
-      zeroing at the transition block, total supply returns to the real value
+- [x] unit: `epsilonTime` parsing + activation/transition semantics (`spec.rs` tests)
+- [ ] e2e (testnet first, mirror `gravity_eip2935_test`): after fork — balance stays 0, system txs
+      execute with correct receipts, no base fee burned, **serial == grevm state root**, nonce
+      continuity, deterministic balance zeroing at the transition block, total supply returns to the
+      real value
 - [ ] staging → mainnet via the hardfork SOP (single PR + atomic image swap + >=24h lead, new fork
       activation time)

--- a/docs/design/system-tx-gas-exempt.md
+++ b/docs/design/system-tx-gas-exempt.md
@@ -1,0 +1,61 @@
+# System Transactions: gas-exempt + zero-balance SYSTEM_CALLER
+
+> **Status: Draft / skeleton.** 实现追踪 [gravity-reth#364](https://github.com/Galxe/gravity-reth/issues/364) ·
+> 分析 [gravity-audit#720](https://github.com/Galxe/gravity-audit/issues/720)。
+> 本文件是 hardfork 实现的设计骨架,代码尚未落地(见下方落点地图 + checklist)。
+
+## 问题
+
+系统交易发送账户 `SYSTEM_CALLER`（`0x00000000000000000000000000000001625f0000`）在 genesis 被预分配「哨兵级无穷大」余额（≈ 1.16×10⁵⁸ G），用来支付每块系统交易的 base fee（实测系统 tx `gas_price=baseFee`、无 tip，base fee 从该账户余额烧掉 ~0.006 G/块）。
+
+虽然已验证假供应未流通、footgun 未触发,但带来 4 个问题:污染供应核算 / 增发 footgun（任何余额外流的 bug = 无上限增发真 G）/ 为系统 tx 从假账户烧 base fee / 软不变量。
+
+## 生产先例
+
+| 维度 | EIP-4788/2935 | Arbitrum `0x6a` ArbInternalTx | Gravity 现状 | 本方案 |
+| --- | --- | --- | --- | --- |
+| receipt / 入块可见 | 无（幽灵） | 有（实测 status=0x1） | 有 | 保留 |
+| nonce 自增 | 否 | 否（恒 0，from=`0xA4B05`） | 是（≈块高） | 是（保留；可选改静态） |
+| gas / fee | 免费、计量 | 全免（gasPrice/gasUsed=0） | 收 base fee（烧假余额） | 免费、计量 |
+| 发送方余额 | 0 | 0 | 1.16×10⁵⁸ 哨兵 | fork 后清 0 |
+
+费用语义与 4788/2935 一致;与 Arbitrum 最接近（真交易 + receipt + 完全免费 + 零余额）。
+
+## 方案（必须 hardfork —— 改状态根,须全节点在同一 fork 高度原子切换）
+
+### ① 执行层:系统 tx 免 fee/balance（保留 gas 计量）
+
+fork 激活后,对系统 tx 的 EVM env:
+- `cfg_env.disable_base_fee = true`
+- `cfg_env.disable_balance_check = true`
+- 系统 tx `gas_price = 0`
+- `disable_nonce_check` 保持 `false`（nonce 序列照常自增）
+
+执行 / calldata / state / receipt / gas_used 全照旧,只是不记账收费。复用仓库已有的 revm cfg 标志。
+
+### ② 状态迁移:fork 块把 SYSTEM_CALLER 余额清 0
+
+fork 激活块做一次确定性状态写 `SYSTEM_CALLER.balance = 0`。nonce 保留（>0 → 非空,不被 EIP-161 裁剪）。
+
+## 代码落点地图（实现者参考）
+
+| 改动点 | 位置 |
+| --- | --- |
+| `SYSTEM_CALLER` 常量 | `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/mod.rs:55` |
+| 系统 tx 执行（设 cfg 标志）| `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs` → `transact_system_txn` |
+| serial 后端系统 tx 路径 | `crates/ethereum/evm/src/lib.rs`（#363 在此加 `set_state_clear_flag`,同处加 fee/balance 豁免）|
+| grevm 并行后端系统 tx 路径 | `crates/ethereum/evm/src/parallel_execute.rs`（**必须同 serial 一起改**，否则状态根分叉）|
+| revm cfg 标志参考用法 | `crates/rpc/rpc-eth-api/src/helpers/call.rs`（`disable_base_fee` / `disable_nonce_check` 已在用）|
+| fork 块清零余额 | block 执行的 `apply_pre_execution_changes` / fork hook |
+| hardfork 注册 | chainspec 的 fork time（参考 `pragueTime` 接法）|
+
+## Checklist
+
+- [ ] serial（disable-grevm）与 grevm 两路同样改（同 #363，否则系统-tx 块状态根分叉）
+- [ ] 确认无合约/逻辑依赖 SYSTEM_CALLER 余额（它是身份 `msg.sender`，非钱）
+- [ ] nonce 序列保持、receipt 不变
+- [ ] coinbase 不受影响（本就无 tip）
+- [ ] gas 上限仍在（免费 != 不限制）
+- [ ] fork 门控 + pre-fork 行为不变
+- [ ] e2e（testnet）：fork 后余额恒 0、系统 tx 执行+receipt 正确、无 base fee、serial==parallel 状态根、nonce 连续、fork-transition 块确定性清零、总供应量回真实值
+- [ ] staging → mainnet 走 hardfork SOP（单 PR + atomic image swap + >=24h lead）

--- a/docs/design/system-tx-gas-exempt.md
+++ b/docs/design/system-tx-gas-exempt.md
@@ -43,13 +43,14 @@ receipt + fully free + zero balance).
 
 When the Epsilon fork is active at the block timestamp, set on the system-tx EVM env:
 
-- `cfg_env.disable_base_fee = true`
-- `cfg_env.disable_balance_check = true`
-- (`gas_price = 0` optional; the tip is already 0)
-- keep `disable_nonce_check = false` (the nonce sequence keeps incrementing)
+- `cfg_env.disable_base_fee = true` — allow a gas price below the base fee.
+- `tx_env.gas_price = 0`, `tx_env.gas_priority_fee = None` — the system tx pays **nothing**, so it
+  needs no balance and burns nothing (which is the whole point). revm's `CfgEnv` has no
+  `disable_balance_check` field, and a zero price makes one unnecessary.
+- keep `disable_nonce_check = false` (the nonce sequence keeps incrementing).
 
 Execution / calldata / state / receipts / `gas_used` are unchanged — only fee accounting is
-skipped. Reuses the revm cfg flags already used in `rpc-eth-api` (eth_call / estimate / prewarm).
+skipped. Same fee-less semantics `rpc-eth-api` already uses for eth_call / estimate.
 
 **Status: implemented** in both backends (must stay in lockstep):
 - serial: `crates/ethereum/evm/src/lib.rs` → `EthEvmConfig::transact_system_txn`

--- a/docs/design/system-tx-gas-exempt.md
+++ b/docs/design/system-tx-gas-exempt.md
@@ -1,61 +1,85 @@
 # System Transactions: gas-exempt + zero-balance SYSTEM_CALLER
 
-> **Status: Draft / skeleton.** 实现追踪 [gravity-reth#364](https://github.com/Galxe/gravity-reth/issues/364) ·
-> 分析 [gravity-audit#720](https://github.com/Galxe/gravity-audit/issues/720)。
-> 本文件是 hardfork 实现的设计骨架,代码尚未落地(见下方落点地图 + checklist)。
+> Implementation tracking: [gravity-reth#364](https://github.com/Galxe/gravity-reth/issues/364) ·
+> analysis: [gravity-audit#720](https://github.com/Galxe/gravity-audit/issues/720).
+> Gated behind the **Epsilon** Gravity hardfork — inert until a chainspec/genesis sets its
+> activation time.
 
-## 问题
+## Problem
 
-系统交易发送账户 `SYSTEM_CALLER`（`0x00000000000000000000000000000001625f0000`）在 genesis 被预分配「哨兵级无穷大」余额（≈ 1.16×10⁵⁸ G），用来支付每块系统交易的 base fee（实测系统 tx `gas_price=baseFee`、无 tip，base fee 从该账户余额烧掉 ~0.006 G/块）。
+The system-transaction sender `SYSTEM_CALLER` (`0x00000000000000000000000000000001625f0000`,
+defined in `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/mod.rs`) is pre-funded in
+genesis with a sentinel "infinite" balance (≈ 1.16e58 G) so it can pay the base fee of the system
+transactions the protocol injects every block. On-chain measurement: each system tx has
+`gas_price = baseFee` with no tip, so its base fee is burned from `SYSTEM_CALLER`'s balance
+(~0.006 G/block; the balance only decreases).
 
-虽然已验证假供应未流通、footgun 未触发,但带来 4 个问题:污染供应核算 / 增发 footgun（任何余额外流的 bug = 无上限增发真 G）/ 为系统 tx 从假账户烧 base fee / 软不变量。
+The fake supply has been verified **not** to circulate and the footgun has **not** fired, but the
+design carries four issues:
 
-## 生产先例
+1. **Supply-accounting pollution** — every total/circulating-supply computation must special-case
+   the 1.16e58 sentinel.
+2. **Unbounded-mint footgun** — any bug that lets value leave this account mints real G without
+   bound.
+3. **Conceptual muddle** — base fee is burned from a fake account for the protocol's own txs.
+4. **Soft invariant** — relies on "1e58 never runs out" instead of a hard "system txs are gas-free"
+   rule.
 
-| 维度 | EIP-4788/2935 | Arbitrum `0x6a` ArbInternalTx | Gravity 现状 | 本方案 |
+## Production precedents
+
+| | EIP-4788/2935 | Arbitrum `0x6a` ArbInternalTx | Gravity (today) | This change |
 | --- | --- | --- | --- | --- |
-| receipt / 入块可见 | 无（幽灵） | 有（实测 status=0x1） | 有 | 保留 |
-| nonce 自增 | 否 | 否（恒 0，from=`0xA4B05`） | 是（≈块高） | 是（保留；可选改静态） |
-| gas / fee | 免费、计量 | 全免（gasPrice/gasUsed=0） | 收 base fee（烧假余额） | 免费、计量 |
-| 发送方余额 | 0 | 0 | 1.16×10⁵⁸ 哨兵 | fork 后清 0 |
+| Receipt / visible in block | none (phantom) | yes (`status=0x1`) | yes | kept |
+| Sender nonce increments | no | no (stays 0, `0xA4B05`) | yes (≈ height) | yes (kept; static optional) |
+| Gas / fee | free, metered | fully free (`gasUsed=0`) | charges base fee | free, metered |
+| Sender balance | 0 | 0 | 1.16e58 sentinel | zeroed at fork |
 
-费用语义与 4788/2935 一致;与 Arbitrum 最接近（真交易 + receipt + 完全免费 + 零余额）。
+The fee semantics match EIP-4788/2935's `SYSTEM_ADDRESS` pattern; closest to Arbitrum (real tx +
+receipt + fully free + zero balance).
 
-## 方案（必须 hardfork —— 改状态根,须全节点在同一 fork 高度原子切换）
+## Plan (hardfork — changes the state root, must switch atomically across all nodes)
 
-### ① 执行层:系统 tx 免 fee/balance（保留 gas 计量）
+### 1. Execution layer: gas-exempt system txs (gas still metered)
 
-fork 激活后,对系统 tx 的 EVM env:
+When the Epsilon fork is active at the block timestamp, set on the system-tx EVM env:
+
 - `cfg_env.disable_base_fee = true`
 - `cfg_env.disable_balance_check = true`
-- 系统 tx `gas_price = 0`
-- `disable_nonce_check` 保持 `false`（nonce 序列照常自增）
+- (`gas_price = 0` optional; the tip is already 0)
+- keep `disable_nonce_check = false` (the nonce sequence keeps incrementing)
 
-执行 / calldata / state / receipt / gas_used 全照旧,只是不记账收费。复用仓库已有的 revm cfg 标志。
+Execution / calldata / state / receipts / `gas_used` are unchanged — only fee accounting is
+skipped. Reuses the revm cfg flags already used in `rpc-eth-api` (eth_call / estimate / prewarm).
 
-### ② 状态迁移:fork 块把 SYSTEM_CALLER 余额清 0
+**Status: implemented** in both backends (must stay in lockstep):
+- serial: `crates/ethereum/evm/src/lib.rs` → `EthEvmConfig::transact_system_txn`
+- grevm: `crates/ethereum/evm/src/parallel_execute.rs` → `GrevmExecutor::transact_system_txn`
 
-fork 激活块做一次确定性状态写 `SYSTEM_CALLER.balance = 0`。nonce 保留（>0 → 非空,不被 EIP-161 裁剪）。
+### 2. State migration: zero `SYSTEM_CALLER`'s balance at the fork block
 
-## 代码落点地图（实现者参考）
+At the Epsilon activation block, perform a deterministic state write `SYSTEM_CALLER.balance = 0`.
+The nonce is preserved (> 0 → not empty → not pruned by EIP-161 state-clear).
 
-| 改动点 | 位置 |
-| --- | --- |
-| `SYSTEM_CALLER` 常量 | `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/mod.rs:55` |
-| 系统 tx 执行（设 cfg 标志）| `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs` → `transact_system_txn` |
-| serial 后端系统 tx 路径 | `crates/ethereum/evm/src/lib.rs`（#363 在此加 `set_state_clear_flag`,同处加 fee/balance 豁免）|
-| grevm 并行后端系统 tx 路径 | `crates/ethereum/evm/src/parallel_execute.rs`（**必须同 serial 一起改**，否则状态根分叉）|
-| revm cfg 标志参考用法 | `crates/rpc/rpc-eth-api/src/helpers/call.rs`（`disable_base_fee` / `disable_nonce_check` 已在用）|
-| fork 块清零余额 | block 执行的 `apply_pre_execution_changes` / fork hook |
-| hardfork 注册 | chainspec 的 fork time（参考 `pragueTime` 接法）|
+**Status: TODO** — apply alongside the existing Gravity hardfork-transition mechanism
+(`crates/ethereum/evm/src/hardfork/common.rs::apply_hardfork_upgrades`, invoked from
+`apply_post_execution_changes`), or a dedicated pre-execution hook at the transition block. Must be
+applied identically in the serial and grevm pre/post-execution paths.
 
-## Checklist
+## Correctness checklist
 
-- [ ] serial（disable-grevm）与 grevm 两路同样改（同 #363，否则系统-tx 块状态根分叉）
-- [ ] 确认无合约/逻辑依赖 SYSTEM_CALLER 余额（它是身份 `msg.sender`，非钱）
-- [ ] nonce 序列保持、receipt 不变
-- [ ] coinbase 不受影响（本就无 tip）
-- [ ] gas 上限仍在（免费 != 不限制）
-- [ ] fork 门控 + pre-fork 行为不变
-- [ ] e2e（testnet）：fork 后余额恒 0、系统 tx 执行+receipt 正确、无 base fee、serial==parallel 状态根、nonce 连续、fork-transition 块确定性清零、总供应量回真实值
-- [ ] staging → mainnet 走 hardfork SOP（单 PR + atomic image swap + >=24h lead）
+- [x] serial + grevm `transact_system_txn` gas-exempt gate (Epsilon) — kept in lockstep (cf. #363)
+- [ ] zero `SYSTEM_CALLER.balance` at the Epsilon transition block (both backends)
+- [ ] confirm no contract/logic depends on `SYSTEM_CALLER`'s balance (it is an identity /
+      `msg.sender`, not funds)
+- [ ] nonce sequence preserved, receipts unchanged
+- [ ] coinbase unaffected (already no tip)
+- [ ] gas limit still enforced (free != unbounded)
+- [ ] fork-gated; pre-fork behavior unchanged
+
+## Test & rollout
+
+- [ ] e2e (testnet first): after fork — balance stays 0, system txs execute with correct receipts,
+      no base fee burned, **serial == grevm state root**, nonce continuity, deterministic balance
+      zeroing at the transition block, total supply returns to the real value
+- [ ] staging → mainnet via the hardfork SOP (single PR + atomic image swap + >=24h lead, new fork
+      activation time)


### PR DESCRIPTION
Eliminates the `SYSTEM_CALLER` sentinel "infinite" balance (≈1.16e58 G) that the protocol currently burns base fee from for its per-block system transactions — removing the supply-accounting pollution, the unbounded-mint footgun, and the burn-from-fake-account muddle (gravity-audit#720). Gated behind a new **Epsilon** Gravity hardfork (inert until a genesis sets `epsilonTime`).

### Implemented (compiles ✅, unit-tested)
1. **`GravityHardfork::Epsilon`** + genesis `epsilonTime` → `ForkCondition::Timestamp` wiring (`chainspec`), mirroring `alphaTime`. Without this the fork could never activate.
2. **Gas-exempt system txs** when Epsilon is active: `disable_base_fee` + `disable_balance_check` on the system-tx EVM env, in **both** backends kept in lockstep (cf. #363) — serial `EthEvmConfig::transact_system_txn` and grevm `GrevmExecutor::transact_system_txn`.
3. **Zero `SYSTEM_CALLER.balance`** on the Epsilon activation block — a one-time irregular state change via the backend-agnostic `ParallelExecutor::apply_state_change` in `execute_ordered_block`, **mirroring the EIP-2935 (Prague) `HISTORY_STORAGE` deployment** (`epsilon.rs`). One call site → serial + grevm identical, no per-backend duplication; nonce preserved; `transitions_at_timestamp`-gated (fires once, reorg-safe).
4. **Unit test**: `epsilonTime` parsing + activation/transition semantics.

Design doc: `docs/design/system-tx-gas-exempt.md` (precedents EIP-4788/2935 · Arbitrum 0x6a; code-location map; checklist).

### Remaining before merge / activation
- **Dual-backend e2e** (mirror `gravity_eip2935_test`): after fork — balance stays 0, system txs get correct receipts, no base fee burned, **serial == grevm state root**, nonce continuity, total supply returns to real value.
- Set `epsilonTime` per the hardfork SOP (single PR + atomic image swap + ≥24h lead).

> **Draft — do not merge** until the e2e lands and an activation time is set.

Tracks #364 · analysis gravity-audit#720.