### PR TITLE
fix: cover gravity hardfork integration test in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,18 +93,17 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      - name: Run gravity pipe + EIP-7702 / EIP-2935 integration tests
+      - name: Run gravity pipe + hardfork / EIP-7702 / EIP-2935 integration tests
         # `--test <name>` is required (vs. just `-E 'binary(...)'`) because
         # nextest's filterset only filters at *run* time — without `--test`,
-        # `-p <crate>` still tries to compile every integration binary in the
-        # crate, including ones that don't compile in this workspace (e.g.
-        # gravity_hardfork_test.rs depends on reth-ethereum-forks which is not
-        # in dev-dependencies). `--test` restricts both compile and run.
+        # `-p <crate>` still tries to compile every integration binary in this
+        # crate. `--test` keeps this job focused on the intended binaries.
         run: |
           cargo nextest run \
             --locked \
             -p reth-pipe-exec-layer-ext-v2 \
             --test gravity_pipe_test \
+            --test gravity_hardfork_test \
             --test gravity_eip2935_test \
             --test gravity_eip7702_test
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9999,6 +9999,7 @@ dependencies = [
  "reth-db",
  "reth-engine-primitives",
  "reth-ethereum-cli",
+ "reth-ethereum-forks",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",

--- a/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
+++ b/crates/pipe-exec-layer-ext-v2/execute/Cargo.toml
@@ -69,6 +69,7 @@ reth-node-ethereum.workspace = true
 reth-node-builder.workspace = true
 reth-provider.workspace = true
 reth-ethereum-cli.workspace = true
+reth-ethereum-forks.workspace = true
 reth-revm.workspace = true
 reth-db.workspace = true
 reth-node-api.workspace = true


### PR DESCRIPTION
## Summary

- Add `reth-ethereum-forks` as a direct dev-dependency for `reth-pipe-exec-layer-ext-v2` so `gravity_hardfork_test` can compile under the crate's integration test build.
- Include `gravity_hardfork_test` in the focused gravity pipe integration workflow.
- Refresh the workflow comment now that the hardfork test is intentionally covered.

Fixes Galxe/gravity-audit#673.

## Validation

- `cargo check -p reth-pipe-exec-layer-ext-v2 --tests`
- `cargo check --locked -p reth-pipe-exec-layer-ext-v2 --tests`

Both checks pass. Existing warnings remain in `reth-pipe-exec-layer-ext-v2` tests/lib code.