### PR TITLE
chore(deps): bump gravity-api-types for epoch-start recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,7 +378,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 # reth
-gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "e9544c8cb3d8a5757d4c7f1b4807b312c03ba060" }
+gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "b1f68dc85781ef0d28a568d9d64604b153be9d9e" }
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }


### PR DESCRIPTION
## Summary
- bump `gravity-api-types` to Galxe/gravity-aptos@b1f68dc
- pick up the `BlockInfo::match_ordered_only` recovery guard from gravity-aptos#75
- allow epoch-start committed roots with earlier executed timestamps to recover instead of panic-looping

## Tests
- `cargo check -p reth-pipe-exec-layer-ext-v2`
