### PR TITLE
fix(pipe-exec): mirror EIP-7702 self-authorization nonce bump in filter_invalid_txs

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -280,6 +280,50 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         let total_spent = gas_spent.saturating_add(tx.value());
         account.balance -= total_spent;
         account.nonce += 1;
+        // EIP-7702 self-authorization nonce side-effect. revm bumps the caller's nonce once
+        // above (mirroring `validate_against_state_and_deduct_caller`), then bumps it AGAIN for
+        // every valid authorization whose authority is this same account, when it applies the
+        // delegation (`apply_auth_list` → `delegate()` → `bump_nonce`). A self-sponsored SetCode
+        // tx therefore advances the sender's nonce by 2, not 1. If the filter only counts +1, a
+        // following same-sender tx at `nonce+1` co-located in the block passes here but hits
+        // `NonceTooLow` in revm → executor panic at `lib.rs:1329` → persistent halt. Mirror
+        // revm's `apply_auth_list` acceptance EXACTLY (revm-handler `pre_execution.rs`).
+        // Closes gravity-audit#822 (self-authorization case).
+        //
+        // Scope: only `authority == sender` is handled here — a cross-account authorization
+        // bumps a *different* account's nonce, which this per-sender pass cannot observe. That
+        // variant requires a block-order simulation over a shared nonce map (tracked in #822).
+        if tx.is_eip7702() {
+            if let Some(auth_list) = tx.authorization_list() {
+                for auth in auth_list {
+                    // chain_id must be 0 (any chain) or the current chain.
+                    if !auth.chain_id().is_zero() && *auth.chain_id() != U256::from(cfg_chain_id) {
+                        continue;
+                    }
+                    // revm skips authorities whose nonce is u64::MAX.
+                    if auth.nonce() == u64::MAX {
+                        continue;
+                    }
+                    // Only a self-authorization advances THIS account's simulated nonce.
+                    let Ok(authority) = auth.recover_authority() else {
+                        continue;
+                    };
+                    if authority != *sender {
+                        continue;
+                    }
+                    // authority == sender: its code is empty-or-7702 (a sender with
+                    // non-delegation code was already dropped by the EIP-3607 gate, and a
+                    // delegation only ever writes the 0xef0100 designator), so revm's code
+                    // check always passes here. Its current simulated nonce is `account.nonce`
+                    // (post caller-bump). revm applies the delegation and bumps the nonce iff
+                    // `auth.nonce == authority.nonce`; multiple self-auths chain off the
+                    // evolving nonce, exactly as this loop does.
+                    if auth.nonce() == account.nonce {
+                        account.nonce += 1;
+                    }
+                }
+            }
+        }
         true
     };
 


### PR DESCRIPTION
## What

`filter_invalid_txs` (the pre-execution tx-admission gate) simulates each sender's
nonce as `+1` per tx — the caller bump. It did not mirror the **second** nonce
bump revm applies when a transaction's own authorization list delegates the
sender (`authority == tx.from`): revm bumps the caller nonce in
`validate_against_state_and_deduct_caller`, then bumps it again in
`apply_auth_list` (`delegate()` → `bump_nonce`). A self-sponsored EIP-7702
SetCode tx therefore advances the sender's nonce by **2**, not 1.

Because the filter under-counted by 1, a following same-sender tx at `nonce+1`
co-located in the same ordered block passed the filter but was then rejected by
revm with `NonceTooLow`, reaching the ordered-block executor's fatal
`InvalidTransaction` path.

This closes the last uncovered `InvalidTransaction` divergence in the
"`filter_invalid_txs` must be a complete superset of revm tx-level validation"
line of work (cf. #343 / #357 / #358). Full analysis, severity and reproduction
are tracked privately in **gravity-audit#822**.

## Change

In `is_tx_valid`, after the caller bump, for a type-4 tx recover each
authorization and — for any `authority == sender` that matches revm's
`apply_auth_list` acceptance (chain_id 0-or-current, `nonce != u64::MAX`, code
empty-or-7702, `auth.nonce == account.nonce`) — apply the second
`account.nonce += 1`. This mirrors revm exactly, including chained
self-authorizations (each subsequent tuple checks the evolving nonce).

**Scope:** `authority == sender` (self-sponsored) — the intra-sender case this
per-sender pass can model. A cross-account authorization bumps a *different*
account's nonce, which this pass cannot observe; that variant needs a block-order
simulation over a shared nonce map and is tracked in gravity-audit#822.

## Verification

Reproduced end-to-end on a Prague single-node devnet built from this branch's
parent (`a379a86`): the self-auth + `nonce+1` pair took the node down before the
fix; with the fix the SetCode tx executes, the now-stale `nonce+1` tx is dropped
at the filter, and the chain keeps producing blocks. The existing Prague
EIP-7702 e2e suite (P-B1..P-B8) passes unchanged.

## Follow-up

Extend `oracle_filter_vs_revm_*` to **multi-tx sequences** — this divergence was
missed because the differential oracle tested transactions in isolation, where
per-tx nonce looks non-divergent.
