### PR TITLE
fix(evm): stabilize skipped transaction reason encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8914,7 +8914,6 @@ dependencies = [
  "gravity-primitives",
  "grevm",
  "parking_lot",
- "postcard",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -583,7 +583,6 @@ parity-scale-codec = "3.2.1"
 parking_lot = "0.12"
 quanta = "0.12"
 paste = "1.0"
-postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 rand = "0.9"
 rayon = "1.7"
 thread-priority = "3.0.0"

--- a/crates/ethereum/evm/Cargo.toml
+++ b/crates/ethereum/evm/Cargo.toml
@@ -20,7 +20,7 @@ reth-chainspec.workspace = true
 reth-ethereum-forks.workspace = true
 reth-primitives-traits.workspace = true
 reth-ethereum-primitives.workspace = true
-revm = { workspace = true, features = ["optional_balance_check", "optional_no_base_fee", "serde"] }
+revm = { workspace = true, features = ["optional_balance_check", "optional_no_base_fee"] }
 reth-evm.workspace = true
 grevm.workspace = true
 gravity-primitives.workspace = true
@@ -37,7 +37,6 @@ alloy-sol-types.workspace = true
 # Misc
 parking_lot = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true }
-postcard.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
@@ -66,7 +65,6 @@ std = [
     "derive_more?/std",
     "alloy-rpc-types-engine/std",
     "alloy-sol-types/std",
-    "postcard/use-std",
     "reth-storage-errors/std",
     "tracing/std",
 ]

--- a/crates/ethereum/evm/src/parallel_execute.rs
+++ b/crates/ethereum/evm/src/parallel_execute.rs
@@ -195,17 +195,14 @@ where
                         tx_index,
                         ?tx_hash,
                         ?reason,
+                        ?error,
                         "included transaction skipped during final execution",
                     );
-                    let receipt =
-                        GravityTxSkippedEvent::receipt(tx_type, cumulative_gas_used, &error);
-                    let receipt = receipt.map_err(|encode_error| {
-                        let message = alloc::format!(
-                            "failed to encode skipped transaction {tx_index}: {encode_error}"
-                        );
-                        BlockExecutionError::msg(message)
-                    })?;
-                    receipts.push(receipt);
+                    receipts.push(GravityTxSkippedEvent::receipt(
+                        tx_type,
+                        cumulative_gas_used,
+                        reason,
+                    ));
                 }
             }
         }

--- a/crates/ethereum/evm/src/skipped_transaction.rs
+++ b/crates/ethereum/evm/src/skipped_transaction.rs
@@ -1,7 +1,7 @@
 //! Protocol encoding for transactions skipped during Gravity block execution.
 
 use alloy_consensus::TxType;
-use alloy_primitives::{Bytes, Log, B256};
+use alloy_primitives::{Log, B256};
 use alloy_sol_types::{sol, SolEvent};
 use grevm::InvalidTransaction;
 use reth_chainspec::GRAVITY_TX_SKIPPED_LOG_ADDRESS;
@@ -10,21 +10,29 @@ use reth_ethereum_primitives::Receipt;
 sol! {
     /// Emitted in the synthetic receipt of an included transaction that was invalid at final
     /// execution state and therefore applied as a no-op.
-    event GravityTxSkipped(uint16 indexed version, uint16 indexed reason, bytes encodedError);
+    event GravityTxSkipped(uint16 indexed version, uint16 indexed reason);
 }
 
 /// Current version of the [`GravityTxSkipped`] event encoding.
 pub const GRAVITY_TX_SKIPPED_LOG_VERSION: u16 = 1;
 
-/// `keccak256("GravityTxSkipped(uint16,uint16,bytes)")`, derived from the Solidity declaration.
+/// `keccak256("GravityTxSkipped(uint16,uint16)")`, derived from the Solidity declaration.
 pub const GRAVITY_TX_SKIPPED_LOG_TOPIC0: B256 = GravityTxSkipped::SIGNATURE_HASH;
 
 macro_rules! define_skip_reasons {
-    ($($variant:ident = $code:literal => $pattern:pat),+ $(,)?) => {
-        /// The zero-based wire tag for a skipped [`InvalidTransaction`].
+    (
+        active {
+            $($variant:ident = $code:literal => $pattern:pat),+ $(,)?
+        }
+        reserved {
+            $($reserved_variant:ident = $reserved_code:literal),* $(,)?
+        }
+    ) => {
+        /// The stable wire tag for a skipped [`InvalidTransaction`].
         ///
-        /// Variants intentionally follow the declaration order of revm's [`InvalidTransaction`].
-        /// A revm upgrade that changes that enum must update this table and the log version.
+        /// The initial assignments follow revm's declaration order. Once assigned, a code must
+        /// never be changed or reused: new variants are appended and removed variants are moved
+        /// to the `reserved` section of the reason table.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[repr(u16)]
         pub enum GravityTxSkipReason {
@@ -32,6 +40,10 @@ macro_rules! define_skip_reasons {
                 #[doc = concat!("Corresponds to [`InvalidTransaction::", stringify!($variant), "`].")]
                 $variant = $code,
             )+
+            $(
+                #[doc = concat!("Reserved historical reason code for `", stringify!($reserved_variant), "`.")]
+                $reserved_variant = $reserved_code,
+            )*
         }
 
         impl GravityTxSkipReason {
@@ -46,6 +58,7 @@ macro_rules! define_skip_reasons {
             pub const fn from_code(code: u16) -> Option<Self> {
                 match code {
                     $($code => Some(Self::$variant),)+
+                    $($reserved_code => Some(Self::$reserved_variant),)*
                     _ => None,
                 }
             }
@@ -54,39 +67,42 @@ macro_rules! define_skip_reasons {
 }
 
 define_skip_reasons! {
-    PriorityFeeGreaterThanMaxFee = 0 => InvalidTransaction::PriorityFeeGreaterThanMaxFee,
-    GasPriceLessThanBasefee = 1 => InvalidTransaction::GasPriceLessThanBasefee,
-    CallerGasLimitMoreThanBlock = 2 => InvalidTransaction::CallerGasLimitMoreThanBlock,
-    CallGasCostMoreThanGasLimit = 3 => InvalidTransaction::CallGasCostMoreThanGasLimit { .. },
-    GasFloorMoreThanGasLimit = 4 => InvalidTransaction::GasFloorMoreThanGasLimit { .. },
-    RejectCallerWithCode = 5 => InvalidTransaction::RejectCallerWithCode,
-    LackOfFundForMaxFee = 6 => InvalidTransaction::LackOfFundForMaxFee { .. },
-    OverflowPaymentInTransaction = 7 => InvalidTransaction::OverflowPaymentInTransaction,
-    NonceOverflowInTransaction = 8 => InvalidTransaction::NonceOverflowInTransaction,
-    NonceTooHigh = 9 => InvalidTransaction::NonceTooHigh { .. },
-    NonceTooLow = 10 => InvalidTransaction::NonceTooLow { .. },
-    CreateInitCodeSizeLimit = 11 => InvalidTransaction::CreateInitCodeSizeLimit,
-    InvalidChainId = 12 => InvalidTransaction::InvalidChainId,
-    MissingChainId = 13 => InvalidTransaction::MissingChainId,
-    TxGasLimitGreaterThanCap = 14 => InvalidTransaction::TxGasLimitGreaterThanCap { .. },
-    AccessListNotSupported = 15 => InvalidTransaction::AccessListNotSupported,
-    MaxFeePerBlobGasNotSupported = 16 => InvalidTransaction::MaxFeePerBlobGasNotSupported,
-    BlobVersionedHashesNotSupported = 17 => InvalidTransaction::BlobVersionedHashesNotSupported,
-    BlobGasPriceGreaterThanMax = 18 => InvalidTransaction::BlobGasPriceGreaterThanMax { .. },
-    EmptyBlobs = 19 => InvalidTransaction::EmptyBlobs,
-    BlobCreateTransaction = 20 => InvalidTransaction::BlobCreateTransaction,
-    TooManyBlobs = 21 => InvalidTransaction::TooManyBlobs { .. },
-    BlobVersionNotSupported = 22 => InvalidTransaction::BlobVersionNotSupported,
-    AuthorizationListNotSupported = 23 => InvalidTransaction::AuthorizationListNotSupported,
-    AuthorizationListInvalidFields = 24 => InvalidTransaction::AuthorizationListInvalidFields,
-    EmptyAuthorizationList = 25 => InvalidTransaction::EmptyAuthorizationList,
-    Eip2930NotSupported = 26 => InvalidTransaction::Eip2930NotSupported,
-    Eip1559NotSupported = 27 => InvalidTransaction::Eip1559NotSupported,
-    Eip4844NotSupported = 28 => InvalidTransaction::Eip4844NotSupported,
-    Eip7702NotSupported = 29 => InvalidTransaction::Eip7702NotSupported,
-    Eip7873NotSupported = 30 => InvalidTransaction::Eip7873NotSupported,
-    Eip7873MissingTarget = 31 => InvalidTransaction::Eip7873MissingTarget,
-    Str = 32 => InvalidTransaction::Str(_),
+    active {
+        PriorityFeeGreaterThanMaxFee = 0 => InvalidTransaction::PriorityFeeGreaterThanMaxFee,
+        GasPriceLessThanBasefee = 1 => InvalidTransaction::GasPriceLessThanBasefee,
+        CallerGasLimitMoreThanBlock = 2 => InvalidTransaction::CallerGasLimitMoreThanBlock,
+        CallGasCostMoreThanGasLimit = 3 => InvalidTransaction::CallGasCostMoreThanGasLimit { .. },
+        GasFloorMoreThanGasLimit = 4 => InvalidTransaction::GasFloorMoreThanGasLimit { .. },
+        RejectCallerWithCode = 5 => InvalidTransaction::RejectCallerWithCode,
+        LackOfFundForMaxFee = 6 => InvalidTransaction::LackOfFundForMaxFee { .. },
+        OverflowPaymentInTransaction = 7 => InvalidTransaction::OverflowPaymentInTransaction,
+        NonceOverflowInTransaction = 8 => InvalidTransaction::NonceOverflowInTransaction,
+        NonceTooHigh = 9 => InvalidTransaction::NonceTooHigh { .. },
+        NonceTooLow = 10 => InvalidTransaction::NonceTooLow { .. },
+        CreateInitCodeSizeLimit = 11 => InvalidTransaction::CreateInitCodeSizeLimit,
+        InvalidChainId = 12 => InvalidTransaction::InvalidChainId,
+        MissingChainId = 13 => InvalidTransaction::MissingChainId,
+        TxGasLimitGreaterThanCap = 14 => InvalidTransaction::TxGasLimitGreaterThanCap { .. },
+        AccessListNotSupported = 15 => InvalidTransaction::AccessListNotSupported,
+        MaxFeePerBlobGasNotSupported = 16 => InvalidTransaction::MaxFeePerBlobGasNotSupported,
+        BlobVersionedHashesNotSupported = 17 => InvalidTransaction::BlobVersionedHashesNotSupported,
+        BlobGasPriceGreaterThanMax = 18 => InvalidTransaction::BlobGasPriceGreaterThanMax { .. },
+        EmptyBlobs = 19 => InvalidTransaction::EmptyBlobs,
+        BlobCreateTransaction = 20 => InvalidTransaction::BlobCreateTransaction,
+        TooManyBlobs = 21 => InvalidTransaction::TooManyBlobs { .. },
+        BlobVersionNotSupported = 22 => InvalidTransaction::BlobVersionNotSupported,
+        AuthorizationListNotSupported = 23 => InvalidTransaction::AuthorizationListNotSupported,
+        AuthorizationListInvalidFields = 24 => InvalidTransaction::AuthorizationListInvalidFields,
+        EmptyAuthorizationList = 25 => InvalidTransaction::EmptyAuthorizationList,
+        Eip2930NotSupported = 26 => InvalidTransaction::Eip2930NotSupported,
+        Eip1559NotSupported = 27 => InvalidTransaction::Eip1559NotSupported,
+        Eip4844NotSupported = 28 => InvalidTransaction::Eip4844NotSupported,
+        Eip7702NotSupported = 29 => InvalidTransaction::Eip7702NotSupported,
+        Eip7873NotSupported = 30 => InvalidTransaction::Eip7873NotSupported,
+        Eip7873MissingTarget = 31 => InvalidTransaction::Eip7873MissingTarget,
+        Str = 32 => InvalidTransaction::Str(_),
+    }
+    reserved {}
 }
 
 /// Encoder and decoder for Gravity's synthetic skipped-transaction receipt.
@@ -94,28 +110,20 @@ define_skip_reasons! {
 pub struct GravityTxSkippedEvent;
 
 impl GravityTxSkippedEvent {
-    /// Creates a protocol log containing the complete [`InvalidTransaction`].
-    ///
-    /// Postcard encodes the enum variant as its zero-based declaration index and serializes every
-    /// field carried by that variant.
-    pub fn encode(error: &InvalidTransaction) -> Result<Log, postcard::Error> {
-        let reason = GravityTxSkipReason::from_invalid_transaction(error);
-        let encoded_error = postcard::to_allocvec(error)?;
-        Ok(Log {
+    /// Creates the protocol log for `reason`.
+    pub fn encode(reason: GravityTxSkipReason) -> Log {
+        Log {
             address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
             data: GravityTxSkipped {
                 version: GRAVITY_TX_SKIPPED_LOG_VERSION,
                 reason: reason as u16,
-                encodedError: Bytes::from(encoded_error),
             }
             .encode_log_data(),
-        })
+        }
     }
 
-    /// Parses a protocol log and reconstructs the complete [`InvalidTransaction`].
-    ///
-    /// A wrong emitter, ABI shape, version, tag, payload, or tag/payload mismatch is rejected.
-    pub fn decode(log: &Log) -> Option<InvalidTransaction> {
+    /// Parses a protocol log, rejecting a wrong emitter, ABI shape, version, or unknown reason.
+    pub fn decode(log: &Log) -> Option<GravityTxSkipReason> {
         if log.address != GRAVITY_TX_SKIPPED_LOG_ADDRESS {
             return None
         }
@@ -125,26 +133,21 @@ impl GravityTxSkippedEvent {
             return None
         }
 
-        let reason = GravityTxSkipReason::from_code(event.reason)?;
-        let error = postcard::from_bytes::<InvalidTransaction>(&event.encodedError).ok()?;
-        if GravityTxSkipReason::from_invalid_transaction(&error) != reason {
-            return None
-        }
-        Some(error)
+        GravityTxSkipReason::from_code(event.reason)
     }
 
     /// Builds the zero-gas failed receipt for a skipped transaction.
     pub fn receipt(
         tx_type: TxType,
         cumulative_gas_used: u64,
-        error: &InvalidTransaction,
-    ) -> Result<Receipt, postcard::Error> {
-        Ok(Receipt {
+        reason: GravityTxSkipReason,
+    ) -> Receipt {
+        Receipt {
             tx_type,
             success: false,
             cumulative_gas_used,
-            logs: alloc::vec![Self::encode(error)?],
-        })
+            logs: alloc::vec![Self::encode(reason)],
+        }
     }
 }
 
@@ -156,53 +159,46 @@ mod tests {
 
     #[test]
     fn topic_is_derived_from_the_documented_solidity_signature() {
-        assert_eq!(
-            GRAVITY_TX_SKIPPED_LOG_TOPIC0,
-            keccak256("GravityTxSkipped(uint16,uint16,bytes)")
-        );
+        assert_eq!(GRAVITY_TX_SKIPPED_LOG_TOPIC0, keccak256("GravityTxSkipped(uint16,uint16)"));
     }
 
     #[test]
-    fn all_invalid_transactions_round_trip_with_declaration_order_tags() {
-        let errors = all_invalid_transactions();
-        for (expected_tag, error) in errors.into_iter().enumerate() {
-            let log = GravityTxSkippedEvent::encode(&error).unwrap();
-            let event = GravityTxSkipped::decode_log(&log).unwrap();
-            assert_eq!(event.reason, expected_tag as u16);
-            assert_eq!(event.encodedError.first().copied(), Some(expected_tag as u8));
-            assert_eq!(GravityTxSkippedEvent::decode(&log), Some(error));
+    fn all_active_reason_codes_are_stable() {
+        for (error, expected_reason, expected_code) in stable_reason_cases() {
+            let reason = GravityTxSkipReason::from_invalid_transaction(&error);
+            assert_eq!(reason, expected_reason);
+            assert_eq!(reason as u16, expected_code);
+
+            let log = GravityTxSkippedEvent::encode(reason);
+            assert_eq!(GravityTxSkippedEvent::decode(&log), Some(reason));
+            assert!(log.data.data.is_empty());
         }
     }
 
     #[test]
-    fn event_decode_rejects_non_protocol_logs_and_mismatched_tags() {
-        let error = InvalidTransaction::NonceTooLow { tx: 0, state: 1 };
-        let log = GravityTxSkippedEvent::encode(&error).unwrap();
+    fn str_message_does_not_affect_consensus_encoding() {
+        let first = InvalidTransaction::Str(Cow::Borrowed("first diagnostic"));
+        let second = InvalidTransaction::Str(Cow::Borrowed("changed diagnostic"));
+        let first_log =
+            GravityTxSkippedEvent::encode(GravityTxSkipReason::from_invalid_transaction(&first));
+        let second_log =
+            GravityTxSkippedEvent::encode(GravityTxSkipReason::from_invalid_transaction(&second));
+        assert_eq!(first_log, second_log);
+    }
+
+    #[test]
+    fn event_decode_rejects_non_protocol_logs_and_unknown_tags() {
+        let log = GravityTxSkippedEvent::encode(GravityTxSkipReason::NonceTooLow);
         let mut wrong_emitter = log;
         wrong_emitter.address = Address::ZERO;
         assert_eq!(GravityTxSkippedEvent::decode(&wrong_emitter), None);
 
         let unknown_reason = Log {
             address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
-            data: GravityTxSkipped {
-                version: GRAVITY_TX_SKIPPED_LOG_VERSION,
-                reason: u16::MAX,
-                encodedError: Bytes::from(postcard::to_allocvec(&error).unwrap()),
-            }
-            .encode_log_data(),
+            data: GravityTxSkipped { version: GRAVITY_TX_SKIPPED_LOG_VERSION, reason: u16::MAX }
+                .encode_log_data(),
         };
         assert_eq!(GravityTxSkippedEvent::decode(&unknown_reason), None);
-
-        let mismatched_reason = Log {
-            address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
-            data: GravityTxSkipped {
-                version: GRAVITY_TX_SKIPPED_LOG_VERSION,
-                reason: GravityTxSkipReason::NonceTooHigh as u16,
-                encodedError: Bytes::from(postcard::to_allocvec(&error).unwrap()),
-            }
-            .encode_log_data(),
-        };
-        assert_eq!(GravityTxSkippedEvent::decode(&mismatched_reason), None);
 
         let malformed = Log {
             address: GRAVITY_TX_SKIPPED_LOG_ADDRESS,
@@ -214,50 +210,153 @@ mod tests {
         assert_eq!(GravityTxSkippedEvent::decode(&malformed), None);
     }
 
-    fn all_invalid_transactions() -> Vec<InvalidTransaction> {
+    fn stable_reason_cases() -> Vec<(InvalidTransaction, GravityTxSkipReason, u16)> {
         vec![
-            InvalidTransaction::PriorityFeeGreaterThanMaxFee,
-            InvalidTransaction::GasPriceLessThanBasefee,
-            InvalidTransaction::CallerGasLimitMoreThanBlock,
-            InvalidTransaction::CallGasCostMoreThanGasLimit {
-                initial_gas: 21_001,
-                gas_limit: 21_000,
-            },
-            InvalidTransaction::GasFloorMoreThanGasLimit { gas_floor: 30_000, gas_limit: 21_000 },
-            InvalidTransaction::RejectCallerWithCode,
-            InvalidTransaction::LackOfFundForMaxFee {
-                fee: Box::new(U256::from(100)),
-                balance: Box::new(U256::from(99)),
-            },
-            InvalidTransaction::OverflowPaymentInTransaction,
-            InvalidTransaction::NonceOverflowInTransaction,
-            InvalidTransaction::NonceTooHigh { tx: 2, state: 1 },
-            InvalidTransaction::NonceTooLow { tx: 0, state: 1 },
-            InvalidTransaction::CreateInitCodeSizeLimit,
-            InvalidTransaction::InvalidChainId,
-            InvalidTransaction::MissingChainId,
-            InvalidTransaction::TxGasLimitGreaterThanCap { gas_limit: 31_000, cap: 30_000 },
-            InvalidTransaction::AccessListNotSupported,
-            InvalidTransaction::MaxFeePerBlobGasNotSupported,
-            InvalidTransaction::BlobVersionedHashesNotSupported,
-            InvalidTransaction::BlobGasPriceGreaterThanMax {
-                block_blob_gas_price: 2,
-                tx_max_fee_per_blob_gas: 1,
-            },
-            InvalidTransaction::EmptyBlobs,
-            InvalidTransaction::BlobCreateTransaction,
-            InvalidTransaction::TooManyBlobs { max: 6, have: 7 },
-            InvalidTransaction::BlobVersionNotSupported,
-            InvalidTransaction::AuthorizationListNotSupported,
-            InvalidTransaction::AuthorizationListInvalidFields,
-            InvalidTransaction::EmptyAuthorizationList,
-            InvalidTransaction::Eip2930NotSupported,
-            InvalidTransaction::Eip1559NotSupported,
-            InvalidTransaction::Eip4844NotSupported,
-            InvalidTransaction::Eip7702NotSupported,
-            InvalidTransaction::Eip7873NotSupported,
-            InvalidTransaction::Eip7873MissingTarget,
-            InvalidTransaction::Str(Cow::Borrowed("custom invalid transaction")),
+            (
+                InvalidTransaction::PriorityFeeGreaterThanMaxFee,
+                GravityTxSkipReason::PriorityFeeGreaterThanMaxFee,
+                0,
+            ),
+            (
+                InvalidTransaction::GasPriceLessThanBasefee,
+                GravityTxSkipReason::GasPriceLessThanBasefee,
+                1,
+            ),
+            (
+                InvalidTransaction::CallerGasLimitMoreThanBlock,
+                GravityTxSkipReason::CallerGasLimitMoreThanBlock,
+                2,
+            ),
+            (
+                InvalidTransaction::CallGasCostMoreThanGasLimit {
+                    initial_gas: 21_001,
+                    gas_limit: 21_000,
+                },
+                GravityTxSkipReason::CallGasCostMoreThanGasLimit,
+                3,
+            ),
+            (
+                InvalidTransaction::GasFloorMoreThanGasLimit {
+                    gas_floor: 30_000,
+                    gas_limit: 21_000,
+                },
+                GravityTxSkipReason::GasFloorMoreThanGasLimit,
+                4,
+            ),
+            (
+                InvalidTransaction::RejectCallerWithCode,
+                GravityTxSkipReason::RejectCallerWithCode,
+                5,
+            ),
+            (
+                InvalidTransaction::LackOfFundForMaxFee {
+                    fee: Box::new(U256::from(100)),
+                    balance: Box::new(U256::from(99)),
+                },
+                GravityTxSkipReason::LackOfFundForMaxFee,
+                6,
+            ),
+            (
+                InvalidTransaction::OverflowPaymentInTransaction,
+                GravityTxSkipReason::OverflowPaymentInTransaction,
+                7,
+            ),
+            (
+                InvalidTransaction::NonceOverflowInTransaction,
+                GravityTxSkipReason::NonceOverflowInTransaction,
+                8,
+            ),
+            (
+                InvalidTransaction::NonceTooHigh { tx: 2, state: 1 },
+                GravityTxSkipReason::NonceTooHigh,
+                9,
+            ),
+            (
+                InvalidTransaction::NonceTooLow { tx: 0, state: 1 },
+                GravityTxSkipReason::NonceTooLow,
+                10,
+            ),
+            (
+                InvalidTransaction::CreateInitCodeSizeLimit,
+                GravityTxSkipReason::CreateInitCodeSizeLimit,
+                11,
+            ),
+            (InvalidTransaction::InvalidChainId, GravityTxSkipReason::InvalidChainId, 12),
+            (InvalidTransaction::MissingChainId, GravityTxSkipReason::MissingChainId, 13),
+            (
+                InvalidTransaction::TxGasLimitGreaterThanCap { gas_limit: 31_000, cap: 30_000 },
+                GravityTxSkipReason::TxGasLimitGreaterThanCap,
+                14,
+            ),
+            (
+                InvalidTransaction::AccessListNotSupported,
+                GravityTxSkipReason::AccessListNotSupported,
+                15,
+            ),
+            (
+                InvalidTransaction::MaxFeePerBlobGasNotSupported,
+                GravityTxSkipReason::MaxFeePerBlobGasNotSupported,
+                16,
+            ),
+            (
+                InvalidTransaction::BlobVersionedHashesNotSupported,
+                GravityTxSkipReason::BlobVersionedHashesNotSupported,
+                17,
+            ),
+            (
+                InvalidTransaction::BlobGasPriceGreaterThanMax {
+                    block_blob_gas_price: 2,
+                    tx_max_fee_per_blob_gas: 1,
+                },
+                GravityTxSkipReason::BlobGasPriceGreaterThanMax,
+                18,
+            ),
+            (InvalidTransaction::EmptyBlobs, GravityTxSkipReason::EmptyBlobs, 19),
+            (
+                InvalidTransaction::BlobCreateTransaction,
+                GravityTxSkipReason::BlobCreateTransaction,
+                20,
+            ),
+            (
+                InvalidTransaction::TooManyBlobs { max: 6, have: 7 },
+                GravityTxSkipReason::TooManyBlobs,
+                21,
+            ),
+            (
+                InvalidTransaction::BlobVersionNotSupported,
+                GravityTxSkipReason::BlobVersionNotSupported,
+                22,
+            ),
+            (
+                InvalidTransaction::AuthorizationListNotSupported,
+                GravityTxSkipReason::AuthorizationListNotSupported,
+                23,
+            ),
+            (
+                InvalidTransaction::AuthorizationListInvalidFields,
+                GravityTxSkipReason::AuthorizationListInvalidFields,
+                24,
+            ),
+            (
+                InvalidTransaction::EmptyAuthorizationList,
+                GravityTxSkipReason::EmptyAuthorizationList,
+                25,
+            ),
+            (InvalidTransaction::Eip2930NotSupported, GravityTxSkipReason::Eip2930NotSupported, 26),
+            (InvalidTransaction::Eip1559NotSupported, GravityTxSkipReason::Eip1559NotSupported, 27),
+            (InvalidTransaction::Eip4844NotSupported, GravityTxSkipReason::Eip4844NotSupported, 28),
+            (InvalidTransaction::Eip7702NotSupported, GravityTxSkipReason::Eip7702NotSupported, 29),
+            (InvalidTransaction::Eip7873NotSupported, GravityTxSkipReason::Eip7873NotSupported, 30),
+            (
+                InvalidTransaction::Eip7873MissingTarget,
+                GravityTxSkipReason::Eip7873MissingTarget,
+                31,
+            ),
+            (
+                InvalidTransaction::Str(Cow::Borrowed("custom invalid transaction")),
+                GravityTxSkipReason::Str,
+                32,
+            ),
         ]
     }
 }

--- a/crates/ethereum/evm/tests/execute.rs
+++ b/crates/ethereum/evm/tests/execute.rs
@@ -20,7 +20,7 @@ use reth_evm::{
 };
 use reth_evm_ethereum::{
     parallel_execute::{
-        GravityTxSkippedEvent, GrevmExecutor, GRAVITY_TX_SKIPPED_LOG_ADDRESS,
+        GravityTxSkipReason, GravityTxSkippedEvent, GrevmExecutor, GRAVITY_TX_SKIPPED_LOG_ADDRESS,
         GRAVITY_TX_SKIPPED_LOG_TOPIC0,
     },
     EthEvmConfig,
@@ -198,7 +198,7 @@ fn grevm_executor_keeps_invalid_tx_in_block_with_skipped_receipt() {
         assert_eq!(skipped_log.data.topics()[0], GRAVITY_TX_SKIPPED_LOG_TOPIC0);
         assert_eq!(
             GravityTxSkippedEvent::decode(skipped_log),
-            Some(grevm::InvalidTransaction::NonceTooLow { tx: 0, state: 1 })
+            Some(GravityTxSkipReason::NonceTooLow)
         );
     }
 }


### PR DESCRIPTION
Follow-up to #393.

Native reth returns `InvalidTransaction` as an execution error and does not produce a receipt, so diagnostic fields such as `InvalidTransaction::Str` messages are not consensus data.

Encoding the full error in Gravity’s synthetic receipt would make implementation details part of the receipts root; this PR instead assigns immutable reason codes to every current variant, requires future variants to append codes, reserves removed codes, and removes postcard/revm serde.