### PR TITLE
chore(deps): bump gravity-aptos api-types to 69008fd0 (drop legacy consensusAlpha)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos?rev=69008fd0ef9bedc8c6c5d9f269a46350f5e6c67f#69008fd0ef9bedc8c6c5d9f269a46350f5e6c67f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,7 +378,7 @@ codegen-units = 1
 
 [workspace.dependencies]
 # reth
-gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "b1f68dc85781ef0d28a568d9d64604b153be9d9e" }
+gravity-api-types = { package = "api-types", git = "https://github.com/Galxe/gravity-aptos", rev = "69008fd0ef9bedc8c6c5d9f269a46350f5e6c67f" }
 op-reth = { path = "crates/optimism/bin" }
 reth = { path = "bin/reth" }
 reth-storage-rpc-provider = { path = "crates/storage/rpc-provider" }


### PR DESCRIPTION
## Summary

Re-pin `gravity-api-types` from `b1f68dc8` to `69008fd0` (Galxe/gravity-aptos#77).

gravity-aptos#77 removes the legacy `consensusAlpha` epoch key from the
consensus-hardfork framework (deletes
`ConsensusHardforks::from_genesis_extra_fields`), closing the audit
finding Galxe/gravity-audit#925. greth does not reference that reader or
any `ConsensusHardfork` type, so this is a source-only dependency bump —
no greth code change.

## Why greth needs to move

gravity-sdk pins both `gaptos` and (transitively, through greth)
`api-types` at the same gravity-aptos rev. To pick up #77 it must bump
`gaptos` to `69008fd0`; cargo refuses to `[patch]` the same git URL to a
different rev, so greth must re-pin `api-types` to the matching rev or the
workspace links two incompatible `api-types` copies. This bump keeps
greth and gaptos in lockstep, as prior bumps did (e.g. #679, #771).

## Verification

- `cargo metadata --locked` passes — the lockfile is consistent with the new rev (api-types' dependency set is unchanged by #77).
- Diff is Cargo.toml + Cargo.lock, one rev line each; no code and no other dependency churn.
- greth builds against the new api-types unchanged (the removed method is unused here); CI confirms.

Ref: Galxe/gravity-audit#925, Galxe/gravity-aptos#77
