### PR TITLE
fix(rpc): debug_traceTransaction target-tx gas-exempt gap + wire deferred #367 tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,6 +121,19 @@ jobs:
         # now pins the allowlist so any new file matching those globs must
         # either be wired here or be listed in the invariant's
         # `KNOWN_UNWIRED_TESTS` skip set with a reason.
+        #
+        # `-E 'not test(...)'` excludes `test_e2e_dual_backend_state_root_
+        # equivalence_across_alpha_boundary` in `gravity_system_tx_gas_exempt_test`:
+        # that test drives `run_pipe_e2e_test` twice inside one `#[test]` fn
+        # (grevm + serial), and each call routes through `NodeCommand::execute`
+        # → `init_gravity_config` (a process-global `OnceLock` with a hard
+        # `assert!`). Nextest gives each `#[test]` its own process, but two
+        # invocations *within* one test share it — the second panics with
+        # `"Global gravity config already initialized"`. The single-invocation
+        # `test_e2e_system_tx_alpha_activation_{grevm,disable_grevm}` in the
+        # same binary work fine and stay wired. Splitting the dual test into
+        # two `#[test]` fns + cross-process state persistence is #367
+        # follow-up; drop this filter when that lands.
         run: |
           cargo nextest run \
             --locked \
@@ -130,7 +143,8 @@ jobs:
             --test gravity_eip7702_test \
             --test gravity_system_tx_gas_exempt_test \
             --test gravity_system_tx_pre_alpha_replay_test \
-            --test gravity_system_tx_simulation_anti_spoof_test
+            --test gravity_system_tx_simulation_anti_spoof_test \
+            -E 'not test(=test_e2e_dual_backend_state_root_equivalence_across_alpha_boundary)'
 
   integration-success:
     name: integration success

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,7 +130,9 @@ jobs:
             --test gravity_eip7702_test \
             --test gravity_system_tx_gas_exempt_test \
             --test gravity_system_tx_pre_alpha_replay_test \
-            --test gravity_system_tx_simulation_anti_spoof_test
+            --test gravity_system_tx_simulation_anti_spoof_test \
+            --test gravity_bls_precompile_test \
+            --test gravity_system_tx_bls_replay_test
 
   integration-success:
     name: integration success

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -121,19 +121,6 @@ jobs:
         # now pins the allowlist so any new file matching those globs must
         # either be wired here or be listed in the invariant's
         # `KNOWN_UNWIRED_TESTS` skip set with a reason.
-        #
-        # `-E 'not test(...)'` excludes `test_e2e_dual_backend_state_root_
-        # equivalence_across_alpha_boundary` in `gravity_system_tx_gas_exempt_test`:
-        # that test drives `run_pipe_e2e_test` twice inside one `#[test]` fn
-        # (grevm + serial), and each call routes through `NodeCommand::execute`
-        # → `init_gravity_config` (a process-global `OnceLock` with a hard
-        # `assert!`). Nextest gives each `#[test]` its own process, but two
-        # invocations *within* one test share it — the second panics with
-        # `"Global gravity config already initialized"`. The single-invocation
-        # `test_e2e_system_tx_alpha_activation_{grevm,disable_grevm}` in the
-        # same binary work fine and stay wired. Splitting the dual test into
-        # two `#[test]` fns + cross-process state persistence is #367
-        # follow-up; drop this filter when that lands.
         run: |
           cargo nextest run \
             --locked \
@@ -143,8 +130,7 @@ jobs:
             --test gravity_eip7702_test \
             --test gravity_system_tx_gas_exempt_test \
             --test gravity_system_tx_pre_alpha_replay_test \
-            --test gravity_system_tx_simulation_anti_spoof_test \
-            -E 'not test(=test_e2e_dual_backend_state_root_equivalence_across_alpha_boundary)'
+            --test gravity_system_tx_simulation_anti_spoof_test
 
   integration-success:
     name: integration success

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,13 +112,25 @@ jobs:
         # crate, including ones that don't compile in this workspace (e.g.
         # gravity_hardfork_test.rs depends on reth-ethereum-forks which is not
         # in dev-dependencies). `--test` restricts both compile and run.
+        #
+        # The `gravity_system_tx_*` + `gravity_bls_*` binaries were added by
+        # #367 and #370 but originally never wired here — they compiled in
+        # local dev but CI silently skipped them, so latent regressions
+        # (e.g. `debug_traceTransaction` target-tx gas-exempt cfg gap) went
+        # unnoticed. Invariant 9 in `scripts/check-gravity-invariants.sh`
+        # now pins the allowlist so any new file matching those globs must
+        # either be wired here or be listed in the invariant's
+        # `KNOWN_UNWIRED_TESTS` skip set with a reason.
         run: |
           cargo nextest run \
             --locked \
             -p reth-pipe-exec-layer-ext-v2 \
             --test gravity_pipe_test \
             --test gravity_eip2935_test \
-            --test gravity_eip7702_test
+            --test gravity_eip7702_test \
+            --test gravity_system_tx_gas_exempt_test \
+            --test gravity_system_tx_pre_alpha_replay_test \
+            --test gravity_system_tx_simulation_anti_spoof_test
 
   integration-success:
     name: integration success

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -1054,4 +1054,110 @@ mod tests {
             "state_size drift between disable_balance_check on/off"
         );
     }
+
+    // --- U-6d: pre-Alpha baseline symmetry (gate OFF) --------------------
+
+    /// `u6d`: even when the Alpha gate is inactive, serial (`WrapExecutor` →
+    /// `EthEvmConfig::transact_system_txn`) and grevm
+    /// (`GrevmExecutor::transact_system_txn`) must produce byte-identical
+    /// bundles for the same batch of pre-Alpha-shaped system txs (i.e.
+    /// `gas_price = basefee`, production fallback path). Pins that
+    /// backend byte-equivalence comes from shared underlying revm/grevm
+    /// semantics, not from the gate short-circuiting both backends onto the
+    /// same fast path.
+    ///
+    /// Dual to U-6 (gate ON) and complementary to U-7b: U-7b compares
+    /// `gas_used` across the fork on a single backend; U-6d compares
+    /// bundles across backends on the pre-Alpha side of the fork.
+    #[test]
+    fn u6d_test_pre_alpha_baseline_symmetry() {
+        // Alpha never fires: pushed out to u64::MAX so `is_system_tx_gas_exempt`
+        // is guaranteed off at the block ts we synthesize below.
+        let chain_spec = alpha_active_chainspec(u64::MAX);
+        let chain_id = chain_spec.chain().id();
+        assert!(
+            !is_system_tx_gas_exempt(chain_spec.as_ref(), 1),
+            "test fixture sanity: Alpha must be inactive at ts=1 with Alpha=u64::MAX"
+        );
+
+        let evm_config = EthEvmConfig::new(chain_spec.clone());
+        let header = alpha_block_header(1);
+        let evm_env = evm_config.evm_env(&header).expect("evm_env must build");
+
+        // With the gate off, `gas_price = 0` would trip `GasPriceLessThanBasefee`.
+        // Use the block's basefee (production fallback path — matches U-7b's
+        // `tx_pre`) so the tx clears revm's fee-check without further cfg
+        // manipulation, keeping the comparison isolated to backend semantics.
+        let basefee = evm_env.block_env.basefee as u128;
+        let build_tx = |nonce: u64| TxEnv {
+            caller: SYSTEM_CALLER,
+            gas_limit: 1_000_000,
+            gas_price: basefee,
+            kind: TxKind::Call(SYSTEM_CALLER),
+            value: U256::ZERO,
+            data: Bytes::new(),
+            nonce,
+            chain_id: Some(chain_id),
+            ..TxEnv::default()
+        };
+        let tx0 = build_tx(0);
+        let tx1 = build_tx(1);
+
+        // Fund SYSTEM_CALLER generously so `basefee × gas_limit × 2` clears
+        // the balance check trivially — the test isn't measuring balance
+        // arithmetic, only backend equivalence.
+        let funded = U256::from(u128::MAX);
+
+        let mut serial =
+            WrapExecutor::new(BasicBlockExecutor::new(evm_config.clone(), seeded_db(funded, 0)));
+        serial
+            .transact_system_txn(evm_env.clone(), Vec::new(), tx0.clone())
+            .expect("serial pre-Alpha tx0 must succeed (production fallback path)");
+        serial
+            .transact_system_txn(evm_env.clone(), Vec::new(), tx1.clone())
+            .expect("serial pre-Alpha tx1 must succeed (production fallback path)");
+        let bundle_serial = serial.take_bundle();
+
+        let mut grevm = GrevmExecutor::new(chain_spec.clone(), &evm_config, seeded_db(funded, 0));
+        grevm
+            .transact_system_txn(evm_env.clone(), Vec::new(), tx0)
+            .expect("grevm pre-Alpha tx0 must succeed (production fallback path)");
+        grevm
+            .transact_system_txn(evm_env, Vec::new(), tx1)
+            .expect("grevm pre-Alpha tx1 must succeed (production fallback path)");
+        let bundle_grevm = grevm.take_bundle();
+
+        // Load-bearing byte-equivalence (same fields as U-6; see U-6 comment
+        // for the `reverts_size` skip rationale).
+        assert_eq!(bundle_serial.state, bundle_grevm.state, "pre-Alpha: state map drift");
+        assert_eq!(bundle_serial.contracts, bundle_grevm.contracts, "pre-Alpha: contracts drift");
+        assert_eq!(
+            bundle_serial.state_size, bundle_grevm.state_size,
+            "pre-Alpha: state_size drift"
+        );
+        assert_eq!(bundle_serial.reverts, bundle_grevm.reverts, "pre-Alpha: reverts content drift");
+
+        // Sanity: SYSTEM_CALLER balance strictly decreased (fee was actually
+        // debited) — proves the gate stayed off and we didn't accidentally
+        // exercise the gas-exempt path.
+        let serial_info = bundle_serial
+            .state
+            .get(&SYSTEM_CALLER)
+            .and_then(|a| a.info.as_ref())
+            .expect("SYSTEM_CALLER must be in serial bundle after two pre-Alpha txs");
+        assert!(
+            serial_info.balance < funded,
+            "SYSTEM_CALLER balance must be debited under the pre-Alpha (gate-off) path"
+        );
+        assert_eq!(serial_info.nonce, 2, "nonce must bump by 2 (one per system tx)");
+
+        // NB: we deliberately do NOT assert coinbase received a positive
+        // balance. With `gas_price = basefee` (production fallback shape),
+        // the EIP-1559 split is `priority_fee = gas_price - basefee = 0`
+        // — the entire fee is burned and coinbase receives nothing. The
+        // `SYSTEM_CALLER.balance < funded` check above is sufficient to
+        // prove the pre-Alpha fee path was exercised (fee was debited);
+        // asserting coinbase balance would only re-derive EIP-1559 math
+        // and is not the invariant U-6d cares about.
+    }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/system_caller_migration.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/system_caller_migration.rs
@@ -427,4 +427,336 @@ mod tests {
         // §6.1 #2 should also fail. The unit test is a fast-feedback canary.
         assert_eq!(SYSTEM_CALLER, address!("0x00000000000000000000000000000001625f0000"));
     }
+
+    // ================================================================
+    // U-6b / U-6c — extensions to the U-6 dual-backend equivalence tests
+    // (defined in `crates/ethereum/evm/src/parallel_execute.rs`).
+    //
+    // These tests live here rather than beside U-6 because
+    // `apply_state_changes_for_block` is `pub(crate)` to this crate and
+    // pipe-exec-layer is downstream of `reth-evm-ethereum`. Colocating the
+    // tests with the hook they exercise avoids either promoting the hook
+    // to `pub` (widens the API surface for a test-only concern) or
+    // reaching into pipe-layer runtime from the U-6 module.
+    // U-6d does not need the hook and lives with U-6.
+    // ================================================================
+
+    /// Build a grevm-backed executor seeded with a `SYSTEM_CALLER` account.
+    ///
+    /// Mirrors [`fresh_executor`] but constructs
+    /// [`reth_evm_ethereum::parallel_execute::GrevmExecutor`] so U-6b/U-6c can
+    /// compare the migration hook / cross-block bundle against the serial
+    /// (`WrapExecutor`) path. Uses `CacheDB<EmptyDB>` on both sides so the
+    /// pre-hook state is byte-identical between backends.
+    fn fresh_grevm_executor(
+        chain_spec: Arc<reth_chainspec::ChainSpec>,
+        seed: AccountInfo,
+    ) -> reth_evm_ethereum::parallel_execute::GrevmExecutor<
+        CacheDB<EmptyDB>,
+        EthEvmConfig,
+        reth_chainspec::ChainSpec,
+    > {
+        let evm_config = EthEvmConfig::new(chain_spec.clone());
+        let mut db = CacheDB::new(EmptyDB::default());
+        db.insert_account_info(SYSTEM_CALLER, seed);
+        reth_evm_ethereum::parallel_execute::GrevmExecutor::new(chain_spec, &evm_config, db)
+    }
+
+    // --- U-6b: migration hook symmetry across serial vs grevm backends ---
+
+    /// `u6b`: the Alpha `SYSTEM_CALLER` migration hook must produce
+    /// byte-identical `BundleState` on both backends. Serial routes through
+    /// `WrapExecutor::apply_state_change`; grevm routes through
+    /// `GrevmExecutor::apply_state_change`. Both consume the same diff shape
+    /// emitted by [`apply_state_changes_for_block`], so any drift is a
+    /// backend-side commit-semantics bug and would fork state root on the
+    /// activation block.
+    ///
+    /// Complements the existing U-6 (`transact_system_txn` equivalence) —
+    /// U-6 never triggers migration (its seed is already balance=0) and U-6b
+    /// never runs a system tx, so together they cover the two orthogonal
+    /// diff sources that land in an Alpha activation block.
+    #[test]
+    fn u6b_test_migration_hook_symmetry() {
+        let chain_spec = alpha_chainspec();
+        let code = nonempty_code();
+        let code_hash = code.hash_slow();
+        let seed = AccountInfo {
+            balance: sentinel_balance(),
+            nonce: 5,
+            code_hash,
+            code: Some(code.clone()),
+        };
+
+        // Serial: WrapExecutor over CacheDB<EmptyDB>, seeded identically.
+        let mut serial = fresh_executor(chain_spec.clone(), seed.clone());
+        apply_state_changes_for_block(
+            &mut serial
+                as &mut dyn ParallelExecutor<
+                    Primitives = EthPrimitives,
+                    Error = BlockExecutionError,
+                >,
+            chain_spec.as_ref(),
+            ALPHA_TS,
+            ALPHA_TS - 1,
+            42,
+        );
+        let bundle_serial = serial.take_bundle();
+
+        // Grevm: GrevmExecutor over CacheDB<EmptyDB>, seeded identically.
+        let mut grevm = fresh_grevm_executor(chain_spec.clone(), seed);
+        apply_state_changes_for_block(
+            &mut grevm
+                as &mut dyn ParallelExecutor<
+                    Primitives = EthPrimitives,
+                    Error = BlockExecutionError,
+                >,
+            chain_spec.as_ref(),
+            ALPHA_TS,
+            ALPHA_TS - 1,
+            42,
+        );
+        let bundle_grevm = grevm.take_bundle();
+
+        // Load-bearing byte-equivalence. Same field selection as U-6 —
+        // `reverts_size` skipped for the same reason (grevm's
+        // `parallel_apply_transitions_and_create_reverts` does not update
+        // `reverts_size`; not consensus-affecting).
+        assert_eq!(
+            bundle_serial.state, bundle_grevm.state,
+            "migration hook state map drift between serial and grevm"
+        );
+        assert_eq!(
+            bundle_serial.contracts, bundle_grevm.contracts,
+            "migration hook contracts drift between serial and grevm"
+        );
+        assert_eq!(
+            bundle_serial.state_size, bundle_grevm.state_size,
+            "migration hook state_size drift between serial and grevm"
+        );
+        assert_eq!(
+            bundle_serial.reverts, bundle_grevm.reverts,
+            "migration hook reverts drift between serial and grevm"
+        );
+
+        // Sanity: the migration actually did its job on the serial side
+        // (mirrored on grevm via the byte-equality above).
+        let acc = bundle_serial
+            .state
+            .get(&SYSTEM_CALLER)
+            .expect("SYSTEM_CALLER must be present after migration");
+        let info = acc.info.as_ref().expect("info present");
+        assert_eq!(info.balance, U256::ZERO, "balance must be zeroed by migration");
+        assert_eq!(info.nonce, 5, "nonce must be preserved by migration");
+        assert_eq!(info.code_hash, code_hash, "code_hash must be preserved by migration");
+        assert!(!info.is_empty(), "post-migration SYSTEM_CALLER must survive EIP-161 (nonce > 0)");
+    }
+
+    // --- U-6c: cross-block bundle carryover (activation + 5 post-Alpha) ---
+
+    /// `u6c`: run a sequence of 6 blocks through both backends
+    /// (activation block T + five post-Alpha blocks T+1..T+5), asserting
+    /// per-block `BundleState` byte-equivalence at every step. Pins that
+    /// backend state carryover across blocks does not drift — a bug that
+    /// only surfaces cumulatively (e.g. grevm forgetting a nonce bump
+    /// between blocks) would show up here as a drift in block N ≥ 2, but
+    /// not in the single-block U-6 or the single-hook U-6b.
+    ///
+    /// Uses "方案 A" from the design doc: the executor is reused across
+    /// blocks, `take_bundle` drains the bundle_state but preserves the
+    /// underlying cache, so block N+1 runs against the accumulated state
+    /// from blocks 1..N without any explicit re-seeding.
+    ///
+    /// The activation block also exercises the load-bearing "migration hook
+    /// diff + system-tx diff on the same block" combination — a serial /
+    /// grevm ordering mismatch there (migration written after tx instead of
+    /// before, or interleaved with the wrong state view) would fail at
+    /// block 1 of the sequence.
+    #[test]
+    fn u6c_test_cross_block_bundle_carryover() {
+        // Alpha = 1000. First block ts = 1000 → migration hook fires.
+        // Subsequent 5 blocks (ts 1001..=1005) → hook is a no-op, only
+        // system txs execute.
+        const ALPHA_C: u64 = 1000;
+        let mut spec = ChainSpecBuilder::from(&*MAINNET)
+            .shanghai_activated()
+            .cancun_activated()
+            .prague_activated()
+            .build();
+        spec.gravity_hardforks =
+            ChainHardforks::from([(GravityHardfork::Alpha, ForkCondition::Timestamp(ALPHA_C))]);
+        let chain_spec = Arc::new(spec);
+        let chain_id = chain_spec.chain().id();
+        let evm_config = EthEvmConfig::new(chain_spec.clone());
+
+        // Both backends: seed SYSTEM_CALLER with the sentinel balance (mirror
+        // production genesis pre-Alpha) and a non-zero nonce. Nonce is set
+        // to 1 rather than 0 so the post-migration `AccountInfo` is
+        // non-empty even before any tx has bumped the nonce — the migration
+        // hook's `apply_state_change` runs with `state_clear_flag = false`
+        // (only `transact_system_txn` flips that flag on the underlying
+        // `State`), and revm's pre-EIP-161 path (`touch_create_pre_eip161`
+        // → `on_touched_created_pre_eip161`) panics with "Wrong state
+        // transition, touch crate is not possible from Loaded" when the
+        // touched account is empty. Nonce ≥ 1 avoids that trap and matches
+        // production reality (SYSTEM_CALLER always has non-zero nonce by
+        // the time Alpha activates — it has been executing per-block system
+        // txs since block 1).
+        let seed = AccountInfo {
+            balance: sentinel_balance(),
+            nonce: 1,
+            code_hash: KECCAK_EMPTY,
+            code: None,
+        };
+        let mut serial = fresh_executor(chain_spec.clone(), seed.clone());
+        let mut grevm = fresh_grevm_executor(chain_spec.clone(), seed);
+
+        // Blocks: (block_number, timestamp, parent_ts)
+        //   block 1 = activation (ts 1000, parent 999) — migration fires
+        //   blocks 2..=6 = post-Alpha (ts 1001..=1005) — migration no-op
+        let sequence: [(u64, u64, u64); 6] = [
+            (1, 1000, 999),
+            (2, 1001, 1000),
+            (3, 1002, 1001),
+            (4, 1003, 1002),
+            (5, 1004, 1003),
+            (6, 1005, 1004),
+        ];
+
+        // Build a Prague-shaped header for each block. Only `timestamp` and
+        // `number` matter for the `EthEvmConfig::evm_env` shape used by
+        // `transact_system_txn`; `parent_hash` / `parent_beacon_block_root`
+        // stay defaulted since we do not chain them through consensus here.
+        let build_header = |number: u64, timestamp: u64| alloy_consensus::Header {
+            parent_hash: alloy_primitives::B256::ZERO,
+            timestamp,
+            number,
+            requests_hash: Some(alloy_eips::eip7685::EMPTY_REQUESTS_HASH),
+            excess_blob_gas: Some(0),
+            blob_gas_used: Some(0),
+            parent_beacon_block_root: Some(alloy_primitives::B256::ZERO),
+            gas_limit: 30_000_000,
+            base_fee_per_gas: Some(1_000_000_000),
+            ..alloy_consensus::Header::default()
+        };
+
+        // Metadata-shaped system tx (gas_price=0, gas-exempt under Alpha).
+        let build_tx = |nonce: u64| revm::context::TxEnv {
+            caller: SYSTEM_CALLER,
+            gas_limit: 1_000_000,
+            gas_price: 0,
+            kind: revm::primitives::TxKind::Call(SYSTEM_CALLER),
+            value: U256::ZERO,
+            data: Bytes::new(),
+            nonce,
+            chain_id: Some(chain_id),
+            ..revm::context::TxEnv::default()
+        };
+
+        // Sanity: gate is ON at ts 1000 (activation), post-Alpha blocks too.
+        assert!(
+            reth_chainspec::is_system_tx_gas_exempt(chain_spec.as_ref(), 1000),
+            "U-6c fixture: gate must be ON at activation ts"
+        );
+        assert!(
+            reth_chainspec::is_system_tx_gas_exempt(chain_spec.as_ref(), 1005),
+            "U-6c fixture: gate must remain ON post-Alpha"
+        );
+
+        for (block_num, ts, prev_ts) in sequence {
+            let header = build_header(block_num, ts);
+            let evm_env = <EthEvmConfig as reth_evm::ConfigureEvm>::evm_env(&evm_config, &header)
+                .expect("evm_env must build");
+
+            // 1) migration hook (fires exactly on block 1, no-op on 2..=6)
+            apply_state_changes_for_block(
+                &mut serial
+                    as &mut dyn ParallelExecutor<
+                        Primitives = EthPrimitives,
+                        Error = BlockExecutionError,
+                    >,
+                chain_spec.as_ref(),
+                ts,
+                prev_ts,
+                block_num,
+            );
+            apply_state_changes_for_block(
+                &mut grevm
+                    as &mut dyn ParallelExecutor<
+                        Primitives = EthPrimitives,
+                        Error = BlockExecutionError,
+                    >,
+                chain_spec.as_ref(),
+                ts,
+                prev_ts,
+                block_num,
+            );
+
+            // 2) two system txs per block. Seed nonce = 1, so tx nonces
+            // start at 1 and grow monotonically: block 1 uses (1, 2),
+            // block 2 uses (3, 4), ..., block N uses (2*(N-1)+1, 2*(N-1)+2).
+            let n_meta = 2 * (block_num - 1) + 1;
+            let n_val = 2 * (block_num - 1) + 2;
+            serial
+                .transact_system_txn(evm_env.clone(), Vec::new(), build_tx(n_meta))
+                .unwrap_or_else(|e| panic!("serial block {block_num} metadata tx failed: {e:?}"));
+            serial
+                .transact_system_txn(evm_env.clone(), Vec::new(), build_tx(n_val))
+                .unwrap_or_else(|e| panic!("serial block {block_num} validator tx failed: {e:?}"));
+            grevm
+                .transact_system_txn(evm_env.clone(), Vec::new(), build_tx(n_meta))
+                .unwrap_or_else(|e| panic!("grevm block {block_num} metadata tx failed: {e:?}"));
+            grevm
+                .transact_system_txn(evm_env, Vec::new(), build_tx(n_val))
+                .unwrap_or_else(|e| panic!("grevm block {block_num} validator tx failed: {e:?}"));
+
+            // 3) drain bundle at end-of-block and assert byte equivalence.
+            // Draining resets bundle_state on both backends but preserves
+            // the underlying cache, so the next iteration continues from
+            // the accumulated state (方案 A from the design doc).
+            let bs = serial.take_bundle();
+            let bg = grevm.take_bundle();
+            assert_eq!(
+                bs.state, bg.state,
+                "block {block_num}: state map drift between serial and grevm"
+            );
+            assert_eq!(
+                bs.contracts, bg.contracts,
+                "block {block_num}: contracts drift between serial and grevm"
+            );
+            assert_eq!(
+                bs.state_size, bg.state_size,
+                "block {block_num}: state_size drift between serial and grevm"
+            );
+            assert_eq!(
+                bs.reverts, bg.reverts,
+                "block {block_num}: reverts drift between serial and grevm"
+            );
+
+            // Sanity per block: after end-of-block drain, SYSTEM_CALLER's
+            // nonce in the just-drained serial bundle equals the highest
+            // tx nonce we issued this block + 1 (revm bumps nonce on each
+            // successful tx).
+            if let Some(info) = bs.state.get(&SYSTEM_CALLER).and_then(|a| a.info.as_ref()) {
+                assert_eq!(
+                    info.nonce,
+                    n_val + 1,
+                    "block {block_num}: SYSTEM_CALLER nonce must reflect all txs so far"
+                );
+                // At and after activation, migration + subsequent txs keep
+                // balance at zero (gas-exempt under Alpha ⇒ no fee debit).
+                assert_eq!(
+                    info.balance,
+                    U256::ZERO,
+                    "block {block_num}: SYSTEM_CALLER balance must be zero post-migration"
+                );
+            }
+        }
+
+        // Final: after 6 blocks × 2 txs = 12 txs, SYSTEM_CALLER nonce
+        // observable via the last block's bundle equals 12. Already checked
+        // per-iteration above; this is a summary anchor for the sequence.
+        // No additional read here — the per-block assertions already pin
+        // the cumulative invariant.
+    }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_system_tx_gas_exempt_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_system_tx_gas_exempt_test.rs
@@ -14,11 +14,7 @@
 //!   activation block T zeroes it via `system_caller_migration::apply_state_changes_for_block`;
 //!   subsequent blocks keep executing 1 metadata system tx each while balance stays 0.
 //!
-//! - §2.2: dual-backend parity — running the same Alpha-crossing block sequence under both grevm
-//!   (parallel) and `--gravity.disable-grevm` (serial `WrapExecutor`) yields **identical** state
-//!   roots at every block, including T-1 (pre-fork), T (activation), and T+i (post-fork). Pinned by
-//!   the shared `apply_state_change` channel + serial/grevm-symmetric `transact_system_txn`
-//!   exemption.
+//! §2.2 coverage moved to U-6b/U-6c/U-6d unit tests (see PR #377).
 //!
 //! Naming and scaffolding mirror `gravity_eip2935_test.rs` /
 //! `gravity_bls_precompile_test.rs` so the matrix row maps 1:1 to a `cargo
@@ -407,62 +403,6 @@ fn test_e2e_system_tx_alpha_activation_disable_grevm() {
         |b| run_alpha_e2e(b, "disable_grevm"),
     );
     assert!(!state_roots.is_empty(), "runner must return non-empty state-root map");
-}
-
-// ---------------------------------------------------------------------------
-// §2.2 dual-backend state-root equivalence across the Alpha boundary.
-//
-// Drives the same activation runner once under grevm and once under
-// `--gravity.disable-grevm`, then asserts the per-block state-root maps match
-// byte-for-byte at every block in {T-1, T, T+1..T+5}. The pre-Alpha entry
-// (T-1) guards against baseline drift (anything that diverges before the fork
-// must be a pre-existing serial/grevm bug, not the Alpha bundle). T and T+i
-// pin both lever paths plus the migration hook.
-//
-// Two CLI invocations live inside one #[test] function — each `run_pipe_e2e_test`
-// drives its own CliRunner against an isolated datadir, so the second
-// invocation re-uses the same harness without inheriting state.
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_e2e_dual_backend_state_root_equivalence_across_alpha_boundary() {
-    let chain_spec = gravity_alpha_chainspec(ALPHA_TIME);
-
-    let grevm_roots = run_pipe_e2e_test(
-        &chain_spec,
-        "data/gravity_system_tx_gas_exempt_dual_grevm",
-        false,
-        |b| run_alpha_e2e(b, "dual/grevm"),
-    );
-    let serial_roots = run_pipe_e2e_test(
-        &chain_spec,
-        "data/gravity_system_tx_gas_exempt_dual_serial",
-        true,
-        |b| run_alpha_e2e(b, "dual/serial"),
-    );
-
-    assert_eq!(
-        grevm_roots.len(),
-        serial_roots.len(),
-        "dual-backend runs must produce state-root maps of equal cardinality (grevm={}, serial={})",
-        grevm_roots.len(),
-        serial_roots.len()
-    );
-
-    for (block, grevm_root) in &grevm_roots {
-        let serial_root = serial_roots
-            .get(block)
-            .unwrap_or_else(|| panic!("serial run is missing state_root for block {block}"));
-        assert_eq!(
-            grevm_root, serial_root,
-            "block {block} state_root divergence: grevm={grevm_root:?} serial={serial_root:?} — Alpha bundle (L1 cfg + L2 gas_price + migration hook) must be serial==grevm symmetric"
-        );
-    }
-
-    println!(
-        "[alpha_e2e dual] all {} block state-roots match across grevm + serial backends",
-        grevm_roots.len()
-    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_system_tx_simulation_anti_spoof_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_system_tx_simulation_anti_spoof_test.rs
@@ -65,11 +65,22 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 // Parameters
 // ---------------------------------------------------------------------------
 
-/// `alphaTime = 1` so every block in the test (numbers 1..=) is strictly
-/// post-Alpha (block 1's timestamp = `ALPHA_TS_BASE + 1` >> 1). The migration
-/// hook fires at block 1 and SYSTEM_CALLER.balance is zeroed thereafter.
+/// Block N timestamp (seconds) = `ALPHA_TS_BASE + N`. Set Alpha activation
+/// to block 1's timestamp so:
+///   - parent (genesis) ts = `gravity_hardfork.json` 0x6490fdd2 = 1687223762 is strictly less than
+///     `ALPHA_TIME_ALWAYS`
+///   - block 1's ts == `ALPHA_TIME_ALWAYS` — Alpha activates exactly at block 1, the migration hook
+///     fires once (zeroing SYSTEM_CALLER.balance), and every block in `1..=TIP_BLOCK` is post-Alpha
+///
+/// (The previously committed `ALPHA_TIME_ALWAYS = 1` was a fixture bug:
+/// `transitions_at_timestamp(parent=1687223762, current=block_n_ts, activation=1)`
+/// returns false for every n because parent already crossed activation,
+/// so the migration never fired and SYSTEM_CALLER.balance stayed at the
+/// sentinel value — making the "post-Alpha balance must be 0" sanity check
+/// panic before any endpoint invocation ran. Same pattern already documented
+/// and fixed in `gravity_system_tx_post_alpha_trace_test.rs`.)
 const ALPHA_TS_BASE: u64 = 2_000_000_000;
-const ALPHA_TIME_ALWAYS: u64 = 1;
+const ALPHA_TIME_ALWAYS: u64 = ALPHA_TS_BASE + 1;
 const TIP_BLOCK: u64 = 10;
 
 /// `SYSTEM_CALLER = 0x…625f0000` — same literal as
@@ -90,6 +101,19 @@ fn gravity_alpha_chainspec(alpha_time: u64) -> String {
         serde_json::from_str(include_str!("../gravity_hardfork.json"))
             .expect("gravity_hardfork.json must parse as JSON");
     json["config"]["alphaTime"] = serde_json::json!(alpha_time);
+    // Pre-seed SYSTEM_CALLER with nonce=1 so the Alpha migration's
+    // balance-zeroing transition produces (balance=0, nonce=1, code=empty)
+    // which stays non-empty under EIP-161. Without this, the migration
+    // would zero balance on a fresh nonce=0 account, transitioning
+    // SYSTEM_CALLER to (balance=0, nonce=0, code=empty) — an "empty"
+    // touched state that revm's AccountStatus state machine rejects
+    // (`Wrong state transition, touch empty is not possible from Loaded`).
+    // In production this never happens because pre-Alpha system txs
+    // already bumped SYSTEM_CALLER nonce by the time Alpha activates;
+    // this fixture mirrors that precondition without paying the cost of
+    // running a real pre-Alpha block series first. Same rationale
+    // documented in `gravity_system_tx_post_alpha_trace_test.rs`.
+    json["alloc"]["0x00000000000000000000000000000001625f0000"]["nonce"] = serde_json::json!(1);
     json.to_string()
 }
 
@@ -278,8 +302,9 @@ async fn run_simulation_anti_spoof(
 
     // Push enough blocks past Alpha so SYSTEM_CALLER.balance is zero and a
     // post-Alpha state snapshot is queryable. Block 1 already activates Alpha
-    // (alphaTime=1, block 1 ts >> 1), but pushing to TIP_BLOCK keeps the test
-    // robust against post-fork blocks accidentally regressing.
+    // (alphaTime=ALPHA_TS_BASE+1, block 1 ts == alphaTime), but pushing to
+    // TIP_BLOCK keeps the test robust against post-fork blocks accidentally
+    // regressing.
     let consensus = MockConsensus::new(pipeline_api, Box::new(alpha_ts_us));
     consensus.push_empty_range(&mut epoch, 1, TIP_BLOCK).await;
     let pipeline_api = consensus.into_inner();

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -267,9 +267,27 @@ where
 
                 let tx_env = this.eth_api().evm_config().tx_env(&tx);
 
+                // Gravity Alpha (system-tx gas-exempt) single-tx-family wiring
+                // for the *target* tx. `replay_transactions_until` above toggles
+                // the cfg for pre-target replay txs internally, but the target
+                // tx trace uses `evm_env` unmodified — so a post-Alpha system tx
+                // (`gas_price = 0` vs `basefee > 0`) would fail with
+                // `GasPriceLessThanBasefee`. Mirrors the parity-namespace path
+                // in `spawn_trace_transaction_in_block_with_inspector`
+                // (`crates/rpc/rpc-eth-api/src/helpers/trace.rs`).
+                let mut target_evm_env = evm_env;
+                if is_system_tx_gas_exempt(
+                    this.eth_api().provider().chain_spec().as_ref(),
+                    target_evm_env.block_env.timestamp.saturating_to::<u64>(),
+                ) && is_gravity_system_caller(tx.signer())
+                {
+                    target_evm_env.cfg_env.disable_base_fee = true;
+                    target_evm_env.cfg_env.disable_balance_check = true;
+                }
+
                 this.trace_transaction(
                     &opts,
-                    evm_env,
+                    target_evm_env,
                     tx_env,
                     &mut db,
                     Some(TransactionContext {

--- a/scripts/check-gravity-invariants.sh
+++ b/scripts/check-gravity-invariants.sh
@@ -34,6 +34,17 @@
 #      `trace_block_until_with_inspector`) per-tx sender-check by
 #      referencing `is_system_tx_gas_exempt` (or
 #      `is_gravity_system_caller`) in the same file.
+#   9. CI allowlist parity: every integration test binary matching
+#      `gravity_system_tx_*_test.rs` or `gravity_bls_*_test.rs` under
+#      `crates/pipe-exec-layer-ext-v2/execute/tests/` must EITHER appear
+#      in the `--test <name>` allowlist in `.github/workflows/integration.yml`
+#      OR be listed in the `KNOWN_UNWIRED_TESTS` skip set inside invariant 9
+#      with a documented reason. Rationale: `-p reth-pipe-exec-layer-ext-v2`
+#      alone would try to compile every binary in the dir, including ones
+#      with dev-dep gaps, so the workflow uses an explicit allowlist.
+#      Without invariant 9, a newly added test file is silently skipped by
+#      CI (as happened with the six #367 / #370 files) — assertions may
+#      pass locally but never gate a merge.
 #
 # Invocation:
 #   bash scripts/check-gravity-invariants.sh
@@ -229,6 +240,93 @@ ${unapproved}A new replay caller must per-tx check sender against SYSTEM_CALLER.
         "rg --type rust -n 'replay_transactions_until|trace_block_until_with_inspector' crates/rpc"
 fi
 ok 8 "RPC replay paths reference SYSTEM_CALLER exemption check"
+
+# ---------------------------------------------------------------------------
+# Invariant 9 — CI allowlist parity for post-#367 / post-#370 RPC replay tests.
+# Every file under `crates/pipe-exec-layer-ext-v2/execute/tests/` matching
+# `gravity_system_tx_*_test.rs` or `gravity_bls_*_test.rs` must EITHER appear
+# as a `--test <basename>` argument in `.github/workflows/integration.yml`
+# OR be listed in `KNOWN_UNWIRED_TESTS` below with a documented reason. The
+# workflow uses an explicit allowlist (not `-p reth-pipe-exec-layer-ext-v2`
+# alone) because the crate has integration binaries whose dev-deps are
+# missing in this workspace; that same allowlist silently skips new files
+# unless they are added by hand.
+#
+# Deferred entries force a future contributor to make an explicit
+# claim ("wire" or "defer, with reason"), preventing another silent-skip
+# incident like #367 / #370.
+# ---------------------------------------------------------------------------
+echo "Invariant 9: CI --test allowlist covers all gravity_system_tx_* / gravity_bls_* integration tests (or explicit KNOWN_UNWIRED_TESTS)"
+
+# Known-unwired: test file basename → one-line reason. Any entry here
+# should also have a follow-up issue / PR tracked. Removing an entry
+# means the corresponding `--test <name>` line must be added to the
+# workflow.
+declare -A KNOWN_UNWIRED_TESTS=(
+    # Requires #372 Track A (mint precompile RPC registration) + the RPC-side
+    # `apply_state_change` Alpha migration hook for `SYSTEM_CALLER.balance`
+    # zeroing to reproduce canonical byte-equal traces on the Alpha activation
+    # block. Locally the block-family assertion diverges by ~9.4k gas at
+    # block 1's metadata tx. Wire after those land.
+    [gravity_system_tx_post_alpha_trace_test]="blocked on #372 mint precompile RPC registration + RPC-side Alpha migration hook"
+    # Requires PR #370 (BLS pop-verify precompile RPC registration) to land.
+    # The file exists on upstream/main but the RPC-side helper it exercises
+    # is only registered by #370.
+    [gravity_bls_precompile_test]="blocked on #370 (BLS pop-verify RPC registration)"
+)
+
+workflow="$REPO_ROOT/.github/workflows/integration.yml"
+tests_dir="crates/pipe-exec-layer-ext-v2/execute/tests"
+if [ ! -f "$workflow" ]; then
+    fail 9 "expected workflow file at .github/workflows/integration.yml — invariant needs to know where to look for the allowlist" \
+        "ls .github/workflows/integration.yml"
+fi
+missing=""
+double_claimed=""
+for f in $(ls "$tests_dir"/gravity_system_tx_*_test.rs "$tests_dir"/gravity_bls_*_test.rs 2>/dev/null); do
+    binary=$(basename "$f" .rs)
+    in_workflow=false
+    if grep -qE "^[[:space:]]*--test[[:space:]]+${binary}([[:space:]]|\\\\|$)" "$workflow"; then
+        in_workflow=true
+    fi
+    in_unwired=false
+    if [ "${KNOWN_UNWIRED_TESTS[$binary]+set}" = "set" ]; then
+        in_unwired=true
+    fi
+    if [ "$in_workflow" = "false" ] && [ "$in_unwired" = "false" ]; then
+        missing="${missing}${binary}
+"
+    fi
+    if [ "$in_workflow" = "true" ] && [ "$in_unwired" = "true" ]; then
+        double_claimed="${double_claimed}${binary}
+"
+    fi
+done
+if [ -n "$missing" ]; then
+    fail 9 "integration test file(s) neither wired to CI nor in KNOWN_UNWIRED_TESTS. Add \`--test <name> \\\` line(s) to .github/workflows/integration.yml (gravity-pipe-test job) OR add an entry to KNOWN_UNWIRED_TESTS in this script with a documented reason. Missing:
+${missing}Rationale: silently-skipped tests can't gate merges (see integration.yml comment)." \
+        "grep -E '^[[:space:]]*--test' .github/workflows/integration.yml"
+fi
+if [ -n "$double_claimed" ]; then
+    fail 9 "integration test file(s) both in CI allowlist AND KNOWN_UNWIRED_TESTS — pick one. Double-claimed:
+${double_claimed}Remove the KNOWN_UNWIRED_TESTS entry if now wired, or drop the workflow line if you meant to defer." \
+        "grep -E '^[[:space:]]*--test' .github/workflows/integration.yml"
+fi
+# Also flag KNOWN_UNWIRED_TESTS references to files that no longer exist —
+# likely a rename / deletion missed the invariant update.
+stale=""
+for binary in "${!KNOWN_UNWIRED_TESTS[@]}"; do
+    if [ ! -f "$tests_dir/${binary}.rs" ]; then
+        stale="${stale}${binary}
+"
+    fi
+done
+if [ -n "$stale" ]; then
+    fail 9 "KNOWN_UNWIRED_TESTS references file(s) that no longer exist under $tests_dir/. Remove the stale entries or restore the files. Stale:
+${stale}" \
+        "ls $tests_dir/"
+fi
+ok 9 "CI --test allowlist + KNOWN_UNWIRED_TESTS jointly cover all gravity_system_tx_* / gravity_bls_* integration tests"
 
 echo
 echo "All Gravity invariants passed."

--- a/scripts/check-gravity-invariants.sh
+++ b/scripts/check-gravity-invariants.sh
@@ -269,10 +269,6 @@ declare -A KNOWN_UNWIRED_TESTS=(
     # block. Locally the block-family assertion diverges by ~9.4k gas at
     # block 1's metadata tx. Wire after those land.
     [gravity_system_tx_post_alpha_trace_test]="blocked on #372 mint precompile RPC registration + RPC-side Alpha migration hook"
-    # Requires PR #370 (BLS pop-verify precompile RPC registration) to land.
-    # The file exists on upstream/main but the RPC-side helper it exercises
-    # is only registered by #370.
-    [gravity_bls_precompile_test]="blocked on #370 (BLS pop-verify RPC registration)"
 )
 
 workflow="$REPO_ROOT/.github/workflows/integration.yml"

--- a/scripts/check-gravity-invariants.sh
+++ b/scripts/check-gravity-invariants.sh
@@ -263,12 +263,18 @@ echo "Invariant 9: CI --test allowlist covers all gravity_system_tx_* / gravity_
 # means the corresponding `--test <name>` line must be added to the
 # workflow.
 declare -A KNOWN_UNWIRED_TESTS=(
-    # Requires #372 Track A (mint precompile RPC registration) + the RPC-side
-    # `apply_state_change` Alpha migration hook for `SYSTEM_CALLER.balance`
-    # zeroing to reproduce canonical byte-equal traces on the Alpha activation
-    # block. Locally the block-family assertion diverges by ~9.4k gas at
-    # block 1's metadata tx. Wire after those land.
-    [gravity_system_tx_post_alpha_trace_test]="blocked on #372 mint precompile RPC registration + RPC-side Alpha migration hook"
+    # Blocked on #372 Track A (mint precompile RPC registration). Fixture is
+    # now correct (ALPHA_TIME_ALWAYS = ALPHA_TS_BASE + 1 and SYSTEM_CALLER
+    # pre-seeded with nonce=1 — see gravity_system_tx_post_alpha_trace_test.rs
+    # lines 82-113), so both `#[test]` fns reach the trace assertions instead
+    # of panicking on the pre-flight balance sanity check. What they now fail
+    # on is the block-family trace-vs-canonical byte-equal invariant:
+    # `trace_block(1)[0]` (block 1's metadata system tx) reports
+    # `gas_used = 292093` while canonical execution reports `gas_used = 282665`
+    # — a 9428-gas divergence caused by the RPC-side execution path missing
+    # the mint precompile registration that the pipe-layer canonical path has.
+    # Wire after #372 Track A lands.
+    [gravity_system_tx_post_alpha_trace_test]="blocked on #372 Track A (mint precompile RPC registration) — trace_block(1)[0] gas diverges 292093 vs canonical 282665 (delta 9428)"
 )
 
 workflow="$REPO_ROOT/.github/workflows/integration.yml"


### PR DESCRIPTION
## Summary

Closes a `debug_traceTransaction` gas-exempt cfg gap shipped by #367 and wires the RPC replay integration test files that #367 / #370 authored but never added to the CI `--test` allowlist. Adds invariant 9 to `check-gravity-invariants.sh` so the next silent-skip incident is caught by lint rather than a user report.

## Track 1 — `debug_traceTransaction` target-tx cfg gap (`crates/rpc/rpc/src/debug.rs`)

`debug_trace_transaction` fetches `evm_env` via `evm_env_at`, clones it into `replay_transactions_until` (which correctly toggles `disable_base_fee` + `disable_balance_check` for pre-target system txs internally), then hands the **original untoggled** `evm_env` straight to `trace_transaction` for the **target** tx. When the target tx is a `SYSTEM_CALLER`-signed system tx on a post-Alpha block (`gas_price = 0` vs `basefee > 0`), revm rejects with `GasPriceLessThanBasefee` — surfaced as `\"max fee per gas less than block base fee\"`.

Parity/otterscan single-tx paths (`trace_transaction` / `trace_replayTransaction` / `trace_get` / `trace_transaction_opcode_gas`) were unaffected because they route through `spawn_trace_transaction_in_block_with_inspector` in `crates/rpc/rpc-eth-api/src/helpers/trace.rs` (lines 253–266), which already does the target-tx toggle. Only the debug-namespace flow bypassed it. Fix mirrors that helper's pattern inline in `debug.rs::debug_trace_transaction`.

Gate keys off the replayed block's timestamp (not node tip), so pre-Alpha historical replays are byte-identical to before.

## Track 2 — CI `--test` allowlist wiring (`.github/workflows/integration.yml`)

The `gravity-pipe-test` job in `integration.yml` uses an explicit `--test <name>` allowlist because the crate contains integration binaries with dev-dep gaps in this workspace (e.g. `gravity_hardfork_test.rs`). #367 and #370 added five RPC-replay integration test files but never added them to that allowlist, so CI silently compiled + ran none of them. The PR-body ✅ checkboxes for those tests were author self-attestation, not CI-enforced.

Wire the three that pass today:

- `gravity_system_tx_gas_exempt_test` — pipe-only, no RPC replay
- `gravity_system_tx_pre_alpha_replay_test` — pre-Alpha, gate returns false so no exemption path exercised
- `gravity_system_tx_simulation_anti_spoof_test` — simulation endpoints, no history replay

Defer the two that block on other work (documented in invariant 9's `KNOWN_UNWIRED_TESTS`):

- `gravity_system_tx_post_alpha_trace_test` — blocked on #372 Track A (mint precompile RPC registration) + an RPC-side Alpha migration hook (`apply_state_change` for `SYSTEM_CALLER.balance` zeroing). With Track 1's fix applied, this test no longer errors on `GasPriceLessThanBasefee` — it now progresses further and diverges from canonical by **~9.4k gas** on block 1's metadata tx (RPC 292093 vs canonical 282665), pointing at the mint gap that #372 already flagged and possibly a separate RPC-side migration-hook gap. Wire after those land.
- `gravity_bls_precompile_test` — blocked on #370 (BLS pop-verify RPC registration). Wire after #370 merges.

## Track 3 — Invariant 9 (`scripts/check-gravity-invariants.sh`)

Adds a new grep-based invariant that enforces every `crates/pipe-exec-layer-ext-v2/execute/tests/gravity_system_tx_*_test.rs` and `gravity_bls_*_test.rs` file must EITHER be wired to the workflow's `--test` allowlist OR be listed in `KNOWN_UNWIRED_TESTS` (an associative bash array in the script itself) with a one-line reason. Also flags:

- Double-claimed files (in both allowlist and skip set)
- Stale skip-list entries whose target file no longer exists

This turns the silent-skip failure mode into a hard CI lint. Any future contributor adding a matching test file has to make an explicit choice.

## Verification

- `cargo +nightly fmt --all --check` — clean
- `RUSTFLAGS=\"-D warnings\" cargo +nightly clippy -p reth-rpc --all-features --locked` — clean
- `bash scripts/check-gravity-invariants.sh` — all 9 invariants pass
- Local run of `gravity_system_tx_post_alpha_trace_test` (with clean datadir, `--retries 0`): pre-fix errored on `GasPriceLessThanBasefee`; post-fix progresses and now hits the block-family gas divergence tracked by #372 — proving Track 1's fix is load-bearing for the post-Alpha replay flow.

## Test plan

- [x] `cargo +nightly fmt --all --check`
- [x] `cargo +nightly clippy -p reth-rpc --all-features --locked`
- [x] `bash scripts/check-gravity-invariants.sh`
- [x] Manual `debug_traceTransaction` on post-Alpha system tx no longer errors with `max fee per gas less than block base fee`
- [ ] CI `gravity-pipe-test` job runs the three newly-wired tests (verified by CI on this PR)
- [ ] After #372 lands: remove `gravity_system_tx_post_alpha_trace_test` from `KNOWN_UNWIRED_TESTS` and add to allowlist
- [ ] After #370 lands: remove `gravity_bls_precompile_test` from `KNOWN_UNWIRED_TESTS` and add to allowlist

## Related

- #367 — shipped the debug.rs gap and the initially-unwired tests
- #370 — BLS RPC registration (adds `gravity_bls_precompile_test` back to the workflow when it lands)
- #372 — mint precompile RPC registration gap + post-Alpha trace test design gap (blocks wiring `gravity_system_tx_post_alpha_trace_test`)

---

## Update: §2.2 dual-backend E2E removed, replaced by U-6b/c/d unit tests

The initial CI failure on this PR surfaced a fourth #367 bug independent of the debug.rs and CI-allowlist tracks: `test_e2e_dual_backend_state_root_equivalence_across_alpha_boundary` at `crates/pipe-exec-layer-ext-v2/execute/tests/gravity_system_tx_gas_exempt_test.rs:427` cannot pass in any environment. It calls `run_pipe_e2e_test` twice inside one `#[test]` fn (grevm + serial), and each call routes through `NodeCommand::execute` → `init_gravity_config`, a process-global `OnceLock` with a hard `assert!`. The second call always panics with `"Global gravity config already initialized"`. Git blame confirms the `OnceLock`+`assert!` form has been unchanged since PR #168 (2025-08-21), so this test has never passed since #367 (2026-07-02) shipped.

The initial fix in this PR (commit `01a219d666`) was a nextest `-E` filter workaround. That has now been superseded by three new unit tests that cover the same backend-equivalence invariants without touching `init_gravity_config`:

- **U-6b** in `crates/pipe-exec-layer-ext-v2/execute/src/system_caller_migration.rs` — migration hook byte-equivalence between backends
- **U-6c** in the same file — six-block sequence across the Alpha activation boundary with real bundle carryover through the shared `ParallelState` cache
- **U-6d** in `crates/ethereum/evm/src/parallel_execute.rs` — permanently pre-Alpha chainspec baseline

All three run against `CacheDB<EmptyDB>` via pure `WrapExecutor` / `GrevmExecutor` API + direct migration hook invocation. Zero use of `NodeCommand`, `CliRunner`, tokio, or `init_gravity_config`.

Adversarial review verdict: **SAFE with caveat**. The backend-equivalence invariants §2.2 was named for are covered by U-6/U-6b/U-6c/U-6d with stronger per-field granularity than the E2E's coarse state-root equality. The two uncovered residues — pipe-layer `parallel_executor()` factory dispatch (`crates/ethereum/evm/src/lib.rs:313-323`) and payload → trie writeback (`self.storage.state_root(...)`) — are integration concerns exercised by every other E2E in the crate (`gravity_pipe_test`, `gravity_eip2935_test`, `gravity_bls_precompile_test`, `gravity_system_tx_pre_alpha_replay_test`, etc.), so no coverage is lost by removing this single E2E.

This update adds four commits on top of the original three:

1. `test: add U-6b/c/d unit tests covering §2.2 backend-equivalence invariants`
2. `test: remove §2.2 dual-backend E2E (superseded by U-6b/c/d)`
3. `ci: drop nextest -E filter now that dual test is removed`
4. `ci: wire #370 tests to CI allowlist, unblock KNOWN_UNWIRED entry` — #370 (BLS pop-verify RPC registration) merged during this PR; invariant 9 caught that #370 landed without touching the allowlist, so this commit wires `gravity_system_tx_bls_replay_test` and moves `gravity_bls_precompile_test` from `KNOWN_UNWIRED_TESTS` into the allowlist. Same silent-skip class the invariant was designed to catch.


---

## Update 2: fix `simulation_anti_spoof` fixture, sharpen `post_alpha_trace` deferral

While auditing every `#[test]` fn added by #367, two more fixture bugs surfaced — the same class as the `ALPHA_TIME_ALWAYS` bug that #367 fixed in `post_alpha_trace_test.rs` after the fact but left in place in the sibling `simulation_anti_spoof_test.rs`.

- **`gravity_system_tx_simulation_anti_spoof_test`** (2 `#[test]` fns) — was dead-on-arrival: `ALPHA_TIME_ALWAYS = 1` combined with genesis `timestamp = 1687223762` means `transitions_at_timestamp(parent, current, activation=1)` returns false for every block, so the migration hook never fires, `SYSTEM_CALLER.balance` never zeroes, and the test's pre-assertion `assert balance == 0` panics before any anti-spoof logic runs. Fixed by mirroring the `post_alpha_trace_test.rs:82-113` pattern: `ALPHA_TIME_ALWAYS = ALPHA_TS_BASE + 1` + pre-seed `SYSTEM_CALLER` with `nonce=1` so the migration's balance-zeroing leaves a non-empty account under EIP-161. Both `test_rpc_simulation_anti_spoof_{grevm,disable_grevm}` now pass.
- **`gravity_system_tx_post_alpha_trace_test`** — fixture was already correct on-tree (thanks to the fix `post_alpha_trace_test.rs:82` documents), but both `#[test]` fns still fail after fixture is right: block-family trace shows `trace_block(1)[0] gas_used = 292093` vs canonical `282665` (delta 9428) due to the mint precompile RPC gap tracked by #372 Track A. The `KNOWN_UNWIRED_TESTS` reason string in `check-gravity-invariants.sh` is now precise to that exact block/tx/delta; issue #372's body has been updated to associate the failing test fn names.

Two new commits:
5. `test: fix ALPHA_TIME_ALWAYS fixture in gravity_system_tx_simulation_anti_spoof_test`
6. `ci: sharpen KNOWN_UNWIRED reason for gravity_system_tx_post_alpha_trace_test`

**Every `#[test]` fn added by #367 is now accounted for**: 17 PASS + 2 DEFERRED-to-#372. No silently-skipped, no assertion-touched. The 19th test (the dual `test_e2e_dual_backend_state_root_equivalence_across_alpha_boundary`) was removed and its invariants folded into U-6 + U-6b + U-6c + U-6d unit tests (see Update 1).
