### PR TITLE
feat: Monad-style 30M per-tx gas cap under Osaka (#392)

### DIFF
--- a/crates/consensus/common/src/validation.rs
+++ b/crates/consensus/common/src/validation.rs
@@ -7,7 +7,8 @@ use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks};
 use reth_consensus::{ConsensusError, TxGasLimitTooHighErr};
 use reth_primitives_traits::{
     constants::{
-        GAS_LIMIT_BOUND_DIVISOR, MAXIMUM_GAS_LIMIT_BLOCK, MAX_TX_GAS_LIMIT_OSAKA, MINIMUM_GAS_LIMIT,
+        GAS_LIMIT_BOUND_DIVISOR, GRAVITY_TX_GAS_LIMIT_CAP, MAXIMUM_GAS_LIMIT_BLOCK,
+        MINIMUM_GAS_LIMIT,
     },
     transaction::TxHashRef,
     Block, BlockBody, BlockHeader, GotExpected, SealedBlock, SealedHeader,
@@ -193,7 +194,8 @@ where
 ///   information about the specific checks in [`validate_shanghai_withdrawals`].
 /// * EIP-4844 blob gas validation, if cancun is active based on the given chainspec. See more
 ///   information about the specific checks in [`validate_cancun_gas`].
-/// * EIP-7825 per-tx gas limit validation, if osaka is active based on the given chainspec.
+/// * Per-tx gas cap validation (Gravity's Monad-style [`GRAVITY_TX_GAS_LIMIT_CAP`] in place of
+///   EIP-7825's `2^24`), if osaka is active based on the given chainspec.
 /// * EIP-7934 block size limit validation, if osaka is active based on the given chainspec.
 pub fn post_merge_hardfork_fields<B, ChainSpec>(
     block: &SealedBlock<B>,
@@ -225,13 +227,16 @@ where
     }
 
     if chain_spec.is_osaka_active_at_timestamp(block.timestamp()) {
-        // EIP-7825: per-tx gas limit
+        // Per-tx gas cap. Gravity uses a Monad-style flat cap (`GRAVITY_TX_GAS_LIMIT_CAP` = 30M)
+        // in place of the EIP-7825 `2^24`, so the 30M system transactions clear it. Must match
+        // the executor cfg (`reth-evm-ethereum`) and the pipe `tx_filter` guard, or a
+        // self-produced block admitted by one path is rejected on another (sync brick).
         for tx in block.body().transactions() {
-            if tx.gas_limit() > MAX_TX_GAS_LIMIT_OSAKA {
+            if tx.gas_limit() > GRAVITY_TX_GAS_LIMIT_CAP {
                 return Err(TxGasLimitTooHighErr {
                     tx_hash: *tx.tx_hash(),
                     gas_limit: tx.gas_limit(),
-                    max_allowed: MAX_TX_GAS_LIMIT_OSAKA,
+                    max_allowed: GRAVITY_TX_GAS_LIMIT_CAP,
                 }
                 .into());
             }

--- a/crates/ethereum/evm/src/lib.rs
+++ b/crates/ethereum/evm/src/lib.rs
@@ -37,7 +37,7 @@ use reth_evm::{
     parallel_execute::{ParallelExecutor, WrapExecutor},
     ConfigureEvm, EvmEnv, NextBlockEnvAttributes, ParallelDatabase,
 };
-use reth_primitives_traits::{constants::MAX_TX_GAS_LIMIT_OSAKA, SealedBlock, SealedHeader};
+use reth_primitives_traits::{constants::GRAVITY_TX_GAS_LIMIT_CAP, SealedBlock, SealedHeader};
 use revm::{
     context::{
         result::{ExecutionResult, HaltReason},
@@ -156,6 +156,19 @@ impl<ChainSpec, EvmFactory> EthEvmConfig<ChainSpec, EvmFactory> {
     }
 }
 
+/// Pin the per-tx gas cap to Gravity's Monad-style value once `Osaka` is active.
+///
+/// alloy-evm's `for_eth_block` / `for_eth_next_block` and `evm_env_for_payload` set
+/// `tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA)` (EIP-7825, `2^24`) under OSAKA. Gravity
+/// overrides that with [`GRAVITY_TX_GAS_LIMIT_CAP`] (30M) so the 30M system transactions clear
+/// the cap. Must stay in lockstep with the consensus-side check (`reth-consensus-common`) and
+/// the pipe `tx_filter` guard.
+const fn apply_gravity_tx_gas_cap(cfg_env: &mut CfgEnv, osaka_active: bool) {
+    if osaka_active {
+        cfg_env.tx_gas_limit_cap = Some(GRAVITY_TX_GAS_LIMIT_CAP);
+    }
+}
+
 impl<ChainSpec> ConfigureEvm for EthEvmConfig<ChainSpec>
 where
     ChainSpec: EthExecutorSpec + EthChainSpec<Header = Header> + Hardforks + 'static,
@@ -175,12 +188,17 @@ where
     }
 
     fn evm_env(&self, header: &Header) -> Result<EvmEnv<SpecId>, Self::Error> {
-        Ok(EvmEnv::for_eth_block(
+        let mut evm_env = EvmEnv::for_eth_block(
             header,
             self.chain_spec(),
             self.chain_spec().chain().id(),
             self.chain_spec().blob_params_at_timestamp(header.timestamp),
-        ))
+        );
+        apply_gravity_tx_gas_cap(
+            &mut evm_env.cfg_env,
+            self.chain_spec().is_osaka_active_at_timestamp(header.timestamp),
+        );
+        Ok(evm_env)
     }
 
     fn next_evm_env(
@@ -188,7 +206,7 @@ where
         parent: &Header,
         attributes: &NextBlockEnvAttributes,
     ) -> Result<EvmEnv, Self::Error> {
-        Ok(EvmEnv::for_eth_next_block(
+        let mut evm_env = EvmEnv::for_eth_next_block(
             parent,
             NextEvmEnvAttributes {
                 timestamp: attributes.timestamp,
@@ -201,7 +219,12 @@ where
             self.chain_spec(),
             self.chain_spec().chain().id(),
             self.chain_spec().blob_params_at_timestamp(attributes.timestamp),
-        ))
+        );
+        apply_gravity_tx_gas_cap(
+            &mut evm_env.cfg_env,
+            self.chain_spec().is_osaka_active_at_timestamp(attributes.timestamp),
+        );
+        Ok(evm_env)
     }
 
     fn context_for_block<'a>(
@@ -313,9 +336,10 @@ where
             cfg_env.set_max_blobs_per_tx(blob_params.max_blobs_per_tx);
         }
 
-        if self.chain_spec().is_osaka_active_at_timestamp(timestamp) {
-            cfg_env.tx_gas_limit_cap = Some(MAX_TX_GAS_LIMIT_OSAKA);
-        }
+        apply_gravity_tx_gas_cap(
+            &mut cfg_env,
+            self.chain_spec().is_osaka_active_at_timestamp(timestamp),
+        );
 
         // derive the EIP-4844 blob fees from the header's `excess_blob_gas` and the current
         // blobparams

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -42,11 +42,12 @@
 //!   `account.nonce += 1`.
 //! - `Eip7873NotSupported` / `Eip7873MissingTarget` — activates on OSAKA. Adding Osaka requires an
 //!   init-code-tx type gate.
-//! - `TxGasLimitGreaterThanCap` — EIP-7825 tx gas-limit cap. `validate_tx_env`
-//!   (`validation.rs:116-123`) rejects `tx.gas_limit() > cfg.tx_gas_limit_cap()`; that cap is
-//!   `u64::MAX` pre-OSAKA and `eip7825::TX_GAS_LIMIT_CAP` (2^24) from OSAKA on (`revm-context
-//!   cfg.rs:272-278`), so it cannot fire on Gravity's Prague spec. Adding Osaka requires a
-//!   `tx.gas_limit() <= 2^24` gate here.
+//! - `TxGasLimitGreaterThanCap` — per-tx gas cap. `validate_tx_env` rejects `tx.gas_limit() >
+//!   cfg.tx_gas_limit_cap()`; that cap is `u64::MAX` pre-OSAKA. Under OSAKA Gravity pins it to a
+//!   Monad-style `GRAVITY_TX_GAS_LIMIT_CAP` (30M) rather than EIP-7825's `2^24` — see the
+//!   OSAKA-gated guard in `is_tx_valid` below. The executor cfg
+//!   (`reth-evm-ethereum::apply_gravity_tx_gas_cap`) and the consensus block check
+//!   (`reth-consensus-common`) are pinned to the same 30M value.
 //!
 //! Procedure on upgrade: `grep 'return Err(InvalidTransaction::'` in
 //! `revm-handler/src/` for the new pin, diff against the "unreachable" list above,
@@ -64,6 +65,7 @@ use reth_chainspec::{ChainSpec, EthChainSpec};
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::ParallelDatabase;
 use reth_evm_ethereum::revm_spec_by_timestamp_and_block_number;
+use reth_primitives_traits::constants::GRAVITY_TX_GAS_LIMIT_CAP;
 use revm::state::AccountInfo;
 use revm_primitives::{eip3860::MAX_INITCODE_SIZE, hardfork::SpecId};
 use tracing::info;
@@ -150,6 +152,26 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                 return false;
             }
             _ => {}
+        }
+        // Per-tx gas cap. Gravity uses a Monad-style flat cap (`GRAVITY_TX_GAS_LIMIT_CAP` = 30M,
+        // matching Monad's `TFM_MAX_GAS_LIMIT`) in place of Ethereum's EIP-7825 `2^24`. Under
+        // OSAKA revm rejects `tx.gas_limit() > cfg.tx_gas_limit_cap()` with
+        // `TxGasLimitGreaterThanCap`; the executor cfg is pinned to the same 30M under OSAKA
+        // (`reth-evm-ethereum::apply_gravity_tx_gas_cap`) and the consensus block check mirrors it
+        // (`reth-consensus-common`). Placed after the chain-id gate and before the fee gates to
+        // mirror revm's `validate_tx_env` rule order. revm's Amsterdam `is_amsterdam_eip8037`
+        // wrapper is not mirrored — Gravity does not activate Amsterdam, so the omission is
+        // over-filter (the safe direction). The boundary is inclusive (`>`): a 30M system tx
+        // passes.
+        if spec_id.is_enabled_in(SpecId::OSAKA) && tx.gas_limit() > GRAVITY_TX_GAS_LIMIT_CAP {
+            info!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                gas_limit=?tx.gas_limit(),
+                cap=?GRAVITY_TX_GAS_LIMIT_CAP,
+                "tx gas limit exceeds Gravity per-tx cap"
+            );
+            return false;
         }
         // Fee gates. revm rejects with `GasPriceLessThanBasefee` when the tx's max fee
         // cap is below the prevailing base fee (this is the unified `max_fee_per_gas` —
@@ -420,6 +442,12 @@ mod tests {
     /// `Eip7702NotSupported` and panic the executor).
     fn shanghai_chain_spec() -> Arc<ChainSpec> {
         Arc::new(ChainSpecBuilder::from(&*MAINNET).shanghai_activated().build())
+    }
+
+    /// Chainspec with Osaka active from genesis — the fixture for the Gravity per-tx gas cap
+    /// gate. The gate is OSAKA-gated, so it only fires under this fixture (not the Prague one).
+    fn osaka_chain_spec() -> Arc<ChainSpec> {
+        Arc::new(ChainSpecBuilder::from(&*MAINNET).osaka_activated().build())
     }
 
     // Mock database for testing
@@ -1565,5 +1593,132 @@ mod tests {
             invalid_idxs.is_empty(),
             "tx from EIP-7702-delegated sender must pass: {invalid_idxs:?}"
         );
+    }
+
+    // ===== Gravity per-tx gas cap (Monad-style 30M, OSAKA-gated) ================
+
+    /// Pins the cap value and the boundary is inclusive, so a system tx built at exactly this
+    /// value (`new_system_call_txn`, 30M) clears the gate. Lowering the cap below 30M — or
+    /// raising the system-tx `gas_limit` above it — would start rejecting system transactions.
+    #[test]
+    fn test_gravity_tx_gas_cap_constant() {
+        assert_eq!(GRAVITY_TX_GAS_LIMIT_CAP, 30_000_000);
+    }
+
+    /// A tx with `gas_limit == cap` (30M) passes under Osaka — the gate is a strict `>`, so the
+    /// boundary is admitted (this is what lets the 30M system transactions through).
+    #[test]
+    fn test_filter_invalid_txs_osaka_gas_cap_boundary_passes() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        // gas_price 1 / base_fee 0 keeps the fee + balance gates out of the way; block budget
+        // (60M) is above the tx so the cumulative pre-pass doesn't truncate first.
+        let tx = create_test_transaction(0, GRAVITY_TX_GAS_LIMIT_CAP, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
+        assert!(
+            invalid_idxs.is_empty(),
+            "30M tx at the cap boundary must pass under Osaka: {invalid_idxs:?}"
+        );
+    }
+
+    /// A tx one gas over the cap (30M + 1) is rejected under Osaka.
+    #[test]
+    fn test_filter_invalid_txs_osaka_gas_cap_over_rejected() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        let tx = create_test_transaction(0, GRAVITY_TX_GAS_LIMIT_CAP + 1, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
+        assert_eq!(invalid_idxs.len(), 1, "tx above the 30M cap must be discarded under Osaka");
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// The gate is OSAKA-gated: the same over-cap tx passes under Prague (no per-tx cap exists
+    /// pre-Osaka, matching revm's `cfg.tx_gas_limit_cap()` = `u64::MAX` there).
+    #[test]
+    fn test_filter_invalid_txs_pre_osaka_no_gas_cap() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        let tx = create_test_transaction(0, GRAVITY_TX_GAS_LIMIT_CAP + 1, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &prague_chain_spec(), 0, 0);
+        assert!(
+            invalid_idxs.is_empty(),
+            "pre-Osaka has no per-tx gas cap, over-cap tx must pass: {invalid_idxs:?}"
+        );
+    }
+
+    /// The cap is per-tx and does not pollute across senders: an over-cap tx from sender A is
+    /// dropped while a normal tx from sender B in the same batch passes, under Osaka.
+    #[test]
+    fn test_filter_invalid_txs_osaka_gas_cap_per_sender() {
+        let mut db = MockDatabase::new();
+        let sender_a = Address::random();
+        let sender_b = Address::random();
+        for s in [sender_a, sender_b] {
+            db.insert_account(
+                s,
+                AccountInfo {
+                    balance: U256::from(1_000_000_000_000_000_000u64),
+                    nonce: 0,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                },
+            );
+        }
+
+        let tx_a = create_test_transaction(0, GRAVITY_TX_GAS_LIMIT_CAP + 1, 1); // over cap
+        let tx_b = create_test_transaction(0, 21_000, 1); // fine
+        let txs = vec![tx_a, tx_b];
+        let senders = vec![sender_a, sender_b];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
+        assert_eq!(invalid_idxs.len(), 1, "only sender A's over-cap tx must be dropped");
+        assert!(invalid_idxs.contains(&0));
     }
 }

--- a/crates/primitives-traits/src/constants/mod.rs
+++ b/crates/primitives-traits/src/constants/mod.rs
@@ -20,6 +20,19 @@ pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 /// Maximum transaction gas limit as defined by [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) activated in `Osaka` hardfork.
 pub const MAX_TX_GAS_LIMIT_OSAKA: u64 = 2u64.pow(24);
 
+/// Gravity's per-transaction gas limit cap, enforced once the `Osaka` hardfork is active.
+///
+/// Gravity replaces the EIP-7825 cap ([`MAX_TX_GAS_LIMIT_OSAKA`], `2^24`) with Monad's flat
+/// per-tx cap (`TFM_MAX_GAS_LIMIT` = 30M). The 30M system transactions built by
+/// `new_system_call_txn` are constructed at exactly this value and clear the cap because the
+/// check is a strict `gas_limit > cap`; the `2^24` cap would reject them.
+///
+/// Enforced in lockstep at three sites, all gated on `Osaka`: the executor cfg
+/// (`reth-evm-ethereum`, `tx_gas_limit_cap`), the consensus block check
+/// (`reth-consensus-common`), and the pipe `tx_filter` guard. Keep this equal to the
+/// system-transaction `gas_limit`: lowering it below 30M would reject system transactions.
+pub const GRAVITY_TX_GAS_LIMIT_CAP: u64 = 30_000_000;
+
 /// The number of blocks to unwind during a reorg that already became a part of canonical chain.
 ///
 /// In reality, the node can end up in this particular situation very rarely. It would happen only


### PR DESCRIPTION
Refs #392.

Under Osaka, Gravity uses a flat Monad-style 30M per-tx gas cap (`TFM_MAX_GAS_LIMIT`)
instead of EIP-7825's `2^24`. This deviates from the issue's original 2^24 design on
purpose: 30M equals the system-transaction `gas_limit`, so the boundary admits them and
#392's separate system-tx gas gating (P2) is no longer needed.

Enforced in lockstep off one constant `GRAVITY_TX_GAS_LIMIT_CAP` at three Osaka-gated
sites — the executor cfg (`tx_gas_limit_cap`), the consensus block check, and the pipe
`tx_filter` guard — so a self-produced block admitted by one path is never rejected on
another. Dormant until `osakaTime`.

Not included (separate follow-ups): the cross-Osaka e2e acceptance, and #392's incidental
revm-bump debt (`nonce == u64::MAX` guard, tx_filter header rewrite).
