### PR TITLE
fix(exec): [v1.7] close EIP-7702 cross-account nonce halt + harden recoverable-error panics

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/dkg.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/dkg.rs
@@ -232,7 +232,21 @@ fn convert_randomness_config(
     let variant = match config.variant {
         ConfigVariant::Off => gravity_api_types::on_chain_config::dkg::ConfigVariant::Off,
         ConfigVariant::V2 => gravity_api_types::on_chain_config::dkg::ConfigVariant::V2,
-        ConfigVariant::__Invalid => panic!("Invalid ConfigVariant"),
+        // An out-of-range on-chain ConfigVariant (alloy decodes an unknown enum byte to
+        // `__Invalid` on the non-validating log path) must NOT panic — this runs on the
+        // deterministic event-decode path in execute_ordered_block, so a panic would halt
+        // every validator on the block emitting it and re-halt on restart (gravity-audit#822
+        // class). Degrade to the safe `Off` (randomness disabled) and log loudly: this is a
+        // system-contract / config-version mismatch signal, never a valid steady state.
+        ConfigVariant::__Invalid => {
+            tracing::error!(
+                target: "gravity::onchain_config::dkg",
+                "unexpected out-of-range RandomnessConfig variant decoded on-chain; \
+                 treating as Off — indicates a system-contract/config-version mismatch, \
+                 NOT a valid state"
+            );
+            gravity_api_types::on_chain_config::dkg::ConfigVariant::Off
+        }
     };
 
     // For Off variant, configV1 should be default/empty

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
@@ -7,17 +7,13 @@
 //! For blockchain events, the payload from relayer is ABI-encoded and passed through unchanged.
 //! This ensures byte-exact match between relayer, on-chain storage, and read-back for comparison.
 
-use super::{
-    new_system_call_txn,
-    types::{GaptosRsaJwk, OracleRSA_JWK, SOURCE_TYPE_JWK},
-    NATIVE_ORACLE_ADDR,
-};
-use alloy_primitives::{keccak256, Bytes, U256};
+use super::{new_system_call_txn, NATIVE_ORACLE_ADDR};
+use alloy_primitives::{Bytes, U256};
 use alloy_sol_macro::sol;
 use alloy_sol_types::SolCall;
 use gravity_api_types::on_chain_config::jwks::{JWKStruct, ProviderJWKs};
 use reth_ethereum_primitives::TransactionSigned;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// Default callback gas limit for oracle updates
 const CALLBACK_GAS_LIMIT: u64 = 500_000;
@@ -60,18 +56,6 @@ fn is_rsa_jwk(jwk: &JWKStruct) -> bool {
 /// Check if a JWKStruct is an UnsupportedJWK (blockchain/other oracle data)
 fn is_unsupported_jwk(jwk: &JWKStruct) -> bool {
     jwk.type_name == "0x1::jwks::Unsupported_JWK"
-}
-
-/// Parse RSA JWK from BCS-encoded data
-fn parse_rsa_jwk_from_bcs(data: &[u8]) -> Option<OracleRSA_JWK> {
-    let gaptos_jwk: GaptosRsaJwk = bcs::from_bytes(data).ok()?;
-    Some(OracleRSA_JWK {
-        kid: gaptos_jwk.kid,
-        kty: gaptos_jwk.kty,
-        alg: gaptos_jwk.alg,
-        e: gaptos_jwk.e,
-        n: gaptos_jwk.n,
-    })
 }
 
 /// Parse chain_id from issuer URI
@@ -167,20 +151,24 @@ pub fn construct_oracle_record_transaction(
         .ok_or_else(|| format!("No JWKs found for issuer: {}", issuer_str))?;
 
     if is_rsa_jwk(first_jwk) {
-        // RSA JWK path is not currently used in production. All JWK data flows through
-        // the UnsupportedJWK (blockchain event) path. If this is reached, something
-        // unexpected has changed in the consensus layer.
-        error!(
+        // RSA JWK path is not exercised in production today — all JWK data flows through the
+        // UnsupportedJWK (blockchain event) path, and the RSA record construction has never
+        // been audited/exercised. Fail CLOSED: return a recoverable `Err` rather than run
+        // unverified construction logic. It must NEVER panic — this runs on the deterministic
+        // execute_ordered_block system-tx path (over consensus `extra_data`), whose `Err` the
+        // caller logs + skips (lib.rs), so a panic here would deterministically halt every
+        // validator on this ordered block (gravity-audit#822 class).
+        warn!(
             target: "gravity::onchain_config::jwk_oracle",
             issuer = %issuer_str,
             jwk_count = provider_jwks.jwks.len(),
-            "RSA JWK path entered unexpectedly — this code path should be unreachable"
+            "RSA JWK path entered unexpectedly — rejecting (unsupported in production)"
         );
-        panic!(
-            "RSA JWK oracle record path is unreachable: issuer={}, jwk_count={}",
+        Err(format!(
+            "RSA JWK oracle record path is not supported: issuer={}, jwk_count={}",
             issuer_str,
             provider_jwks.jwks.len()
-        );
+        ))
     } else if is_unsupported_jwk(first_jwk) {
         // Blockchain/oracle events - use recordBatch for ALL logs
         construct_blockchain_batch_transaction(provider_jwks, nonce, gas_price)
@@ -188,46 +176,6 @@ pub fn construct_oracle_record_transaction(
         warn!(target: "gravity::onchain_config::jwk_oracle", "Unknown JWK type '{}' for issuer: {}", first_jwk.type_name, issuer_str);
         Err(format!("Unknown JWK type '{}' for issuer: {}", first_jwk.type_name, issuer_str))
     }
-}
-
-/// Construct transaction for JWK update (sourceType=1)
-fn construct_jwk_record_transaction(
-    provider_jwks: ProviderJWKs,
-    nonce: u64,
-    gas_price: u128,
-) -> Result<TransactionSigned, String> {
-    let issuer = &provider_jwks.issuer;
-    let version = provider_jwks.version;
-
-    // All JWKs are guaranteed to be RSA type when entering this function
-    let rsa_jwks: Vec<OracleRSA_JWK> =
-        provider_jwks.jwks.iter().filter_map(|jwk| parse_rsa_jwk_from_bcs(&jwk.data)).collect();
-
-    info!(
-        issuer = %String::from_utf8_lossy(issuer),
-        version = version,
-        jwk_count = rsa_jwks.len(),
-        "Constructing JWK record transaction"
-    );
-
-    // sourceId = keccak256(issuer)
-    let issuer_hash = keccak256(issuer);
-    let source_id = U256::from_be_bytes(issuer_hash.0);
-
-    // Encode payload: (bytes issuer, uint64 version, OracleRSA_JWK[] jwks)
-    let payload = alloy_sol_types::SolValue::abi_encode(&(issuer.as_slice(), version, rsa_jwks));
-
-    let call = recordCall {
-        sourceType: SOURCE_TYPE_JWK,
-        sourceId: source_id,
-        nonce: version as u128,
-        blockNumber: U256::ZERO, // JWK records don't have a source block number
-        payload: payload.into(),
-        callbackGasLimit: U256::from(CALLBACK_GAS_LIMIT),
-    };
-
-    let input: Bytes = call.abi_encode().into();
-    Ok(new_system_call_txn(NATIVE_ORACLE_ADDR, nonce, gas_price, input))
 }
 
 /// Construct transaction for blockchain events using recordBatch()

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -42,6 +42,11 @@
 //!   `account.nonce += 1`.
 //! - `Eip7873NotSupported` / `Eip7873MissingTarget` — activates on OSAKA. Adding Osaka requires an
 //!   init-code-tx type gate.
+//! - `TxGasLimitGreaterThanCap` — EIP-7825 tx gas-limit cap. `validate_tx_env`
+//!   (`validation.rs:116-123`) rejects `tx.gas_limit() > cfg.tx_gas_limit_cap()`; that cap is
+//!   `u64::MAX` pre-OSAKA and `eip7825::TX_GAS_LIMIT_CAP` (2^24) from OSAKA on (`revm-context
+//!   cfg.rs:272-278`), so it cannot fire on Gravity's Prague spec. Adding Osaka requires a
+//!   `tx.gas_limit() <= 2^24` gate here.
 //!
 //! Procedure on upgrade: `grep 'return Err(InvalidTransaction::'` in
 //! `revm-handler/src/` for the new pin, diff against the "unreachable" list above,
@@ -55,7 +60,6 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, U256,
 };
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::ParallelDatabase;
@@ -108,11 +112,6 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                 break;
             }
         }
-    }
-
-    let mut sender_idx: HashMap<&Address, Vec<usize>> = HashMap::default();
-    for (i, sender) in senders[..gas_limit_exceeded_tx_idx].iter().enumerate() {
-        sender_idx.entry(sender).or_default().push(i);
     }
 
     let cfg_chain_id = chain_spec.chain_id();
@@ -261,6 +260,14 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         // would pass here and panic in revm with `LackOfFundForMaxFee`. Closes audit#710
         // gap 4. The per-sender simulated balance is then reduced by the *effective*
         // cost so subsequent txs from the same sender see what revm sees post-refund.
+        //
+        // The `saturating_*` arithmetic below is also load-bearing for a second revm variant:
+        // `validate_against_state_and_deduct_caller` calls `tx.max_balance_spending()`
+        // (`pre_execution.rs:135`), which returns `OverflowPaymentInTransaction` when
+        // `gas_limit * max_fee (+ value)` overflows. Saturating to `U256::MAX` and rejecting via
+        // the `balance < max_total` comparison is a strict superset of that reject for every
+        // physically-possible balance (a real divergence needs balance >= 2^128 wei). Keep these
+        // saturating — switching to checked/wrapping would drop the implicit gate.
         let max_charge =
             U256::from(tx.max_fee_per_gas()).saturating_mul(U256::from(tx.gas_limit()));
         let max_total = max_charge.saturating_add(tx.value());
@@ -283,39 +290,100 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         true
     };
 
-    let mut invalid_tx_idxs = sender_idx
-        .into_par_iter()
-        .flat_map(|(sender, idxs)| {
-            let Some(mut account) = db.basic_ref(*sender).unwrap() else {
-                // Sender does not exist in the state trie, balance is 0
-                info!(target: "filter_invalid_txs",
-                    tx_hash=?txs[idxs[0]].hash(),
-                    sender=?sender,
-                    "insufficient balance"
-                );
-                return idxs;
-            };
-            // EIP-3607 gate: a sender with non-empty code cannot originate transactions,
-            // unless the code is a valid EIP-7702 delegation designator (Pectra relaxed
-            // 3607 to permit delegated EOAs). revm fires `RejectCallerWithCode`
-            // otherwise. Per-sender, not per-tx — if the sender has unauthorised code,
-            // all its txs in this batch are invalid. Closes audit#710 gap 6.
-            if account.code_hash != KECCAK_EMPTY {
-                let bytecode =
-                    account.code.clone().or_else(|| db.code_by_hash_ref(account.code_hash).ok());
-                let is_7702_delegation = bytecode.as_ref().map(|b| b.is_eip7702()).unwrap_or(false);
-                if !is_7702_delegation {
-                    info!(target: "filter_invalid_txs",
-                        sender=?sender,
-                        code_hash=?account.code_hash,
-                        "EIP-3607: sender has non-delegation code"
-                    );
-                    return idxs;
+    // `true` if the account's code is empty or a valid EIP-7702 delegation designator —
+    // i.e. it may originate a tx (EIP-3607, closes audit#710 gap 6) and, as an
+    // authorization authority, revm will apply its delegation.
+    let code_permits = |acct: &AccountInfo| -> bool {
+        acct.code_hash == KECCAK_EMPTY ||
+            acct.code
+                .clone()
+                .or_else(|| db.code_by_hash_ref(acct.code_hash).ok())
+                .map(|b| b.is_eip7702())
+                .unwrap_or(false)
+    };
+
+    // Block-order sequential simulation. `sim[addr]` is the address's account evolved
+    // in-block (nonce + balance), seeded lazily from the certified parent state; `None`
+    // marks an address absent from state. It holds BOTH tx senders AND EIP-7702
+    // authorities: a self-sponsored OR cross-account authorization bumps ITS authority's
+    // nonce during execution (revm `apply_auth_list` -> `delegate()` -> `bump_nonce`), so
+    // a *later same-block* tx from that authority must see the bumped nonce, or it hits
+    // `NonceTooLow` in revm and panics the executor (gravity-audit#822).
+    //
+    // This is sequential (not the previous per-sender-parallel pass) because cross-account
+    // nonce effects cross sender groups, so the simulation must advance in a single global
+    // block order. The per-tx guards are cheap; the extra `recover_authority()` ECDSA
+    // recovery runs only for type-4 txs.
+    let mut sim: HashMap<Address, Option<AccountInfo>> = HashMap::default();
+    let mut invalid_tx_idxs: HashSet<usize> = HashSet::default();
+    for idx in 0..gas_limit_exceeded_tx_idx {
+        let tx = &txs[idx];
+        let sender = senders[idx];
+
+        // Validate the tx against the simulated sender account and apply the caller nonce
+        // bump + balance deduction. Scoped so the `sim[sender]` borrow is released before
+        // the authorization loop re-borrows `sim` (an authority may be any account).
+        let valid = {
+            let sender_acct = sim.entry(sender).or_insert_with(|| db.basic_ref(sender).unwrap());
+            match sender_acct.as_mut() {
+                // Sender absent from state -> cannot pay for / originate the tx.
+                None => false,
+                Some(account) => {
+                    if !code_permits(account) {
+                        info!(target: "filter_invalid_txs",
+                            sender=?sender,
+                            code_hash=?account.code_hash,
+                            "EIP-3607: sender has non-delegation code"
+                        );
+                        false
+                    } else {
+                        // Mutates `account` (caller nonce bump + balance deduct) on success.
+                        is_tx_valid(tx, &sender, account)
+                    }
                 }
             }
-            idxs.into_iter().filter(|&idx| !is_tx_valid(&txs[idx], sender, &mut account)).collect()
-        })
-        .collect::<HashSet<_>>();
+        };
+        if !valid {
+            invalid_tx_idxs.insert(idx);
+            continue;
+        }
+
+        // Mirror revm `apply_auth_list`: for a type-4 tx every valid authorization bumps
+        // ITS authority's nonce once — self (authority == sender) AND cross-account. The
+        // caller bump above already advanced the sender, so a self-authorization matching
+        // `sender_nonce + 1` bumps it a second time; chained authorizations advance off the
+        // evolving simulated nonce exactly as revm applies them in order.
+        if tx.is_eip7702() {
+            if let Some(auth_list) = tx.authorization_list() {
+                for auth in auth_list {
+                    if !auth.chain_id().is_zero() && *auth.chain_id() != U256::from(cfg_chain_id) {
+                        continue;
+                    }
+                    if auth.nonce() == u64::MAX {
+                        continue;
+                    }
+                    let Ok(authority) = auth.recover_authority() else { continue };
+                    let auth_acct =
+                        sim.entry(authority).or_insert_with(|| db.basic_ref(authority).unwrap());
+                    // revm applies the delegation iff the authority's (block-start) code is
+                    // empty/7702 and its *current* nonce equals the authorization nonce; a
+                    // nonexistent authority has nonce 0 and is created on delegation.
+                    let (authority_nonce, code_ok) = match auth_acct.as_ref() {
+                        Some(a) => (a.nonce, code_permits(a)),
+                        None => (0, true),
+                    };
+                    if code_ok && auth.nonce() == authority_nonce {
+                        match auth_acct {
+                            Some(a) => a.nonce = a.nonce.saturating_add(1),
+                            None => {
+                                *auth_acct = Some(AccountInfo { nonce: 1, ..Default::default() })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     invalid_tx_idxs.extend(gas_limit_exceeded_tx_idx..txs.len());
     invalid_tx_idxs
 }


### PR DESCRIPTION
## Summary

Backport of #385 onto `branch-v1.7`.

Cherry-pick of `c7c58074` applied cleanly on top of `3fd603db` (v1.7 base), with git auto-merging one hunk in `dkg.rs`. No manual conflict resolution required.

Files touched (matches the deferred-scope tip of #385 — filter/exec/jwk/dkg only):
- `crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs`
- `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs`
- `crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/dkg.rs`

Context see #385:
- close EIP-7702 cross-account nonce halt (block-order sim in `filter_invalid_txs` mirrors revm's caller + `apply_auth_list` nonce bumps for self AND cross-account authorities)
- harden recoverable-error panics on the deterministic execution path (RSA JWK fail-closed, DKG on-chain enum unknown-variant degrade-to-Off)

## Test plan

- [x] `cargo check -p reth-pipe-exec-layer-ext-v2` passes on the backport
- [ ] CI green