### PR TITLE
docs(evm): explain Gravity withdrawal invariant

### DIFF
--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -367,7 +367,12 @@ where
         );
     }
 
-    // process withdrawals
+    // Gravity ordered blocks cannot carry proposer-controlled withdrawals: the Gravity SDK
+    // consensus block has no withdrawals field and every honest node's reth adapter constructs an
+    // empty list. A Byzantine node that modifies its local adapter would compute a different block
+    // hash, while commit votes bind the execution result, so that result cannot join an honest
+    // quorum. Keep the standard withdrawal processing here because this generic executor is also
+    // used to replay and validate post-Shanghai Ethereum mainnet history.
     insert_post_block_withdrawals_balance_increments(
         chain_spec,
         block.header().timestamp(),


### PR DESCRIPTION
close https://github.com/Galxe/gravity-audit/issues/839

## Summary

- document why Gravity ordered blocks cannot carry proposer-controlled withdrawals
- explain that divergent local execution results cannot join an honest commit quorum
- clarify that standard withdrawal processing remains necessary for Ethereum mainnet history replay

This addresses the exploitability assumption raised in Galxe/gravity-audit#839 without changing execution semantics.

Documentation-only change; no runtime behavior changed.