### PR TITLE
fix(precompile): gas guard on randomness_by_height precompile

### DIFF
--- a/crates/gravity-precompiles/src/randomness_by_height.rs
+++ b/crates/gravity-precompiles/src/randomness_by_height.rs
@@ -129,7 +129,17 @@ where
     let precompile_id = PrecompileId::custom("randomness_by_height");
 
     (precompile_id, move |input: PrecompileInput<'_>| -> PrecompileResult {
-        randomness_by_height_handler_raw(input.data, provider.as_ref())
+        // Gas guard (mirrors `bls_precompile`): explicitly enforce the precompile's gas and
+        // return OutOfGas when the call forwarded less than `gas_used`, instead of letting the
+        // precompile dispatcher underflow-panic on `record_cost`. Without this, any user
+        // transaction that calls this precompile with insufficient forwarded gas panics every
+        // node — a network-wide consensus halt. The lookup itself is cheap, so charging after
+        // computing the (data-dependent) gas tier is fine.
+        let output = randomness_by_height_handler_raw(input.data, provider.as_ref())?;
+        if output.gas_used > input.gas {
+            return Err(PrecompileError::OutOfGas);
+        }
+        Ok(output)
     })
         .into()
 }


### PR DESCRIPTION
## Problem
`create_randomness_by_height_precompile`'s handler returns `PrecompileOutput { gas_used }` (the data-dependent recent/storage/lookup tier) **without checking `input.gas`**. When a call forwards less gas than `gas_used`, the precompile dispatcher underflows on `record_cost` and **panics** (`Gas underflow is not possible`, alloy-evm `precompiles.rs`) instead of returning `OutOfGas`. Because every validator executes the same transaction deterministically, this is a **consensus-level halt**, not a single failed call.

`bls_precompile` already guards against exactly this — its comment documents the dispatcher-panic / network-halt failure mode and returns `OutOfGas` up front. The randomness precompile shipped without the equivalent guard.

## Fix
Mirror `bls_precompile`: compute the (cheap, data-dependent) gas and return `PrecompileError::OutOfGas` when `gas_used > input.gas`, so the call fails gracefully (tx `status = 0`, gas charged) and nodes keep running.

```rust
let output = randomness_by_height_handler_raw(input.data, provider.as_ref())?;
if output.gas_used > input.gas {
    return Err(PrecompileError::OutOfGas);
}
Ok(output)
```

## Verification
On an isolated 3-node devnet (`chain_id 1337`), a transaction calling the precompile with insufficient forwarded gas halted **all three validators** with the `Gas underflow is not possible` panic (and did not self-heal on restart). With this patch the same transaction is included as an ordinary failed tx (`status = 0`, full gas charged) and the chain keeps producing blocks; sufficient-gas output is unchanged.

> ⚠️ The precompile is active post-Alpha, so this affects the deployed v1.7.x line. Please backport / hotfix the release branch, not just `main`.

A unit test for the closure's gas path is a good follow-up (constructing `PrecompileInput` in-crate is awkward; the existing tests cover `randomness_by_height_handler_raw`).