### PR TITLE
feat(exec): skip recoverable invalid transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,15 +1497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,11 +4480,10 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=eecc6fc8bfcc07916517ac15f41a70c8036381bb#eecc6fc8bfcc07916517ac15f41a70c8036381bb"
+source = "git+https://github.com/Galxe/grevm?rev=dcd1460b20d9f3d793c8309c28b0b7401be91523#dcd1460b20d9f3d793c8309c28b0b7401be91523"
 dependencies = [
  "ahash",
  "alloy-evm",
- "atomic",
  "auto_impl",
  "dashmap 6.2.1",
  "futures",
@@ -8919,10 +8909,12 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-sol-types",
  "derive_more",
  "gravity-primitives",
  "grevm",
  "parking_lot",
+ "postcard",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -8933,6 +8925,7 @@ dependencies = [
  "reth-testing-utils",
  "revm",
  "secp256k1 0.30.0",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,7 +451,7 @@ reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
 reth-revm = { path = "crates/revm", default-features = false }
-grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", rev = "eecc6fc8bfcc07916517ac15f41a70c8036381bb" }
+grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", rev = "dcd1460b20d9f3d793c8309c28b0b7401be91523" }
 reth-rpc = { path = "crates/rpc/rpc" }
 reth-rpc-api = { path = "crates/rpc/rpc-api" }
 reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }
@@ -583,6 +583,7 @@ parity-scale-codec = "3.2.1"
 parking_lot = "0.12"
 quanta = "0.12"
 paste = "1.0"
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 rand = "0.9"
 rayon = "1.7"
 thread-priority = "3.0.0"

--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -27,6 +27,14 @@ hardfork!(
 /// design §2.5 ("地址字面量收口").
 pub const SYSTEM_CALLER: Address = address!("00000000000000000000000000000001625f0000");
 
+/// Protocol-reserved synthetic emitter for `GravityTxSkipped` receipt logs.
+///
+/// This is not an EVM account or precompile. It is reserved in the Gravity system-address
+/// namespace so indexers can query skipped transactions through a single stable emitter without
+/// risking a future system contract reusing the same address.
+pub const GRAVITY_TX_SKIPPED_LOG_ADDRESS: Address =
+    address!("00000000000000000000000000000001625f50ff");
+
 /// Returns `true` iff `addr` is the canonical Gravity [`SYSTEM_CALLER`].
 ///
 /// Prefer this helper over direct comparison so future address-shape changes have a

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -31,7 +31,7 @@ pub use alloy_evm::EvmLimitParams;
 pub use api::EthChainSpec;
 pub use gravity::{
     is_gravity_system_caller, is_system_tx_gas_exempt, system_txs_form_head_prefix,
-    GravityHardfork, SYSTEM_CALLER,
+    GravityHardfork, GRAVITY_TX_SKIPPED_LOG_ADDRESS, SYSTEM_CALLER,
 };
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,7 +20,7 @@ reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
 reth-primitives-traits.workspace = true
 reth-ethereum-primitives.workspace = true
-revm = { workspace = true, features = ["optional_balance_check", "optional_no_base_fee"] }
+revm = { workspace = true, features = ["optional_balance_check", "optional_no_base_fee", "serde"] }
 reth-evm.workspace = true
 grevm.workspace = true
 gravity-primitives.workspace = true
@@ -32,10 +32,13 @@ alloy-eips.workspace = true
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
+alloy-sol-types.workspace = true
 
 # Misc
 parking_lot = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true }
+postcard.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 reth-testing-utils.workspace = true
@@ -62,7 +65,10 @@ std = [
     "reth-ethereum-primitives/std",
     "derive_more?/std",
     "alloy-rpc-types-engine/std",
+    "alloy-sol-types/std",
+    "postcard/use-std",
     "reth-storage-errors/std",
+    "tracing/std",
 ]
 test-utils = [
     "std",

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -29,12 +29,11 @@ use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_types_engine::ExecutionData;
 use core::{convert::Infallible, fmt::Debug};
 use gravity_primitives::get_gravity_config;
+use grevm::{DelegatedSafetyConfig, GrevmConfig};
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, MAINNET};
 use reth_ethereum_primitives::{Block, EthPrimitives};
 use reth_evm::{
-    eth::NextEvmEnvAttributes,
-    execute::{BasicBlockExecutor, BlockExecutionError},
-    parallel_execute::{ParallelExecutor, WrapExecutor},
+    eth::NextEvmEnvAttributes, execute::BlockExecutionError, parallel_execute::ParallelExecutor,
     ConfigureEvm, EvmEnv, NextBlockEnvAttributes, ParallelDatabase,
 };
 use reth_primitives_traits::{constants::GRAVITY_TX_GAS_LIMIT_CAP, SealedBlock, SealedHeader};
@@ -44,7 +43,7 @@ use revm::{
         BlockEnv, CfgEnv, TxEnv,
     },
     context_interface::block::BlobExcessGasAndPrice,
-    database::{State, WrapDatabaseRef},
+    database::State,
     primitives::hardfork::SpecId,
     DatabaseCommit,
 };
@@ -78,6 +77,7 @@ pub mod execute {
 
 pub mod hardfork;
 pub mod parallel_execute;
+pub mod skipped_transaction;
 
 // ============================================================================
 // Gravity system-tx gas-exempt gating
@@ -166,6 +166,34 @@ impl<ChainSpec, EvmFactory> EthEvmConfig<ChainSpec, EvmFactory> {
 const fn apply_gravity_tx_gas_cap(cfg_env: &mut CfgEnv, osaka_active: bool) {
     if osaka_active {
         cfg_env.tx_gas_limit_cap = Some(GRAVITY_TX_GAS_LIMIT_CAP);
+    }
+}
+
+impl<ChainSpec> EthEvmConfig<ChainSpec>
+where
+    ChainSpec: EthExecutorSpec + EthChainSpec<Header = Header> + Hardforks + 'static,
+{
+    /// Creates a grevm executor with the delegated-account policy required by the caller.
+    ///
+    /// The regular history-sync path passes [`DelegatedSafetyConfig::disabled`]. Gravity's live
+    /// pipeline passes [`DelegatedSafetyConfig::enabled`]; grevm makes that policy inert for
+    /// pre-Prague specs on a per-block basis.
+    pub fn parallel_executor_with_delegated_safety<'a, DB: ParallelDatabase + 'a>(
+        &self,
+        db: DB,
+        delegated_safety: DelegatedSafetyConfig,
+    ) -> Box<dyn ParallelExecutor<Primitives = EthPrimitives, Error = BlockExecutionError> + 'a>
+    {
+        let mut config = GrevmConfig::from_env().with_delegated_safety(delegated_safety);
+        if get_gravity_config().disable_grevm {
+            config.force_sequential = true;
+        }
+        Box::new(GrevmExecutor::new_with_runtime_config(
+            self.chain_spec().clone(),
+            self,
+            db,
+            config,
+        ))
     }
 }
 
@@ -263,11 +291,7 @@ where
         db: DB,
     ) -> Box<dyn ParallelExecutor<Primitives = Self::Primitives, Error = BlockExecutionError> + 'a>
     {
-        if get_gravity_config().disable_grevm {
-            Box::new(WrapExecutor::new(BasicBlockExecutor::new(self.clone(), WrapDatabaseRef(db))))
-        } else {
-            Box::new(GrevmExecutor::new(self.chain_spec().clone(), self, db))
-        }
+        self.parallel_executor_with_delegated_safety(db, DelegatedSafetyConfig::disabled())
     }
 
     fn transact_system_txn<DB: Database>(

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
 };
 use alloy_primitives::{map::HashMap, Address};
 use gravity_primitives::get_gravity_config;
-use grevm::{ParallelBundleState, ParallelState, Scheduler};
+use grevm::{GrevmConfig, ParallelBundleState, ParallelState, Scheduler, TxExecutionOutcome};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, Hardforks};
 use reth_ethereum_primitives::{Block, EthPrimitives, Receipt};
 use reth_evm::{
@@ -36,6 +36,12 @@ use revm::{
     Database, DatabaseCommit,
 };
 
+pub use crate::skipped_transaction::{
+    GravityTxSkipReason, GravityTxSkippedEvent, GRAVITY_TX_SKIPPED_LOG_TOPIC0,
+    GRAVITY_TX_SKIPPED_LOG_VERSION,
+};
+pub use reth_chainspec::GRAVITY_TX_SKIPPED_LOG_ADDRESS;
+
 /// EVM executor using Grevm that executes blocks in parallel.
 #[derive(Debug)]
 pub struct GrevmExecutor<DB, EvmConfig, ChainSpec> {
@@ -49,6 +55,8 @@ pub struct GrevmExecutor<DB, EvmConfig, ChainSpec> {
     system_caller: SystemCaller<Arc<ChainSpec>>,
     /// Custom precompiled contracts to inject into the EVM.
     custom_precompiles: Option<Arc<Vec<(Address, DynPrecompile)>>>,
+    /// Block-scoped grevm execution policy.
+    grevm_config: GrevmConfig,
 }
 
 impl<DB, EvmConfig, ChainSpec> GrevmExecutor<DB, EvmConfig, ChainSpec>
@@ -63,6 +71,23 @@ where
 {
     /// Creates a new [`GrevmExecutor`]
     pub fn new(chain_spec: Arc<ChainSpec>, evm_config: &EvmConfig, db: DB) -> Self {
+        Self::new_with_runtime_config(chain_spec, evm_config, db, GrevmConfig::from_env())
+    }
+
+    /// Creates a [`GrevmExecutor`] that executes user transactions sequentially.
+    pub fn new_sequential(chain_spec: Arc<ChainSpec>, evm_config: &EvmConfig, db: DB) -> Self {
+        let mut config = GrevmConfig::from_env();
+        config.force_sequential = true;
+        Self::new_with_runtime_config(chain_spec, evm_config, db, config)
+    }
+
+    /// Creates a [`GrevmExecutor`] with an explicit block execution policy.
+    pub fn new_with_runtime_config(
+        chain_spec: Arc<ChainSpec>,
+        evm_config: &EvmConfig,
+        db: DB,
+        grevm_config: GrevmConfig,
+    ) -> Self {
         let system_caller = SystemCaller::new(chain_spec.clone());
         let report_db_metrics = get_gravity_config().report_db_metrics;
         Self {
@@ -71,6 +96,7 @@ where
             evm_config: evm_config.clone(),
             system_caller,
             custom_precompiles: None,
+            grevm_config,
         }
     }
 
@@ -107,15 +133,15 @@ where
 
         let (results, state) = {
             let EvmEnv { cfg_env, block_env } = evm_env;
-            let executor = Scheduler::new(
+            let executor = Scheduler::new_with_runtime_config(
                 cfg_env,
                 block_env,
                 txs,
                 state,
-                false,
                 self.custom_precompiles.clone(),
+                self.grevm_config.clone(),
             );
-            executor.parallel_execute(None).map_err(|e| {
+            executor.execute().map_err(|e| {
                 // `e.txid` is grevm's per-tx index; for block-level errors it can be a
                 // sentinel or out-of-bounds value. Use a saturating lookup so the error
                 // path itself cannot panic (closes gravity-audit#696 trigger 4 fallout —
@@ -136,18 +162,52 @@ where
 
         self.state = Some(state);
 
+        if results.len() != block.transaction_count() {
+            return Err(BlockExecutionError::msg(alloc::format!(
+                "grevm outcome count mismatch: got {}, expected {}",
+                results.len(),
+                block.transaction_count()
+            )))
+        }
+
         let mut receipts = Vec::with_capacity(results.len());
         let mut cumulative_gas_used = 0;
-        for (result, tx_type) in
-            results.into_iter().zip(block.body().transactions().map(|tx| tx.tx_type()))
+        for (tx_index, (outcome, transaction)) in
+            results.into_iter().zip(block.body().transactions()).enumerate()
         {
-            cumulative_gas_used += result.tx_gas_used();
-            receipts.push(Receipt {
-                tx_type,
-                success: result.is_success(),
-                cumulative_gas_used,
-                logs: result.into_logs(),
-            });
+            let tx_type = transaction.tx_type();
+            match outcome {
+                TxExecutionOutcome::Executed(result) => {
+                    cumulative_gas_used += result.tx_gas_used();
+                    receipts.push(Receipt {
+                        tx_type,
+                        success: result.is_success(),
+                        cumulative_gas_used,
+                        logs: result.into_logs(),
+                    });
+                }
+                TxExecutionOutcome::Skipped(error) => {
+                    let tx_hash = transaction.recalculate_hash();
+                    let reason = GravityTxSkipReason::from_invalid_transaction(&error);
+                    tracing::error!(
+                        target: "reth::evm::skipped_transaction",
+                        block_number = block.number,
+                        tx_index,
+                        ?tx_hash,
+                        ?reason,
+                        "included transaction skipped during final execution",
+                    );
+                    let receipt =
+                        GravityTxSkippedEvent::receipt(tx_type, cumulative_gas_used, &error);
+                    let receipt = receipt.map_err(|encode_error| {
+                        let message = alloc::format!(
+                            "failed to encode skipped transaction {tx_index}: {encode_error}"
+                        );
+                        BlockExecutionError::msg(message)
+                    })?;
+                    receipts.push(receipt);
+                }
+            }
         }
         Ok(ExecuteOutput { receipts, gas_used: cumulative_gas_used })
     }

--- a/crates/ethereum/evm/src/skipped_transaction.rs
+++ b/crates/ethereum/evm/src/skipped_transaction.rs
@@ -1,0 +1,263 @@
+//! Protocol encoding for transactions skipped during Gravity block execution.
+
+use alloy_consensus::TxType;
+use alloy_primitives::{Bytes, Log, B256};
+use alloy_sol_types::{sol, SolEvent};
+use grevm::InvalidTransaction;
+use reth_chainspec::GRAVITY_TX_SKIPPED_LOG_ADDRESS;
+use reth_ethereum_primitives::Receipt;
+
+sol! {
+    /// Emitted in the synthetic receipt of an included transaction that was invalid at final
+    /// execution state and therefore applied as a no-op.
+    event GravityTxSkipped(uint16 indexed version, uint16 indexed reason, bytes encodedError);
+}
+
+/// Current version of the [`GravityTxSkipped`] event encoding.
+pub const GRAVITY_TX_SKIPPED_LOG_VERSION: u16 = 1;
+
+/// `keccak256("GravityTxSkipped(uint16,uint16,bytes)")`, derived from the Solidity declaration.
+pub const GRAVITY_TX_SKIPPED_LOG_TOPIC0: B256 = GravityTxSkipped::SIGNATURE_HASH;
+
+macro_rules! define_skip_reasons {
+    ($($variant:ident = $code:literal => $pattern:pat),+ $(,)?) => {
+        /// The zero-based wire tag for a skipped [`InvalidTransaction`].
+        ///
+        /// Variants intentionally follow the declaration order of revm's [`InvalidTransaction`].
+        /// A revm upgrade that changes that enum must update this table and the log version.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[repr(u16)]
+        pub enum GravityTxSkipReason {
+            $(
+                #[doc = concat!("Corresponds to [`InvalidTransaction::", stringify!($variant), "`].")]
+                $variant = $code,
+            )+
+        }
+
+        impl GravityTxSkipReason {
+            /// Returns the wire tag for `error`.
+            pub const fn from_invalid_transaction(error: &InvalidTransaction) -> Self {
+                match error {
+                    $($pattern => Self::$variant,)+
+                }
+            }
+
+            /// Parses a wire tag.
+            pub const fn from_code(code: u16) -> Option<Self> {
+                match code {
+                    $($code => Some(Self::$variant),)+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+define_skip_reasons! {
+    PriorityFeeGreaterThanMaxFee = 0 => InvalidTransaction::PriorityFeeGreaterThanMaxFee,
+    GasPriceLessThanBasefee = 1 => InvalidTransaction::GasPriceLessThanBasefee,
+    CallerGasLimitMoreThanBlock = 2 => InvalidTransaction::CallerGasLimitMoreThanBlock,
+    CallGasCostMoreThanGasLimit = 3 => InvalidTransaction::CallGasCostMoreThanGasLimit { .. },
+    GasFloorMoreThanGasLimit = 4 => InvalidTransaction::GasFloorMoreThanGasLimit { .. },
+    RejectCallerWithCode = 5 => InvalidTransaction::RejectCallerWithCode,
+    LackOfFundForMaxFee = 6 => InvalidTransaction::LackOfFundForMaxFee { .. },
+    OverflowPaymentInTransaction = 7 => InvalidTransaction::OverflowPaymentInTransaction,
+    NonceOverflowInTransaction = 8 => InvalidTransaction::NonceOverflowInTransaction,
+    NonceTooHigh = 9 => InvalidTransaction::NonceTooHigh { .. },
+    NonceTooLow = 10 => InvalidTransaction::NonceTooLow { .. },
+    CreateInitCodeSizeLimit = 11 => InvalidTransaction::CreateInitCodeSizeLimit,
+    InvalidChainId = 12 => InvalidTransaction::InvalidChainId,
+    MissingChainId = 13 => InvalidTransaction::MissingChainId,
+    TxGasLimitGreaterThanCap = 14 => InvalidTransaction::TxGasLimitGreaterThanCap { .. },
+    AccessListNotSupported = 15 => InvalidTransaction::AccessListNotSupported,
+    MaxFeePerBlobGasNotSupported = 16 => InvalidTransaction::MaxFeePerBlobGasNotSupported,
+    BlobVersionedHashesNotSupported = 17 => InvalidTransaction::BlobVersionedHashesNotSupported,
+    BlobGasPriceGreaterThanMax = 18 => InvalidTransaction::BlobGasPriceGreaterThanMax { .. },
+    EmptyBlobs = 19 => InvalidTransaction::EmptyBlobs,
+    BlobCreateTransaction = 20 => InvalidTransaction::BlobCreateTransaction,
+    TooManyBlobs = 21 => InvalidTransaction::TooManyBlobs { .. },
+    BlobVersionNotSupported = 22 => InvalidTransaction::BlobVersionNotSupported,
+    AuthorizationListNotSupported = 23 => InvalidTransaction::AuthorizationListNotSupported,
+    AuthorizationListInvalidFields = 24 => InvalidTransaction::AuthorizationListInvalidFields,
+    EmptyAuthorizationList = 25 => InvalidTransaction::EmptyAuthorizationList,
+    Eip2930NotSupported = 26 => InvalidTransaction::Eip2930NotSupported,
+    Eip1559NotSupported = 27 => InvalidTransaction::Eip1559NotSupported,
+    Eip4844NotSupported = 28 => InvalidTransaction::Eip4844NotSupported,
+    Eip7702NotSupported = 29 => InvalidTransaction::Eip7702NotSupported,
+    Eip7873NotSupported = 30 => InvalidTransaction::Eip7873NotSupported,
+    Eip7873MissingTarget = 31 => InvalidTransaction::Eip7873MissingTarget,
+    Str = 32 => InvalidTransaction::Str(_),
+}
+
+/// Encoder and decoder for Gravity's synthetic skipped-transaction receipt.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GravityTxSkippedEvent;
+
+impl GravityTxSkippedEvent {
+    /// Creates a protocol log containing the complete [`InvalidTransaction`].
+    ///
+    /// Postcard encodes the enum variant as its zero-based declaration index and serializes every
+    /// field carried by that variant.
+    pub fn encode(error: &InvalidTransaction) -> Result<Log, postcard::Error> {
+        let reason = GravityTxSkipReason::from_invalid_transaction(error);
+        let encoded_error = postcard::to_allocvec(error)?;
+        Ok(Log {
+            address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
+            data: GravityTxSkipped {
+                version: GRAVITY_TX_SKIPPED_LOG_VERSION,
+                reason: reason as u16,
+                encodedError: Bytes::from(encoded_error),
+            }
+            .encode_log_data(),
+        })
+    }
+
+    /// Parses a protocol log and reconstructs the complete [`InvalidTransaction`].
+    ///
+    /// A wrong emitter, ABI shape, version, tag, payload, or tag/payload mismatch is rejected.
+    pub fn decode(log: &Log) -> Option<InvalidTransaction> {
+        if log.address != GRAVITY_TX_SKIPPED_LOG_ADDRESS {
+            return None
+        }
+
+        let event = GravityTxSkipped::decode_log(log).ok()?;
+        if event.version != GRAVITY_TX_SKIPPED_LOG_VERSION {
+            return None
+        }
+
+        let reason = GravityTxSkipReason::from_code(event.reason)?;
+        let error = postcard::from_bytes::<InvalidTransaction>(&event.encodedError).ok()?;
+        if GravityTxSkipReason::from_invalid_transaction(&error) != reason {
+            return None
+        }
+        Some(error)
+    }
+
+    /// Builds the zero-gas failed receipt for a skipped transaction.
+    pub fn receipt(
+        tx_type: TxType,
+        cumulative_gas_used: u64,
+        error: &InvalidTransaction,
+    ) -> Result<Receipt, postcard::Error> {
+        Ok(Receipt {
+            tx_type,
+            success: false,
+            cumulative_gas_used,
+            logs: alloc::vec![Self::encode(error)?],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{borrow::Cow, boxed::Box, vec, vec::Vec};
+    use alloy_primitives::{keccak256, Address, LogData, U256};
+
+    #[test]
+    fn topic_is_derived_from_the_documented_solidity_signature() {
+        assert_eq!(
+            GRAVITY_TX_SKIPPED_LOG_TOPIC0,
+            keccak256("GravityTxSkipped(uint16,uint16,bytes)")
+        );
+    }
+
+    #[test]
+    fn all_invalid_transactions_round_trip_with_declaration_order_tags() {
+        let errors = all_invalid_transactions();
+        for (expected_tag, error) in errors.into_iter().enumerate() {
+            let log = GravityTxSkippedEvent::encode(&error).unwrap();
+            let event = GravityTxSkipped::decode_log(&log).unwrap();
+            assert_eq!(event.reason, expected_tag as u16);
+            assert_eq!(event.encodedError.first().copied(), Some(expected_tag as u8));
+            assert_eq!(GravityTxSkippedEvent::decode(&log), Some(error));
+        }
+    }
+
+    #[test]
+    fn event_decode_rejects_non_protocol_logs_and_mismatched_tags() {
+        let error = InvalidTransaction::NonceTooLow { tx: 0, state: 1 };
+        let log = GravityTxSkippedEvent::encode(&error).unwrap();
+        let mut wrong_emitter = log;
+        wrong_emitter.address = Address::ZERO;
+        assert_eq!(GravityTxSkippedEvent::decode(&wrong_emitter), None);
+
+        let unknown_reason = Log {
+            address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
+            data: GravityTxSkipped {
+                version: GRAVITY_TX_SKIPPED_LOG_VERSION,
+                reason: u16::MAX,
+                encodedError: Bytes::from(postcard::to_allocvec(&error).unwrap()),
+            }
+            .encode_log_data(),
+        };
+        assert_eq!(GravityTxSkippedEvent::decode(&unknown_reason), None);
+
+        let mismatched_reason = Log {
+            address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
+            data: GravityTxSkipped {
+                version: GRAVITY_TX_SKIPPED_LOG_VERSION,
+                reason: GravityTxSkipReason::NonceTooHigh as u16,
+                encodedError: Bytes::from(postcard::to_allocvec(&error).unwrap()),
+            }
+            .encode_log_data(),
+        };
+        assert_eq!(GravityTxSkippedEvent::decode(&mismatched_reason), None);
+
+        let malformed = Log {
+            address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
+            data: LogData::new_unchecked(
+                alloc::vec![GRAVITY_TX_SKIPPED_LOG_TOPIC0],
+                Default::default(),
+            ),
+        };
+        assert_eq!(GravityTxSkippedEvent::decode(&malformed), None);
+    }
+
+    fn all_invalid_transactions() -> Vec<InvalidTransaction> {
+        vec![
+            InvalidTransaction::PriorityFeeGreaterThanMaxFee,
+            InvalidTransaction::GasPriceLessThanBasefee,
+            InvalidTransaction::CallerGasLimitMoreThanBlock,
+            InvalidTransaction::CallGasCostMoreThanGasLimit {
+                initial_gas: 21_001,
+                gas_limit: 21_000,
+            },
+            InvalidTransaction::GasFloorMoreThanGasLimit { gas_floor: 30_000, gas_limit: 21_000 },
+            InvalidTransaction::RejectCallerWithCode,
+            InvalidTransaction::LackOfFundForMaxFee {
+                fee: Box::new(U256::from(100)),
+                balance: Box::new(U256::from(99)),
+            },
+            InvalidTransaction::OverflowPaymentInTransaction,
+            InvalidTransaction::NonceOverflowInTransaction,
+            InvalidTransaction::NonceTooHigh { tx: 2, state: 1 },
+            InvalidTransaction::NonceTooLow { tx: 0, state: 1 },
+            InvalidTransaction::CreateInitCodeSizeLimit,
+            InvalidTransaction::InvalidChainId,
+            InvalidTransaction::MissingChainId,
+            InvalidTransaction::TxGasLimitGreaterThanCap { gas_limit: 31_000, cap: 30_000 },
+            InvalidTransaction::AccessListNotSupported,
+            InvalidTransaction::MaxFeePerBlobGasNotSupported,
+            InvalidTransaction::BlobVersionedHashesNotSupported,
+            InvalidTransaction::BlobGasPriceGreaterThanMax {
+                block_blob_gas_price: 2,
+                tx_max_fee_per_blob_gas: 1,
+            },
+            InvalidTransaction::EmptyBlobs,
+            InvalidTransaction::BlobCreateTransaction,
+            InvalidTransaction::TooManyBlobs { max: 6, have: 7 },
+            InvalidTransaction::BlobVersionNotSupported,
+            InvalidTransaction::AuthorizationListNotSupported,
+            InvalidTransaction::AuthorizationListInvalidFields,
+            InvalidTransaction::EmptyAuthorizationList,
+            InvalidTransaction::Eip2930NotSupported,
+            InvalidTransaction::Eip1559NotSupported,
+            InvalidTransaction::Eip4844NotSupported,
+            InvalidTransaction::Eip7702NotSupported,
+            InvalidTransaction::Eip7873NotSupported,
+            InvalidTransaction::Eip7873MissingTarget,
+            InvalidTransaction::Str(Cow::Borrowed("custom invalid transaction")),
+        ]
+    }
+}

--- a/crates/ethereum/evm/tests/execute.rs
+++ b/crates/ethereum/evm/tests/execute.rs
@@ -14,10 +14,17 @@ use reth_chainspec::{ChainSpecBuilder, EthereumHardfork, ForkCondition, MAINNET}
 use reth_ethereum_primitives::{Block, BlockBody, Transaction};
 use reth_evm::{
     execute::{BasicBlockExecutor, Executor},
+    parallel_execute::ParallelExecutor,
     precompiles::{DynPrecompile, PrecompileInput},
     ConfigureEvm,
 };
-use reth_evm_ethereum::EthEvmConfig;
+use reth_evm_ethereum::{
+    parallel_execute::{
+        GravityTxSkippedEvent, GrevmExecutor, GRAVITY_TX_SKIPPED_LOG_ADDRESS,
+        GRAVITY_TX_SKIPPED_LOG_TOPIC0,
+    },
+    EthEvmConfig,
+};
 use reth_execution_types::BlockExecutionResult;
 use reth_primitives_traits::{
     crypto::secp256k1::public_key_to_address, Block as _, RecoveredBlock,
@@ -129,6 +136,71 @@ fn create_custom_precompile_executor_and_block(
     )]));
 
     (executor, block)
+}
+
+#[test]
+fn grevm_executor_keeps_invalid_tx_in_block_with_skipped_receipt() {
+    let chain_spec = Arc::new(ChainSpecBuilder::from(&*MAINNET).shanghai_activated().build());
+    let sender_key_pair = generators::generate_key(&mut generators::rng());
+    let sender = public_key_to_address(sender_key_pair.public_key());
+
+    let make_tx = |nonce| {
+        sign_tx_with_key_pair(
+            sender_key_pair,
+            Transaction::Legacy(TxLegacy {
+                chain_id: Some(chain_spec.chain.id()),
+                nonce,
+                gas_price: 1,
+                gas_limit: 21_000,
+                to: TxKind::Call(sender),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }),
+        )
+    };
+
+    // tx1 repeats tx0's nonce and is skipped. tx2 proves the skipped transaction did not bump the
+    // sender nonce and execution continued with the next valid transaction.
+    let mut transactions = vec![make_tx(0), make_tx(0)];
+    transactions.extend((1..=62).map(make_tx));
+    let header =
+        Header { number: 1, gas_limit: 2_000_000, base_fee_per_gas: Some(1), ..Header::default() };
+    let block = Block { header, body: BlockBody { transactions, ..Default::default() } }
+        .try_into_recovered()
+        .unwrap();
+
+    let evm_config = EthEvmConfig::new(chain_spec.clone());
+
+    for force_sequential in [false, true] {
+        let mut db = CacheDB::new(EmptyDB::default());
+        db.insert_account_info(
+            sender,
+            AccountInfo { balance: U256::from(ETH_TO_WEI), ..Default::default() },
+        );
+        let mut executor = if force_sequential {
+            GrevmExecutor::new_sequential(chain_spec.clone(), &evm_config, db)
+        } else {
+            GrevmExecutor::new(chain_spec.clone(), &evm_config, db)
+        };
+
+        let result = executor.execute_one(&block).expect("invalid tx should be skipped");
+        assert_eq!(result.receipts.len(), 64);
+        assert!(result.receipts[0].success);
+        assert!(!result.receipts[1].success);
+        assert!(result.receipts[2..].iter().all(|receipt| receipt.success));
+        assert_eq!(result.receipts[0].cumulative_gas_used, 21_000);
+        assert_eq!(result.receipts[1].cumulative_gas_used, 21_000);
+        assert_eq!(result.receipts[2].cumulative_gas_used, 42_000);
+        assert_eq!(result.gas_used, 63 * 21_000);
+
+        let skipped_log = &result.receipts[1].logs[0];
+        assert_eq!(skipped_log.address, GRAVITY_TX_SKIPPED_LOG_ADDRESS);
+        assert_eq!(skipped_log.data.topics()[0], GRAVITY_TX_SKIPPED_LOG_TOPIC0);
+        assert_eq!(
+            GravityTxSkippedEvent::decode(skipped_log),
+            Some(grevm::InvalidTransaction::NonceTooLow { tx: 0, state: 1 })
+        );
+    }
 }
 
 #[test]

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -29,6 +29,7 @@ use gravity_precompiles::{
     randomness_by_height::randomness_by_height_gas_policy_at_block,
 };
 use gravity_primitives::PIPE_BLOCK_GAS_LIMIT;
+use grevm::DelegatedSafetyConfig;
 use reth_chain_state::{ExecutedBlockWithTrieUpdates, ExecutedTrieUpdates};
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks, GravityHardfork};
 use reth_ethereum_primitives::{Block, BlockBody, Receipt, TransactionSigned};
@@ -1228,7 +1229,9 @@ impl<Storage: GravityStorage> Core<Storage> {
 
         // Create executor with state. System transactions will commit directly to its
         // ParallelState, so there is a single source of truth for both system and user txns.
-        let mut executor = self.evm_config.parallel_executor(state);
+        let mut executor = self
+            .evm_config
+            .parallel_executor_with_delegated_safety(state, DelegatedSafetyConfig::enabled());
         executor.apply_custom_precompiles(
             self.custom_precompiles_for_ordered_block(&ordered_block, parent_header),
         );

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/mod.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/mod.rs
@@ -95,6 +95,8 @@ pub const ORACLE_REQUEST_QUEUE_ADDR: Address = address!("00000000000000000000000
 pub const NATIVE_MINT_PRECOMPILE_ADDR: Address =
     address!("00000000000000000000000000000001625f5000");
 pub use gravity_precompiles::randomness_by_height::RANDOMNESS_BY_HEIGHT_PRECOMPILE_ADDR;
+// Reserved synthetic protocol-log emitter; not an executable precompile.
+pub use reth_chainspec::GRAVITY_TX_SKIPPED_LOG_ADDRESS;
 
 // Legacy aliases (for backward compatibility)
 pub const SYSTEM_CONTRACT_ADDRESS: Address = SYSTEM_CALLER;

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
@@ -19,15 +19,15 @@
 //!   gravity-audit#668 fix at the integration boundary.
 //! - **P-13** positive control: a sufficient-gas 7702 tx with one valid authorization is included;
 //!   the authority's account code becomes the 23-byte EIP-7702 designator `0xef0100 || target`.
-//! - **P-14** executor variant smoke: P-13 is run twice — once with `disable_grevm = true`
-//!   (`WrapExecutor<BasicBlockExecutor>`) and once with `false` (`GrevmExecutor`). Both paths must
-//!   apply the authorization so the authority ends up holding the 23-byte designator. The spec's
+//! - **P-14** executor variant smoke: P-13 is run twice — once with `disable_grevm = true` (grevm's
+//!   forced-sequential path) and once with `false` (grevm's parallel path). Both paths must apply
+//!   the authorization so the authority ends up holding the 23-byte designator. The spec's
 //!   *stronger* claim ("byte-identical state roots") is not asserted here because this codebase is
 //!   known to produce different block-level accumulators across executor variants — see
-//!   `crates/ethereum/evm/src/parallel_execute.rs:446-449`, which delegates cross-executor
-//!   equivalence to unit-level diff tests rather than e2e state-root comparison. Both state roots
-//!   are printed for forensic inspection, but the test passes as long as the user-observable
-//!   designator state is identical.
+//!   `crates/ethereum/evm/src/parallel_execute.rs`, which delegates cross-executor equivalence to
+//!   unit-level diff tests rather than e2e state-root comparison. Both state roots are printed for
+//!   forensic inspection, but the test passes as long as the user-observable designator state is
+//!   identical.
 //!
 //! Cases that primarily exercise upstream pool, revm, or grevm semantics
 //! (P-1/P-3 pool fork-gate, P-5/P-6 multi-auth + chain_id==0, P-7 re-delegation,
@@ -59,8 +59,8 @@ use reth_pipe_exec_layer_ext_v2::{
     new_pipe_exec_layer_api, ExecutionArgs, OrderedBlock, PipeExecLayerApi,
 };
 use reth_provider::{
-    providers::BlockchainProvider, BlockHashReader, BlockNumReader, DatabaseProviderFactory,
-    HeaderProvider, StateProviderFactory,
+    providers::BlockchainProvider, AccountReader, BlockHashReader, BlockNumReader,
+    DatabaseProviderFactory, HeaderProvider, StateProviderFactory,
 };
 use reth_rpc_eth_api::{helpers::EthCall, RpcTypes};
 use reth_tracing::{
@@ -120,6 +120,21 @@ const FUNDED_ADDR: Address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb9226
 /// 7702 designator is `0xef0100 || target`; the target's code (or lack
 /// thereof) only matters if the authority is subsequently CALLed.
 const TARGET_ADDR: Address = address!("0x0000000000000000000000000000000000001234");
+const CREATE_DELEGATE_ADDR: Address = address!("0x0000000000000000000000000000000000007702");
+
+/// Runtime: `CREATE(0, 0, 0); POP; STOP`.
+const DELEGATED_CREATE_CODE: &str = "0x600060006000f05000";
+
+fn gravity_delegated_create_chainspec() -> String {
+    let mut json: serde_json::Value =
+        serde_json::from_str(&gravity_prague_chainspec(Some(PRAGUE_TS_BLOCK_100))).unwrap();
+    let alloc = json["alloc"].as_object_mut().expect("genesis alloc must be an object");
+    alloc.insert(
+        format!("{CREATE_DELEGATE_ADDR:#x}"),
+        serde_json::json!({ "balance": "0x0", "code": DELEGATED_CREATE_CODE }),
+    );
+    json.to_string()
+}
 
 fn funded_signer() -> PrivateKeySigner {
     PrivateKeySigner::from_bytes(&B256::from(*FUNDED_PRIVKEY_HEX))
@@ -373,6 +388,22 @@ fn assert_no_authority_code<P: StateProviderFactory>(
     );
 }
 
+fn assert_authority_nonce<P: StateProviderFactory>(
+    provider: &P,
+    block_number: u64,
+    authority: Address,
+    expected_nonce: u64,
+) {
+    let state = provider
+        .state_by_block_number_or_tag(alloy_eips::BlockNumberOrTag::Number(block_number))
+        .expect("state provider for authority nonce check");
+    let account = state
+        .basic_account(&authority)
+        .expect("read authority account")
+        .expect("authority account must exist after 7702 authorization");
+    assert_eq!(account.nonce, expected_nonce, "authority nonce mismatch");
+}
+
 fn read_state_root<P: HeaderProvider>(provider: &P, block_number: u64) -> B256 {
     use alloy_consensus::BlockHeader;
     provider
@@ -523,6 +554,63 @@ fn test_p13_happy_path_disable_grevm() {
         run_p13_happy_path,
     );
     println!("[eip7702_test] disable_grevm state root = {state_root:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Delegated safety — CREATE is disabled in live pipeline execution.
+// ---------------------------------------------------------------------------
+
+async fn run_delegated_create_guard(
+    builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, ChainSpec>>,
+) -> eyre::Result<()> {
+    let (_chain_spec, provider, pipeline_api, latest_block_number) = boot_pipeline(builder).await?;
+    let mut epoch: u64 = pipeline_api
+        .fetch_config_bytes(OnChainConfig::Epoch, BlockNumber::Latest)
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let consensus = MockConsensus::new(pipeline_api, Box::new(p3_ts_us));
+    consensus.push_empty_range(&mut epoch, latest_block_number + 1, P3_ACTIVATION_BLOCK - 1).await;
+
+    let relayer = funded_signer();
+    let authority = authority_signer(0x73);
+    let authorization = sign_authorization(&authority, CHAIN_ID, CREATE_DELEGATE_ADDR, 0);
+    let (tx, sender) = build_signed_eip7702_tx(
+        &relayer,
+        0,
+        300_000,
+        authority.address(),
+        Bytes::new(),
+        vec![authorization],
+    );
+    let block = ordered_block_with_txs(
+        epoch,
+        P3_ACTIVATION_BLOCK,
+        mock_block_id(P3_ACTIVATION_BLOCK),
+        mock_block_id(P3_ACTIVATION_BLOCK - 1),
+        p3_ts_us(P3_ACTIVATION_BLOCK),
+        vec![tx],
+        vec![sender],
+    );
+    consensus.push_one(&mut epoch, block).await;
+    let pipeline_api = consensus.into_inner();
+    pipeline_api.wait_for_block_persistence(P3_ACTIVATION_BLOCK).await.unwrap();
+
+    assert_designator(&provider, P3_ACTIVATION_BLOCK, authority.address(), CREATE_DELEGATE_ADDR);
+    // The authorization increments the authority from nonce 0 to 1. A successful delegated
+    // CREATE would increment it again; the pipe safety policy halts CREATE before that mutation.
+    assert_authority_nonce(&provider, P3_ACTIVATION_BLOCK, authority.address(), 1);
+    Ok(())
+}
+
+#[test]
+fn test_delegated_create_forbidden_in_pipe() {
+    run_pipe_e2e_test(
+        &gravity_delegated_create_chainspec(),
+        "data/gravity_eip7702_delegated_create_guard_test",
+        false,
+        run_delegated_create_guard,
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Background

follow https://github.com/Galxe/grevm/pull/111, resolve https://github.com/Galxe/gravity-audit/issues/838

Gravity uses pipeline execution: consensus may build the next block before the previous block has been committed by the execution layer. A transaction that passed the consensus-side filter can therefore become invalid against the final execution state—for example, an EIP-7702 delegated call may change another account's nonce before that account's transaction is executed.

Previously, recoverable errors such as nonce mismatch or insufficient balance were returned as block-level execution errors. This could stop block execution and leave the validator without a safe way to handle a transaction that consensus had already included.

## Design

This PR adds a last-resort execution-layer safeguard for recoverable invalid transactions:

- grevm classifies a fixed set of recoverable transaction errors and returns `TxExecutionOutcome::Skipped(reason)`.
- If parallel execution encounters one of these errors, grevm rolls back the speculative execution and re-executes the block through its sequential fallback.
- gravity-reth keeps the transaction in the block but applies it as a no-op: no state changes and no gas charged.
- A skipped transaction receives a failed receipt with unchanged cumulative gas and one versioned `GravityTxSkipped(uint16,uint16)` log.
- The log uses a protocol-reserved emitter address so indexers and operators can reliably identify the transaction and decode its skip reason.
- Unknown transaction errors, database errors, and commit errors remain fatal instead of being silently skipped.
- The `disable_grevm` path uses the same grevm sequential executor, keeping skipped-transaction semantics identical across both execution modes.

Skipped transactions remain persisted and queryable through Ethereum RPC by transaction hash and receipt. Execution continues with subsequent transactions in the block.

## Validation

- Added receipt encoding and decoding tests.
- Added executor tests covering skipped transactions, zero gas usage, unchanged state, and continued execution.
- Added EIP-7702 pipeline end-to-end tests for both parallel grevm and `disable_grevm` modes.
- Upgraded grevm to the revision that provides recoverable-error classification and sequential fallback behavior.
