### PR TITLE
chore(deps): bump grevm eecc6fc → dcd1460

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,7 +1046,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1057,7 +1057,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1494,15 +1494,6 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
-]
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -3499,7 +3490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4256,8 +4247,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4489,11 +4480,10 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=eecc6fc8bfcc07916517ac15f41a70c8036381bb#eecc6fc8bfcc07916517ac15f41a70c8036381bb"
+source = "git+https://github.com/Galxe/grevm?rev=dcd1460b20d9f3d793c8309c28b0b7401be91523#dcd1460b20d9f3d793c8309c28b0b7401be91523"
 dependencies = [
  "ahash",
  "alloy-evm",
- "atomic",
  "auto_impl",
  "dashmap 6.2.1",
  "futures",
@@ -4952,7 +4942,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5309,7 +5299,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6367,7 +6357,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11465,7 +11455,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11545,7 +11535,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12202,7 +12192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12429,7 +12419,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13739,7 +13729,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,7 +451,7 @@ reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
 reth-revm = { path = "crates/revm", default-features = false }
-grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", rev = "eecc6fc8bfcc07916517ac15f41a70c8036381bb" }
+grevm = { package = "grevm", git = "https://github.com/Galxe/grevm", rev = "dcd1460b20d9f3d793c8309c28b0b7401be91523" }
 reth-rpc = { path = "crates/rpc/rpc" }
 reth-rpc-api = { path = "crates/rpc/rpc-api" }
 reth-rpc-api-testing-util = { path = "crates/rpc/rpc-testing-util" }

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -12,7 +12,7 @@ use alloy_evm::{
 };
 use alloy_primitives::{map::HashMap, Address};
 use gravity_primitives::get_gravity_config;
-use grevm::{ParallelBundleState, ParallelState, Scheduler};
+use grevm::{ParallelBundleState, ParallelState, Scheduler, TxExecutionOutcome};
 use reth_chainspec::{EthChainSpec, EthereumHardfork, EthereumHardforks, Hardforks};
 use reth_ethereum_primitives::{Block, EthPrimitives, Receipt};
 use reth_evm::{
@@ -107,14 +107,8 @@ where
 
         let (results, state) = {
             let EvmEnv { cfg_env, block_env } = evm_env;
-            let executor = Scheduler::new(
-                cfg_env,
-                block_env,
-                txs,
-                state,
-                false,
-                self.custom_precompiles.clone(),
-            );
+            let executor =
+                Scheduler::new(cfg_env, block_env, txs, state, self.custom_precompiles.clone());
             executor.parallel_execute(None).map_err(|e| {
                 // `e.txid` is grevm's per-tx index; for block-level errors it can be a
                 // sentinel or out-of-bounds value. Use a saturating lookup so the error
@@ -138,9 +132,31 @@ where
 
         let mut receipts = Vec::with_capacity(results.len());
         let mut cumulative_gas_used = 0;
-        for (result, tx_type) in
-            results.into_iter().zip(block.body().transactions().map(|tx| tx.tx_type()))
+        // grevm dcd1460 (#111) added a `Skipped(InvalidTransaction)` fallback outcome. The
+        // gravity D-1b design routes skipped txs out of the final block via the pipe layer
+        // (see `project-seq-skip-invalid-txn-design`), but that spans the gravity-sdk repo
+        // and has not landed yet. Until it does, keep the pre-v2.3.0 semantics: any grevm-
+        // reported invalid tx is surfaced as a `BlockValidationError::InvalidTx`, matching
+        // the existing pipe-layer error/panic path — no silent no-op receipts that would
+        // fork state root against the pre-v2.3.0 backends.
+        for (idx, (outcome, tx_type)) in
+            results.into_iter().zip(block.body().transactions().map(|tx| tx.tx_type())).enumerate()
         {
+            let result = match outcome {
+                TxExecutionOutcome::Executed(r) => r,
+                TxExecutionOutcome::Skipped(inv_tx) => {
+                    // Same saturating hash lookup as the block-level error mapping above.
+                    let hash = block
+                        .transactions_with_sender()
+                        .nth(idx)
+                        .map(|(_, tx)| tx.recalculate_hash())
+                        .unwrap_or_default();
+                    return Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                        hash,
+                        error: Box::new(inv_tx),
+                    }));
+                }
+            };
             cumulative_gas_used += result.tx_gas_used();
             receipts.push(Receipt {
                 tx_type,


### PR DESCRIPTION
Picks up:

- #109 parallel-bundle `reverts_size` fix (the reason the earlier alloy upgrade was reverted)
- #111 invalid-tx skip fallback (introduces `TxExecutionOutcome::{Executed, Skipped}`)
- #114 delegated-context CREATE + reserve balance
- #115 async finality/commit refactor
- #116 revm 40 / alloy-evm 0.36 re-upgrade — the pinned alloy/revm versions match the current workspace again

Adapts `GrevmExecutor::execute_transactions` to the new API:

- `Scheduler::new` drops the `disable_grevm` bool argument (unified runtime-config path — see grevm `docs/use-with-reth.md`).
- Per-tx results are now `Vec<TxExecutionOutcome>`. `Skipped(inv)` is surfaced as `BlockValidationError::InvalidTx { hash, error }`, preserving the pre-v2.3.0 executor semantics: any grevm-reported invalid tx flows through the existing pipe-layer error/panic path. **No silent no-op receipts** — the full D-1b design (skipped txs dropped from the final block via the pipe layer) spans the gravity-sdk repo and has not landed yet, and a no-op receipt here would fork state root against the pre-v2.3.0 backends.

## Test plan

- [x] `cargo check --workspace --all-features` — clean
- [x] `cargo +nightly fmt --all --check` — clean
- [x] `cargo +nightly clippy -p reth-evm-ethereum --all-features --lib --tests` — no new warnings (23 pre-existing `redundant_clone` in tests, unrelated)
- [ ] CI (unit + fmt + clippy + book)