### PR TITLE
fix(pruner): reclaim storage-v2 changeset static files during history pruning

### DIFF
--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -8,7 +8,7 @@ use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, DBProvider, DatabaseProviderFactory,
     NodePrimitivesProvider, PruneCheckpointReader, PruneCheckpointWriter,
-    StaticFileProviderFactory,
+    StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune_types::PruneModes;
 use std::time::Duration;
@@ -85,7 +85,7 @@ impl PrunerBuilder {
                                 + BlockReader<Transaction: Encodable2718>
                                 + StaticFileProviderFactory<
                     Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
-                >,
+                > + StorageSettingsCache,
             > + StaticFileProviderFactory<
                 Primitives = <PF::ProviderRW as NodePrimitivesProvider>::Primitives,
             >,
@@ -114,7 +114,8 @@ impl PrunerBuilder {
             > + DBProvider<Tx: DbTxMut>
             + BlockReader<Transaction: Encodable2718>
             + PruneCheckpointWriter
-            + PruneCheckpointReader,
+            + PruneCheckpointReader
+            + StorageSettingsCache,
     {
         let segments = SegmentSet::<Provider>::from_components(static_file_provider, self.segments);
 

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -7,7 +7,7 @@ use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     providers::StaticFileProvider, BlockReader, DBProvider, PruneCheckpointReader,
-    PruneCheckpointWriter, StaticFileProviderFactory,
+    PruneCheckpointWriter, StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune_types::PruneModes;
 
@@ -52,7 +52,8 @@ where
         > + DBProvider<Tx: DbTxMut>
         + PruneCheckpointWriter
         + PruneCheckpointReader
-        + BlockReader<Transaction: Encodable2718>,
+        + BlockReader<Transaction: Encodable2718>
+        + StorageSettingsCache,
 {
     /// Creates a [`SegmentSet`] from an existing components, such as [`StaticFileProvider`] and
     /// [`PruneModes`].

--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -1,11 +1,16 @@
 use crate::{
     db_ext::DbTxPruneExt,
-    segments::{user::history::prune_history_indices, PruneInput, Segment},
+    segments::{
+        user::history::{finalize_history_prune, HistoryPruneResult},
+        PruneInput, Segment,
+    },
     PrunerError,
 };
-use itertools::Itertools;
+use alloy_primitives::BlockNumber;
 use reth_db_api::{models::ShardedKey, tables, transaction::DbTxMut};
-use reth_provider::DBProvider;
+use reth_provider::{
+    DBProvider, StaticFileProviderFactory, StaticFileSegment, StorageSettingsCache,
+};
 use reth_prune_types::{
     PruneMode, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
 };
@@ -31,7 +36,7 @@ impl AccountHistory {
 
 impl<Provider> Segment<Provider> for AccountHistory
 where
-    Provider: DBProvider<Tx: DbTxMut>,
+    Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + StorageSettingsCache,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::AccountHistory
@@ -56,6 +61,106 @@ where
         };
         let range_end = *range.end();
 
+        // Under storage-v2 the account changesets live in static files and the database changeset
+        // table is empty, so pruning the DB table would no-op while the jars leak. Walk the static
+        // files and reclaim their jars instead.
+        if provider.cached_storage_settings().changesets_in_static_files {
+            self.prune_static_files(provider, input, range, range_end)
+        } else {
+            self.prune_database(provider, input, range, range_end)
+        }
+    }
+}
+
+impl AccountHistory {
+    /// Prunes account history when changesets are stored in static files.
+    ///
+    /// Walks the changesets from static files to prune the [`tables::AccountsHistory`] index, then
+    /// reclaims any changeset jar that has fallen entirely below the prune horizon.
+    fn prune_static_files<Provider>(
+        &self,
+        provider: &Provider,
+        input: PruneInput,
+        range: std::ops::RangeInclusive<BlockNumber>,
+        range_end: BlockNumber,
+    ) -> Result<SegmentOutput, PrunerError>
+    where
+        Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
+    {
+        // Split the budget across both tables, matching the database path: the changeset walk and
+        // the history-index prune each get half.
+        let mut limiter = if let Some(limit) = input.limiter.deleted_entries_limit() {
+            input.limiter.set_deleted_entries_limit(limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE)
+        } else {
+            input.limiter
+        };
+
+        // The limiter may already be exhausted by a previous segment in the same prune run.
+        if limiter.is_limit_reached() {
+            return Ok(SegmentOutput::not_done(
+                limiter.interrupt_reason(),
+                input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
+            ))
+        }
+
+        // Deleted account changeset keys (account addresses) with the highest block number deleted
+        // for that key. Bounded the same way as the database path below.
+        let mut highest_deleted_accounts = FxHashMap::default();
+        let mut last_changeset_pruned_block = None;
+        let mut pruned_changesets = 0;
+        let mut done = true;
+
+        let walker = provider.static_file_provider().walk_account_changeset_range(range);
+        for result in walker {
+            if limiter.is_limit_reached() {
+                done = false;
+                break
+            }
+            let (block_number, changeset) = result?;
+            highest_deleted_accounts.insert(changeset.address, block_number);
+            last_changeset_pruned_block = Some(block_number);
+            pruned_changesets += 1;
+            limiter.increment_deleted_entries_count();
+        }
+
+        // Reclaim whole jars only once the range is fully processed, so a jar straddling the
+        // horizon is never removed while it still holds live blocks (`delete_segment_below_block`
+        // additionally refuses to delete the highest jar).
+        if done && let Some(last_block) = last_changeset_pruned_block {
+            provider
+                .static_file_provider()
+                .delete_segment_below_block(StaticFileSegment::AccountChangeSets, last_block + 1)?;
+        }
+        trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned account history (changesets from static files)");
+
+        let result = HistoryPruneResult {
+            highest_deleted: highest_deleted_accounts,
+            last_pruned_block: last_changeset_pruned_block,
+            pruned_count: pruned_changesets,
+            done,
+        };
+        finalize_history_prune::<_, tables::AccountsHistory, _, _>(
+            provider,
+            result,
+            range_end,
+            &limiter,
+            ShardedKey::new,
+            |a, b| a.key == b.key,
+        )
+        .map_err(Into::into)
+    }
+
+    /// Prunes account history when changesets are stored in the database changeset table.
+    fn prune_database<Provider>(
+        &self,
+        provider: &Provider,
+        input: PruneInput,
+        range: std::ops::RangeInclusive<BlockNumber>,
+        range_end: BlockNumber,
+    ) -> Result<SegmentOutput, PrunerError>
+    where
+        Provider: DBProvider<Tx: DbTxMut>,
+    {
         let mut limiter = if let Some(limit) = input.limiter.deleted_entries_limit() {
             input.limiter.set_deleted_entries_limit(limit / ACCOUNT_HISTORY_TABLES_TO_PRUNE)
         } else {
@@ -68,7 +173,6 @@ where
             ))
         }
 
-        let mut last_changeset_pruned_block = None;
         // Deleted account changeset keys (account addresses) with the highest block number deleted
         // for that key.
         //
@@ -78,6 +182,7 @@ where
         // size should be up to 0.5MB + some hashmap overhead. `blocks_since_last_run` is
         // additionally limited by the `max_reorg_depth`, so no OOM is expected here.
         let mut highest_deleted_accounts = FxHashMap::default();
+        let mut last_changeset_pruned_block = None;
         let (pruned_changesets, done) =
             provider.tx_ref().prune_table_with_range::<tables::AccountChangeSets>(
                 range,
@@ -88,39 +193,23 @@ where
                     last_changeset_pruned_block = Some(block_number);
                 },
             )?;
-        trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned account history (changesets)");
+        trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned account history (changesets from database)");
 
-        let last_changeset_pruned_block = last_changeset_pruned_block
-            // If there's more account changesets to prune, set the checkpoint block number to
-            // previous, so we could finish pruning its account changesets on the next run.
-            .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
-            .unwrap_or(range_end);
-
-        // Sort highest deleted block numbers by account address and turn them into sharded keys.
-        // We did not use `BTreeMap` from the beginning, because it's inefficient for hashes.
-        let highest_sharded_keys = highest_deleted_accounts
-            .into_iter()
-            .sorted_unstable() // Unstable is fine because no equal keys exist in the map
-            .map(|(address, block_number)| {
-                ShardedKey::new(address, block_number.min(last_changeset_pruned_block))
-            });
-        let outcomes = prune_history_indices::<Provider, tables::AccountsHistory, _>(
+        let result = HistoryPruneResult {
+            highest_deleted: highest_deleted_accounts,
+            last_pruned_block: last_changeset_pruned_block,
+            pruned_count: pruned_changesets,
+            done,
+        };
+        finalize_history_prune::<_, tables::AccountsHistory, _, _>(
             provider,
-            highest_sharded_keys,
+            result,
+            range_end,
+            &limiter,
+            ShardedKey::new,
             |a, b| a.key == b.key,
-        )?;
-        trace!(target: "pruner", ?outcomes, %done, "Pruned account history (indices)");
-
-        let progress = limiter.progress(done);
-
-        Ok(SegmentOutput {
-            progress,
-            pruned: pruned_changesets + outcomes.deleted,
-            checkpoint: Some(SegmentOutputCheckpoint {
-                block_number: Some(last_changeset_pruned_block),
-                tx_number: None,
-            }),
-        })
+        )
+        .map_err(Into::into)
     }
 }
 
@@ -132,8 +221,11 @@ mod tests {
     };
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
-    use reth_db_api::{tables, BlockNumberList};
-    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
+    use reth_db_api::{models::GravityStorageSettings, tables, BlockNumberList};
+    use reth_provider::{
+        DatabaseProviderFactory, PruneCheckpointReader, StaticFileProviderFactory,
+        StaticFileSegment, StorageSettingsCache,
+    };
     use reth_prune_types::{
         PruneCheckpoint, PruneInterruptReason, PruneMode, PruneProgress, PruneSegment,
     };
@@ -302,5 +394,98 @@ mod tests {
         );
         test_prune(998, 2, (PruneProgress::Finished, 998));
         test_prune(1400, 3, (PruneProgress::Finished, 804));
+    }
+
+    /// Exercises the static-file changeset path. With `changesets_in_static_files` enabled the
+    /// changesets live in static files (the DB changeset table is empty), so pruning must walk the
+    /// static files to prune the `AccountsHistory` index and to reclaim below-horizon jars.
+    #[test]
+    fn prune_static_files_path() {
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=100,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();
+        let (changesets, _) = random_changeset_range(
+            &mut rng,
+            blocks.iter(),
+            accounts.into_iter().map(|(addr, acc)| (addr, (acc, Vec::new()))),
+            0..0,
+            0..0,
+        );
+
+        // Changesets in static files, history index in the database.
+        db.insert_changesets_to_static_files(changesets.clone(), None)
+            .expect("insert changesets to static files");
+        db.insert_history(changesets.clone(), None).expect("insert history");
+
+        // Under this configuration the database changeset table stays empty.
+        assert!(db.table::<tables::AccountChangeSets>().unwrap().is_empty());
+
+        let count_index_blocks = || {
+            db.table::<tables::AccountsHistory>()
+                .unwrap()
+                .iter()
+                .map(|(_, blocks)| blocks.iter().count())
+                .sum::<usize>()
+        };
+        let blocks_before = count_index_blocks();
+        assert!(blocks_before > 0);
+
+        let to_block: BlockNumber = 50;
+        let prune_mode = PruneMode::Before(to_block);
+        let input =
+            PruneInput { previous_checkpoint: None, to_block, limiter: PruneLimiter::default() };
+        let segment = AccountHistory::new(prune_mode);
+
+        // Route to the static-file path.
+        db.factory.set_storage_settings_cache(GravityStorageSettings {
+            changesets_in_static_files: true,
+        });
+
+        let provider = db.factory.database_provider_rw().unwrap();
+        let result = segment.prune(&provider, input).unwrap();
+
+        assert_matches!(
+            result,
+            SegmentOutput { progress: PruneProgress::Finished, pruned, checkpoint: Some(_) }
+                if pruned > 0
+        );
+
+        segment
+            .save_checkpoint(&provider, result.checkpoint.unwrap().as_prune_checkpoint(prune_mode))
+            .unwrap();
+        provider.commit().expect("commit");
+
+        // The history index no longer references pruned blocks, and it shrank.
+        assert!(count_index_blocks() < blocks_before);
+        for (_, blocks) in db.table::<tables::AccountsHistory>().unwrap() {
+            assert!(blocks.iter().all(|b| b > to_block));
+        }
+
+        // Checkpoint advanced to the prune horizon.
+        assert_eq!(
+            db.factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::AccountHistory)
+                .unwrap(),
+            Some(PruneCheckpoint { block_number: Some(to_block), tx_number: None, prune_mode })
+        );
+
+        // The single changeset jar spans the tip, so it is not reclaimed, but nothing above the
+        // horizon is lost: the static-file tip is preserved.
+        assert_eq!(
+            db.factory
+                .static_file_provider()
+                .get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
+            Some(100)
+        );
     }
 }

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -1,4 +1,6 @@
+use crate::PruneLimiter;
 use alloy_primitives::BlockNumber;
+use itertools::Itertools;
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW},
     models::ShardedKey,
@@ -7,6 +9,8 @@ use reth_db_api::{
     BlockNumberList, DatabaseError, RawKey, RawTable, RawValue,
 };
 use reth_provider::DBProvider;
+use reth_prune_types::{SegmentOutput, SegmentOutputCheckpoint};
+use rustc_hash::FxHashMap;
 
 enum PruneShardOutcome {
     Deleted,
@@ -19,6 +23,67 @@ pub(crate) struct PrunedIndices {
     pub(crate) deleted: usize,
     pub(crate) updated: usize,
     pub(crate) unchanged: usize,
+}
+
+/// Result of pruning history changesets, used to build the final segment output.
+pub(crate) struct HistoryPruneResult<K> {
+    /// Map of the highest deleted changeset keys to their block numbers.
+    pub(crate) highest_deleted: FxHashMap<K, BlockNumber>,
+    /// The last block number that had changesets pruned.
+    pub(crate) last_pruned_block: Option<BlockNumber>,
+    /// Number of changesets pruned.
+    pub(crate) pruned_count: usize,
+    /// Whether pruning is complete.
+    pub(crate) done: bool,
+}
+
+/// Finalizes history pruning by sorting sharded keys, pruning history indices, and building output.
+///
+/// Shared between the static-file and database changeset paths for both account and storage
+/// history: the changeset source differs, but computing the checkpoint block, pruning the history
+/// index shards, and assembling [`SegmentOutput`] is identical.
+pub(crate) fn finalize_history_prune<Provider, T, K, SK>(
+    provider: &Provider,
+    result: HistoryPruneResult<K>,
+    range_end: BlockNumber,
+    limiter: &PruneLimiter,
+    to_sharded_key: impl Fn(K, BlockNumber) -> T::Key,
+    key_matches: impl Fn(&T::Key, &T::Key) -> bool,
+) -> Result<SegmentOutput, DatabaseError>
+where
+    Provider: DBProvider<Tx: DbTxMut>,
+    T: Table<Value = BlockNumberList>,
+    T::Key: AsRef<ShardedKey<SK>>,
+    K: Ord,
+{
+    let HistoryPruneResult { highest_deleted, last_pruned_block, pruned_count, done } = result;
+
+    // If there's more changesets to prune, set the checkpoint block number to the previous one, so
+    // we can finish pruning its changesets on the next run.
+    let last_changeset_pruned_block = last_pruned_block
+        .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
+        .unwrap_or(range_end);
+
+    // Sort highest deleted block numbers and turn them into sharded keys.
+    // `sorted_unstable` is fine because no equal keys exist in the map.
+    let highest_sharded_keys =
+        highest_deleted.into_iter().sorted_unstable().map(|(key, block_number)| {
+            to_sharded_key(key, block_number.min(last_changeset_pruned_block))
+        });
+
+    let outcomes =
+        prune_history_indices::<Provider, T, _>(provider, highest_sharded_keys, key_matches)?;
+
+    let progress = limiter.progress(done);
+
+    Ok(SegmentOutput {
+        progress,
+        pruned: pruned_count + outcomes.deleted,
+        checkpoint: Some(SegmentOutputCheckpoint {
+            block_number: Some(last_changeset_pruned_block),
+            tx_number: None,
+        }),
+    })
 }
 
 /// Prune history indices according to the provided list of highest sharded keys.

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -1,15 +1,20 @@
 use crate::{
     db_ext::DbTxPruneExt,
-    segments::{user::history::prune_history_indices, PruneInput, Segment, SegmentOutput},
+    segments::{
+        user::history::{finalize_history_prune, HistoryPruneResult},
+        PruneInput, Segment, SegmentOutput,
+    },
     PrunerError,
 };
-use itertools::Itertools;
+use alloy_primitives::{Address, BlockNumber, B256};
 use reth_db_api::{
     models::{storage_sharded_key::StorageShardedKey, BlockNumberAddress},
     tables,
     transaction::DbTxMut,
 };
-use reth_provider::DBProvider;
+use reth_provider::{
+    DBProvider, StaticFileProviderFactory, StaticFileSegment, StorageSettingsCache,
+};
 use reth_prune_types::{PruneMode, PrunePurpose, PruneSegment, SegmentOutputCheckpoint};
 use rustc_hash::FxHashMap;
 use tracing::{instrument, trace};
@@ -33,7 +38,7 @@ impl StorageHistory {
 
 impl<Provider> Segment<Provider> for StorageHistory
 where
-    Provider: DBProvider<Tx: DbTxMut>,
+    Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory + StorageSettingsCache,
 {
     fn segment(&self) -> PruneSegment {
         PruneSegment::StorageHistory
@@ -58,6 +63,108 @@ where
         };
         let range_end = *range.end();
 
+        // Under storage-v2 the storage changesets live in static files and the database changeset
+        // table is empty, so pruning the DB table would no-op while the jars leak. Walk the static
+        // files and reclaim their jars instead.
+        if provider.cached_storage_settings().changesets_in_static_files {
+            self.prune_static_files(provider, input, range, range_end)
+        } else {
+            self.prune_database(provider, input, range, range_end)
+        }
+    }
+}
+
+impl StorageHistory {
+    /// Prunes storage history when changesets are stored in static files.
+    ///
+    /// Walks the changesets from static files to prune the [`tables::StoragesHistory`] index, then
+    /// reclaims any changeset jar that has fallen entirely below the prune horizon.
+    fn prune_static_files<Provider>(
+        &self,
+        provider: &Provider,
+        input: PruneInput,
+        range: std::ops::RangeInclusive<BlockNumber>,
+        range_end: BlockNumber,
+    ) -> Result<SegmentOutput, PrunerError>
+    where
+        Provider: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
+    {
+        // Split the budget across both tables, matching the database path: the changeset walk and
+        // the history-index prune each get half.
+        let mut limiter = if let Some(limit) = input.limiter.deleted_entries_limit() {
+            input.limiter.set_deleted_entries_limit(limit / STORAGE_HISTORY_TABLES_TO_PRUNE)
+        } else {
+            input.limiter
+        };
+
+        // The limiter may already be exhausted by a previous segment in the same prune run.
+        if limiter.is_limit_reached() {
+            return Ok(SegmentOutput::not_done(
+                limiter.interrupt_reason(),
+                input.previous_checkpoint.map(SegmentOutputCheckpoint::from_prune_checkpoint),
+            ))
+        }
+
+        // Deleted storage changeset keys (account address + storage slot) with the highest block
+        // number deleted for that key. Bounded the same way as the database path below.
+        let mut highest_deleted_storages = FxHashMap::default();
+        let mut last_changeset_pruned_block = None;
+        let mut pruned_changesets = 0;
+        let mut done = true;
+
+        let walker = provider.static_file_provider().walk_storage_changeset_range(range);
+        for result in walker {
+            if limiter.is_limit_reached() {
+                done = false;
+                break
+            }
+            let (BlockNumberAddress((block_number, address)), entry) = result?;
+            highest_deleted_storages.insert((address, entry.key), block_number);
+            last_changeset_pruned_block = Some(block_number);
+            pruned_changesets += 1;
+            limiter.increment_deleted_entries_count();
+        }
+
+        // Reclaim whole jars only once the range is fully processed, so a jar straddling the
+        // horizon is never removed while it still holds live blocks (`delete_segment_below_block`
+        // additionally refuses to delete the highest jar).
+        if done && let Some(last_block) = last_changeset_pruned_block {
+            provider
+                .static_file_provider()
+                .delete_segment_below_block(StaticFileSegment::StorageChangeSets, last_block + 1)?;
+        }
+        trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned storage history (changesets from static files)");
+
+        let result = HistoryPruneResult {
+            highest_deleted: highest_deleted_storages,
+            last_pruned_block: last_changeset_pruned_block,
+            pruned_count: pruned_changesets,
+            done,
+        };
+        finalize_history_prune::<_, tables::StoragesHistory, (Address, B256), _>(
+            provider,
+            result,
+            range_end,
+            &limiter,
+            |(address, storage_key), block_number| {
+                StorageShardedKey::new(address, storage_key, block_number)
+            },
+            |a, b| a.address == b.address && a.sharded_key.key == b.sharded_key.key,
+        )
+        .map_err(Into::into)
+    }
+
+    /// Prunes storage history when changesets are stored in the database changeset table.
+    fn prune_database<Provider>(
+        &self,
+        provider: &Provider,
+        input: PruneInput,
+        range: std::ops::RangeInclusive<BlockNumber>,
+        range_end: BlockNumber,
+    ) -> Result<SegmentOutput, PrunerError>
+    where
+        Provider: DBProvider<Tx: DbTxMut>,
+    {
         let mut limiter = if let Some(limit) = input.limiter.deleted_entries_limit() {
             input.limiter.set_deleted_entries_limit(limit / STORAGE_HISTORY_TABLES_TO_PRUNE)
         } else {
@@ -70,16 +177,16 @@ where
             ))
         }
 
-        let mut last_changeset_pruned_block = None;
         // Deleted storage changeset keys (account addresses and storage slots) with the highest
         // block number deleted for that key.
         //
         // The size of this map it's limited by `prune_delete_limit * blocks_since_last_run /
-        // ACCOUNT_HISTORY_TABLES_TO_PRUNE`, and with current default it's usually `3500 * 5
+        // STORAGE_HISTORY_TABLES_TO_PRUNE`, and with current default it's usually `3500 * 5
         // / 2`, so 8750 entries. Each entry is `160 bit + 256 bit + 64 bit`, so the total
         // size should be up to 0.5MB + some hashmap overhead. `blocks_since_last_run` is
         // additionally limited by the `max_reorg_depth`, so no OOM is expected here.
         let mut highest_deleted_storages = FxHashMap::default();
+        let mut last_changeset_pruned_block = None;
         let (pruned_changesets, done) =
             provider.tx_ref().prune_table_with_range::<tables::StorageChangeSets>(
                 BlockNumberAddress::range(range),
@@ -90,44 +197,25 @@ where
                     last_changeset_pruned_block = Some(block_number);
                 },
             )?;
-        trace!(target: "pruner", deleted = %pruned_changesets, %done, "Pruned storage history (changesets)");
+        trace!(target: "pruner", deleted = %pruned_changesets, %done, "Pruned storage history (changesets from database)");
 
-        let last_changeset_pruned_block = last_changeset_pruned_block
-            // If there's more storage changesets to prune, set the checkpoint block number to
-            // previous, so we could finish pruning its storage changesets on the next run.
-            .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
-            .unwrap_or(range_end);
-
-        // Sort highest deleted block numbers by account address and storage key and turn them into
-        // sharded keys.
-        // We did not use `BTreeMap` from the beginning, because it's inefficient for hashes.
-        let highest_sharded_keys = highest_deleted_storages
-            .into_iter()
-            .sorted_unstable() // Unstable is fine because no equal keys exist in the map
-            .map(|((address, storage_key), block_number)| {
-                StorageShardedKey::new(
-                    address,
-                    storage_key,
-                    block_number.min(last_changeset_pruned_block),
-                )
-            });
-        let outcomes = prune_history_indices::<Provider, tables::StoragesHistory, _>(
+        let result = HistoryPruneResult {
+            highest_deleted: highest_deleted_storages,
+            last_pruned_block: last_changeset_pruned_block,
+            pruned_count: pruned_changesets,
+            done,
+        };
+        finalize_history_prune::<_, tables::StoragesHistory, (Address, B256), _>(
             provider,
-            highest_sharded_keys,
+            result,
+            range_end,
+            &limiter,
+            |(address, storage_key), block_number| {
+                StorageShardedKey::new(address, storage_key, block_number)
+            },
             |a, b| a.address == b.address && a.sharded_key.key == b.sharded_key.key,
-        )?;
-        trace!(target: "pruner", ?outcomes, %done, "Pruned storage history (indices)");
-
-        let progress = limiter.progress(done);
-
-        Ok(SegmentOutput {
-            progress,
-            pruned: pruned_changesets + outcomes.deleted,
-            checkpoint: Some(SegmentOutputCheckpoint {
-                block_number: Some(last_changeset_pruned_block),
-                tx_number: None,
-            }),
-        })
+        )
+        .map_err(Into::into)
     }
 }
 
@@ -139,8 +227,11 @@ mod tests {
     };
     use alloy_primitives::{BlockNumber, B256};
     use assert_matches::assert_matches;
-    use reth_db_api::{tables, BlockNumberList};
-    use reth_provider::{DatabaseProviderFactory, PruneCheckpointReader};
+    use reth_db_api::{models::GravityStorageSettings, tables, BlockNumberList};
+    use reth_provider::{
+        DatabaseProviderFactory, PruneCheckpointReader, StaticFileProviderFactory,
+        StaticFileSegment, StorageSettingsCache,
+    };
     use reth_prune_types::{PruneCheckpoint, PruneMode, PruneProgress, PruneSegment};
     use reth_stages::test_utils::{StorageKind, TestStageDB};
     use reth_testing_utils::generators::{
@@ -315,5 +406,98 @@ mod tests {
         );
         test_prune(998, 2, (PruneProgress::Finished, 499));
         test_prune(1200, 3, (PruneProgress::Finished, 202));
+    }
+
+    /// Exercises the static-file changeset path. With `changesets_in_static_files` enabled the
+    /// changesets live in static files (the DB changeset table is empty), so pruning must walk the
+    /// static files to prune the `StoragesHistory` index and to reclaim below-horizon jars.
+    #[test]
+    fn prune_static_files_path() {
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=100,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();
+        let (changesets, _) = random_changeset_range(
+            &mut rng,
+            blocks.iter(),
+            accounts.into_iter().map(|(addr, acc)| (addr, (acc, Vec::new()))),
+            1..2,
+            1..2,
+        );
+
+        // Changesets in static files, history index in the database.
+        db.insert_changesets_to_static_files(changesets.clone(), None)
+            .expect("insert changesets to static files");
+        db.insert_history(changesets.clone(), None).expect("insert history");
+
+        // Under this configuration the database changeset table stays empty.
+        assert!(db.table::<tables::StorageChangeSets>().unwrap().is_empty());
+
+        let count_index_blocks = || {
+            db.table::<tables::StoragesHistory>()
+                .unwrap()
+                .iter()
+                .map(|(_, blocks)| blocks.iter().count())
+                .sum::<usize>()
+        };
+        let blocks_before = count_index_blocks();
+        assert!(blocks_before > 0);
+
+        let to_block: BlockNumber = 50;
+        let prune_mode = PruneMode::Before(to_block);
+        let input =
+            PruneInput { previous_checkpoint: None, to_block, limiter: PruneLimiter::default() };
+        let segment = StorageHistory::new(prune_mode);
+
+        // Route to the static-file path.
+        db.factory.set_storage_settings_cache(GravityStorageSettings {
+            changesets_in_static_files: true,
+        });
+
+        let provider = db.factory.database_provider_rw().unwrap();
+        let result = segment.prune(&provider, input).unwrap();
+
+        assert_matches!(
+            result,
+            SegmentOutput { progress: PruneProgress::Finished, pruned, checkpoint: Some(_) }
+                if pruned > 0
+        );
+
+        segment
+            .save_checkpoint(&provider, result.checkpoint.unwrap().as_prune_checkpoint(prune_mode))
+            .unwrap();
+        provider.commit().expect("commit");
+
+        // The history index no longer references pruned blocks, and it shrank.
+        assert!(count_index_blocks() < blocks_before);
+        for (_, blocks) in db.table::<tables::StoragesHistory>().unwrap() {
+            assert!(blocks.iter().all(|b| b > to_block));
+        }
+
+        // Checkpoint advanced to the prune horizon.
+        assert_eq!(
+            db.factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::StorageHistory)
+                .unwrap(),
+            Some(PruneCheckpoint { block_number: Some(to_block), tx_number: None, prune_mode })
+        );
+
+        // The single changeset jar spans the tip, so it is not reclaimed, but nothing above the
+        // horizon is lost: the static-file tip is preserved.
+        assert_eq!(
+            db.factory
+                .static_file_provider()
+                .get_highest_static_file_block(StaticFileSegment::StorageChangeSets),
+            Some(100)
+        );
     }
 }

--- a/crates/stages/stages/src/stages/prune.rs
+++ b/crates/stages/stages/src/stages/prune.rs
@@ -3,7 +3,7 @@ use reth_db_api::{table::Value, transaction::DbTxMut};
 use reth_primitives_traits::NodePrimitives;
 use reth_provider::{
     BlockReader, DBProvider, PruneCheckpointReader, PruneCheckpointWriter,
-    StaticFileProviderFactory,
+    StaticFileProviderFactory, StorageSettingsCache,
 };
 use reth_prune::{
     PruneMode, PruneModes, PruneSegment, PrunerBuilder, SegmentOutput, SegmentOutputCheckpoint,
@@ -45,7 +45,7 @@ where
         + BlockReader
         + StaticFileProviderFactory<
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
-        >,
+        > + StorageSettingsCache,
 {
     fn id(&self) -> StageId {
         StageId::Prune
@@ -149,7 +149,7 @@ where
         + BlockReader
         + StaticFileProviderFactory<
             Primitives: NodePrimitives<SignedTx: Value, Receipt: Value, BlockHeader: Value>,
-        >,
+        > + StorageSettingsCache,
 {
     fn id(&self) -> StageId {
         StageId::PruneSenderRecovery

--- a/crates/stages/stages/src/test_utils/test_db.rs
+++ b/crates/stages/stages/src/test_utils/test_db.rs
@@ -8,7 +8,7 @@ use reth_db_api::{
     common::KeyValue,
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO},
     database::Database,
-    models::{AccountBeforeTx, StoredBlockBodyIndices},
+    models::{AccountBeforeTx, StorageBeforeTx, StoredBlockBodyIndices},
     table::Table,
     tables,
     transaction::{DbTx, DbTxMut},
@@ -443,6 +443,51 @@ impl TestStageDB {
                 })
             })
         })
+    }
+
+    /// Insert a collection of [`ChangeSet`] into the account and storage changeset static files.
+    pub fn insert_changesets_to_static_files<I>(
+        &self,
+        changesets: I,
+        block_offset: Option<u64>,
+    ) -> ProviderResult<()>
+    where
+        I: IntoIterator<Item = ChangeSet>,
+    {
+        let offset = block_offset.unwrap_or_default();
+        let static_file_provider = self.factory.static_file_provider();
+
+        let mut account_changeset_writer =
+            static_file_provider.latest_writer(StaticFileSegment::AccountChangeSets)?;
+        let mut storage_changeset_writer =
+            static_file_provider.latest_writer(StaticFileSegment::StorageChangeSets)?;
+
+        for (block, changeset) in changesets.into_iter().enumerate() {
+            let block_number = offset + block as u64;
+
+            let mut account_changesets = Vec::new();
+            let mut storage_changesets = Vec::new();
+
+            for (address, old_account, old_storage) in changeset {
+                account_changesets.push(AccountBeforeTx { address, info: Some(old_account) });
+
+                for entry in old_storage {
+                    storage_changesets.push(StorageBeforeTx {
+                        address,
+                        key: entry.key,
+                        value: entry.value,
+                    });
+                }
+            }
+
+            account_changeset_writer.append_account_changeset(account_changesets, block_number)?;
+            storage_changeset_writer.append_storage_changeset(storage_changesets, block_number)?;
+        }
+
+        account_changeset_writer.commit()?;
+        storage_changeset_writer.commit()?;
+
+        Ok(())
     }
 
     pub fn insert_history<I>(&self, changesets: I, _block_offset: Option<u64>) -> ProviderResult<()>

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -487,6 +487,51 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         }
     }
 
+    /// Deletes every static file jar for `segment` that lies entirely below `block`.
+    ///
+    /// A jar is removed only when its highest block is still below `block`, so a jar that
+    /// straddles `block` — i.e. still holds live blocks at or above the prune horizon — is kept
+    /// (files can only be removed whole). The highest jar is never deleted, so at least one jar
+    /// always remains if any exist, even when `block` is past the segment tip.
+    ///
+    /// History pruning uses this to reclaim account/storage changeset jars once all of their
+    /// blocks fall below the prune horizon.
+    pub fn delete_segment_below_block(
+        &self,
+        segment: StaticFileSegment,
+        block: BlockNumber,
+    ) -> ProviderResult<()> {
+        // Nothing to delete if block is 0.
+        if block == 0 {
+            return Ok(())
+        }
+
+        let highest_block = self.get_highest_static_file_block(segment);
+
+        loop {
+            // `get_lowest_static_file_block` returns the *end* of the lowest jar's block range, so
+            // the jar is fully below the horizon only while that end is still `< block`.
+            let Some(range_end) = self.get_lowest_static_file_block(segment) else { return Ok(()) };
+
+            // Stop once the lowest jar reaches the horizon, and never delete the highest jar.
+            if range_end >= block || Some(range_end) == highest_block {
+                return Ok(())
+            }
+
+            debug!(
+                target: "provider::static_file",
+                ?segment,
+                ?range_end,
+                "Deleting static file below block"
+            );
+
+            // Wipe the jar; this updates the index and advances the lowest tracked block height.
+            self.delete_jar(segment, range_end).inspect_err(|err| {
+                warn!(target: "provider::static_file", ?segment, %range_end, ?err, "Failed to delete static file below block")
+            })?;
+        }
+    }
+
     /// Given a segment and block, it deletes the jar and all files from the respective block range.
     ///
     /// CAUTION: destructive. Deletes files on disk.

--- a/crates/storage/provider/src/providers/static_file/mod.rs
+++ b/crates/storage/provider/src/providers/static_file/mod.rs
@@ -590,7 +590,9 @@ mod changeset_tests {
     use super::*;
     use crate::{test_utils::create_test_provider_factory, StaticFileProviderFactory};
     use alloy_primitives::{Address, B256, U256};
+    use reth_db::test_utils::create_test_static_files_dir;
     use reth_db_api::models::{AccountBeforeTx, StorageBeforeTx};
+    use reth_ethereum_primitives::EthPrimitives;
     use reth_primitives_traits::Account;
     use reth_storage_api::{ChangeSetReader, StorageChangeSetReader};
 
@@ -690,6 +692,63 @@ mod changeset_tests {
         assert_eq!(sf.account_block_changeset(1)?.len(), 2);
         assert!(sf.account_block_changeset(3)?.is_empty());
         assert_eq!(sf.account_changesets_range(0..=3)?.len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn delete_segment_below_block_reclaims_whole_jars() -> eyre::Result<()> {
+        // Small jars so blocks span multiple files: jars are [0..=4], [5..=9], [10..=14], ...
+        let (static_dir, _) = create_test_static_files_dir();
+        let sf = StaticFileProvider::<EthPrimitives>::read_write(&static_dir)?
+            .with_custom_blocks_per_file(5);
+
+        let addr = Address::with_last_byte(1);
+
+        // Account changesets for blocks 0..=12 → jars [0..=4], [5..=9], and a partial [10..=12].
+        {
+            let mut writer = sf.latest_writer(StaticFileSegment::AccountChangeSets)?;
+            for block in 0..=12u64 {
+                writer.append_account_changeset(
+                    vec![AccountBeforeTx { address: addr, info: None }],
+                    block,
+                )?;
+            }
+            writer.commit()?;
+        }
+        // The `min_block` index (which `get_lowest_static_file_block` reads) is only rebuilt by
+        // `initialize_index`, which a production provider runs at startup. Refresh it here so it
+        // reflects the jars we just wrote, mirroring a fresh provider over existing files.
+        sf.initialize_index()?;
+
+        // `get_lowest_static_file_block` returns the *end* of the lowest jar's range.
+        assert_eq!(sf.get_lowest_static_file_block(StaticFileSegment::AccountChangeSets), Some(4));
+        assert_eq!(
+            sf.get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
+            Some(12)
+        );
+
+        // Horizon at block 10: jars [0..=4] and [5..=9] end below it and are reclaimed, while the
+        // straddling jar [10..=12] still holds live blocks (>= 10) and must be kept whole.
+        sf.delete_segment_below_block(StaticFileSegment::AccountChangeSets, 10)?;
+
+        assert_eq!(sf.get_lowest_static_file_block(StaticFileSegment::AccountChangeSets), Some(12));
+        assert_eq!(
+            sf.get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
+            Some(12)
+        );
+        // Live changesets at/above the horizon are intact.
+        assert_eq!(sf.account_block_changeset(10)?.len(), 1);
+        assert_eq!(sf.account_block_changeset(12)?.len(), 1);
+
+        // The highest jar is never deleted, even when the horizon is far past the tip.
+        sf.delete_segment_below_block(StaticFileSegment::AccountChangeSets, 1_000)?;
+        assert_eq!(sf.get_lowest_static_file_block(StaticFileSegment::AccountChangeSets), Some(12));
+        assert_eq!(
+            sf.get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
+            Some(12)
+        );
+        assert_eq!(sf.account_block_changeset(12)?.len(), 1);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #402

Under `changesets_in_static_files`, account/storage history pruning only pruned the (empty) DB changeset tables, so the changeset static-file jars below the prune horizon were never physically reclaimed — changeset disk usage grew unbounded with chain length while logical pruning kept working correctly.

Dispatch account/storage history pruning on `changesets_in_static_files`: the static-file path walks the changesets, prunes the history index, then reclaims whole jars below the horizon via the new `StaticFileProvider::delete_segment_below_block`, which keys off each jar's range end and never deletes the highest jar — so a jar straddling the horizon (still holding live blocks) is kept whole.

Ports #21346 to the merge branch, without the RocksDB history path (not present here).
