### PR TITLE
feat(tx-filter): EIP-7702 lockdown gated by Beta (betaTime)

### DIFF
--- a/crates/chainspec/src/api.rs
+++ b/crates/chainspec/src/api.rs
@@ -69,7 +69,7 @@ pub trait EthChainSpec: Send + Sync + Unpin + Debug {
     /// ```ignore
     /// use reth_chainspec::GravityHardfork;
     /// chain_spec.gravity_hardforks().is_fork_active_at_timestamp(GravityHardfork::Alpha, ts);
-    /// chain_spec.gravity_hardforks().fork(GravityHardfork::Gamma).transitions_at_block(n);
+    /// chain_spec.gravity_hardforks().is_fork_active_at_timestamp(GravityHardfork::Beta, ts);
     /// ```
     fn gravity_hardforks(&self) -> &reth_ethereum_forks::ChainHardforks;
 

--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -9,12 +9,13 @@ hardfork!(
     GravityHardfork {
         /// Alpha hardfork: upgrade Staking/StakePool contracts and disable PoW rewards
         Alpha,
-        /// Beta hardfork: upgrade StakePool contracts with correct FACTORY immutable
+        /// Beta hardfork: EIP-7702 lockdown release gate (audit#838).
+        ///
+        /// Until Beta activates, the pre-execution filter rejects all type-4 txs and
+        /// txs from/to currently-delegated accounts. Activation is via genesis
+        /// `betaTime` (timestamp). Missing/unknown key → Beta never active → lockdown
+        /// stays on (fail-closed).
         Beta,
-        /// Gamma hardfork: audit fixes, precompile changes, 12 contract bytecode upgrades
-        Gamma,
-        /// Delta hardfork: activate Governance contract by setting Ownable._owner
-        Delta,
     }
 );
 
@@ -62,6 +63,20 @@ pub fn is_gravity_system_caller(addr: Address) -> bool {
 #[inline]
 pub fn is_system_tx_gas_exempt<S: EthChainSpec>(chain_spec: &S, block_ts: u64) -> bool {
     chain_spec.gravity_hardforks().is_fork_active_at_timestamp(GravityHardfork::Alpha, block_ts)
+}
+
+/// EIP-7702 emergency lockdown (audit#838). Active until Beta.
+///
+/// Returns `true` when the pre-execution filter must still reject all type-4
+/// (`SetCode`) txs and txs from/to currently-delegated accounts. Once
+/// [`GravityHardfork::Beta`] is active at `block_ts` (genesis `betaTime`), the
+/// lockdown is off and 7702 traffic is admitted under the normal Prague rules.
+///
+/// Fail-closed: if `betaTime` is missing or misspelled in genesis, Beta is never
+/// scheduled and this returns `true` forever.
+#[inline]
+pub fn is_eip7702_lockdown_active<S: EthChainSpec>(chain_spec: &S, block_ts: u64) -> bool {
+    !chain_spec.gravity_hardforks().is_fork_active_at_timestamp(GravityHardfork::Beta, block_ts)
 }
 
 /// Verifies the protocol invariant that every [`SYSTEM_CALLER`]-signed

--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -7,7 +7,11 @@ use reth_ethereum_forks::hardfork;
 hardfork!(
     /// Gravity hardforks.
     GravityHardfork {
-        /// Alpha hardfork: upgrade Staking/StakePool contracts and disable PoW rewards
+        /// Alpha hardfork: system-tx gas exemption, randomness precompile, and
+        /// one-shot [`SYSTEM_CALLER`] balance migration to zero.
+        ///
+        /// Activation is via genesis `alphaTime` (timestamp). See
+        /// [`is_system_tx_gas_exempt`].
         Alpha,
         /// Beta hardfork: EIP-7702 lockdown release gate (audit#838).
         ///

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -30,8 +30,8 @@ pub use reth_ethereum_forks::*;
 pub use alloy_evm::EvmLimitParams;
 pub use api::EthChainSpec;
 pub use gravity::{
-    is_gravity_system_caller, is_system_tx_gas_exempt, system_txs_form_head_prefix,
-    GravityHardfork, GRAVITY_TX_SKIPPED_LOG_ADDRESS, SYSTEM_CALLER,
+    is_eip7702_lockdown_active, is_gravity_system_caller, is_system_tx_gas_exempt,
+    system_txs_form_head_prefix, GravityHardfork, GRAVITY_TX_SKIPPED_LOG_ADDRESS, SYSTEM_CALLER,
 };
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -469,11 +469,11 @@ pub struct ChainSpec<H: BlockHeader = Header> {
     /// Block number at which [`Self::gravity_min_base_fee`] activates on this branch.
     /// On main this is hardcoded to `0` in `From<Genesis>` (floor enforced from
     /// genesis). Released testnet branches read it from genesis JSON
-    /// `config.extra_fields` (the same mechanism used by Alpha/Beta/Gamma/Delta), so
-    /// the rolling-upgrade activation height can be set per-network without code
-    /// changes. Historical-segment values from prior schedule steps still live in
-    /// branch-specific code, ensuring nodes restarted across multiple hardforks
-    /// validate older blocks correctly from the binary's full schedule.
+    /// `config.extra_fields` (the same mechanism used by Alpha/Beta timestamp
+    /// hardforks), so the rolling-upgrade activation height can be set per-network
+    /// without code changes. Historical-segment values from prior schedule steps
+    /// still live in branch-specific code, ensuring nodes restarted across multiple
+    /// hardforks validate older blocks correctly from the binary's full schedule.
     pub gravity_min_base_fee_activation_block: u64,
 }
 
@@ -977,7 +977,9 @@ impl From<Genesis> for ChainSpec {
 
         let hardforks = ChainHardforks::new(ordered_hardforks);
 
-        // Gravity-specific hardforks from genesis extra_fields
+        // Gravity-specific hardforks from genesis extra_fields (timestamp-gated only).
+        // Fail-closed: missing / misspelled keys (e.g. legacy `betaBlock`) mean the
+        // fork is never scheduled — Alpha gas-exempt stays off, Beta lockdown stays on.
         let mut gravity_hardforks = Vec::new();
         if let Some(alpha_time) =
             genesis.config.extra_fields.get("alphaTime").and_then(|v| v.as_u64())
@@ -985,26 +987,12 @@ impl From<Genesis> for ChainSpec {
             gravity_hardforks
                 .push((GravityHardfork::Alpha.boxed(), ForkCondition::Timestamp(alpha_time)));
         }
-
-        let gravity_hardfork_opts = [
-            (
-                GravityHardfork::Beta.boxed(),
-                genesis.config.extra_fields.get("betaBlock").and_then(|v| v.as_u64()),
-            ),
-            (
-                GravityHardfork::Gamma.boxed(),
-                genesis.config.extra_fields.get("gammaBlock").and_then(|v| v.as_u64()),
-            ),
-            (
-                GravityHardfork::Delta.boxed(),
-                genesis.config.extra_fields.get("deltaBlock").and_then(|v| v.as_u64()),
-            ),
-        ];
-        gravity_hardforks.extend(
-            gravity_hardfork_opts
-                .into_iter()
-                .filter_map(|(fork, opt)| opt.map(|block| (fork, ForkCondition::Block(block)))),
-        );
+        if let Some(beta_time) =
+            genesis.config.extra_fields.get("betaTime").and_then(|v| v.as_u64())
+        {
+            gravity_hardforks
+                .push((GravityHardfork::Beta.boxed(), ForkCondition::Timestamp(beta_time)));
+        }
         let gravity_hardforks = ChainHardforks::new(gravity_hardforks);
 
         // Gravity protocol minimum base fee floor (wei). Presence marks the chainspec
@@ -1013,9 +1001,9 @@ impl From<Genesis> for ChainSpec {
         let gravity_min_base_fee =
             genesis.config.extra_fields.get("gravityMinBaseFee").and_then(|v| v.as_u64());
         // main: floor activates at genesis (block 0). Released testnet branches override
-        // this to read the rolling-upgrade activation height from genesis (e.g.
-        // `epsilonBlock`), keeping the value configurable per-network without code
-        // changes — same mechanism as Alpha/Beta/Gamma/Delta above.
+        // this to read the rolling-upgrade activation height from genesis, keeping the
+        // value configurable per-network without code changes — same mechanism as
+        // Alpha/Beta timestamp hardforks above.
         let gravity_min_base_fee_activation_block = 0u64;
 
         Self {

--- a/crates/ethereum/evm/src/hardfork/common.rs
+++ b/crates/ethereum/evm/src/hardfork/common.rs
@@ -1,10 +1,9 @@
 //! Common types and traits for Gravity hardfork state changes.
 //!
-//! Each hardfork module (alpha, beta, gamma, ...) defines a set of
-//! system contract bytecode upgrades. This module provides a trait
-//! that standardizes how upgrade tables are exposed, enabling generic
-//! verification logic in tests and a single `apply_hardfork_upgrades`
-//! entry point for the executor.
+//! Each hardfork module defines a set of system contract bytecode
+//! upgrades. This module provides a trait that standardizes how upgrade
+//! tables are exposed, enabling generic verification logic in tests and
+//! a single `apply_hardfork_upgrades` entry point for the executor.
 
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use reth_evm::{execute::BlockExecutionError, ParallelDatabase};
@@ -21,7 +20,7 @@ pub type BytecodeUpgrade = (Address, &'static [u8]);
 pub type StoragePatch = (Address, B256, U256);
 
 /// A batch storage patch: same (slot, value) applied to multiple addresses.
-/// Used for Gamma's `ReentrancyGuard` initialization across all `StakePool` instances.
+/// Used for multi-address storage initialization across StakePool instances.
 pub type BatchStoragePatch = (&'static [Address], B256, U256);
 
 /// Trait implemented by each hardfork module to describe its upgrades.
@@ -31,7 +30,7 @@ pub type BatchStoragePatch = (&'static [Address], B256, U256);
 /// fn verify_hardfork_applied<H: HardforkUpgrades>(provider: &P, block: u64) { ... }
 /// ```
 pub trait HardforkUpgrades {
-    /// The human-readable name of this hardfork (e.g. "Gamma").
+    /// The human-readable name of this hardfork (e.g. "Alpha").
     fn name(&self) -> &'static str;
 
     /// System contract bytecode upgrades: `(address, new_bytecode)` pairs.
@@ -50,7 +49,7 @@ pub trait HardforkUpgrades {
     }
 
     /// Batch storage patches: apply the same (slot, value) to multiple addresses.
-    /// Used for Gamma's `ReentrancyGuard` initialization across all `StakePool` instances.
+    /// Used for multi-address storage initialization across StakePool instances.
     fn batch_storage_patches(&self) -> &'static [BatchStoragePatch] {
         &[]
     }

--- a/crates/ethereum/evm/src/hardfork/common.rs
+++ b/crates/ethereum/evm/src/hardfork/common.rs
@@ -20,7 +20,7 @@ pub type BytecodeUpgrade = (Address, &'static [u8]);
 pub type StoragePatch = (Address, B256, U256);
 
 /// A batch storage patch: same (slot, value) applied to multiple addresses.
-/// Used for multi-address storage initialization across StakePool instances.
+/// Used for multi-address storage initialization across `StakePool` instances.
 pub type BatchStoragePatch = (&'static [Address], B256, U256);
 
 /// Trait implemented by each hardfork module to describe its upgrades.
@@ -49,7 +49,7 @@ pub trait HardforkUpgrades {
     }
 
     /// Batch storage patches: apply the same (slot, value) to multiple addresses.
-    /// Used for multi-address storage initialization across StakePool instances.
+    /// Used for multi-address storage initialization across `StakePool` instances.
     fn batch_storage_patches(&self) -> &'static [BatchStoragePatch] {
         &[]
     }

--- a/crates/pipe-exec-layer-ext-v2/execute/gravity_hardfork.json
+++ b/crates/pipe-exec-layer-ext-v2/execute/gravity_hardfork.json
@@ -30,10 +30,8 @@
     "terminalTotalDifficultyPassed": true,
     "extraFields": {},
     "depositContractAddress": null,
-    "gammaBlock": 20,
     "alphaTime": 5,
-    "betaBlock": 10,
-    "deltaBlock": 25
+    "betaTime": 9999999999
   },
   "alloc": {
     "0x00000000000000000000000000000001625f3000": {

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -61,7 +61,7 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, U256,
 };
-use reth_chainspec::{ChainSpec, EthChainSpec};
+use reth_chainspec::{is_eip7702_lockdown_active, ChainSpec, EthChainSpec};
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::ParallelDatabase;
 use reth_evm_ethereum::revm_spec_by_timestamp_and_block_number;
@@ -81,6 +81,11 @@ use tracing::info;
 /// `revm_spec_by_timestamp_and_block_number` helper is used so the same
 /// (correct) mapping that the executor sees is the one the filter is gating
 /// against — no risk of the two drifting apart on a future hardfork.
+///
+/// EIP-7702 emergency lockdown (audit#838) is computed inside this function from
+/// [`is_eip7702_lockdown_active`] (active until [`reth_chainspec::GravityHardfork::Beta`])
+/// — not a bool parameter — so every call site agrees without a consensus-critical
+/// flag that could drift.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     db: DB,
@@ -92,6 +97,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     block_timestamp: u64,
     block_number: u64,
 ) -> HashSet<usize> {
+    let eip7702_lockdown = is_eip7702_lockdown_active(chain_spec, block_timestamp);
     let spec_id =
         revm_spec_by_timestamp_and_block_number(chain_spec, block_timestamp, block_number);
     let mut gas_limit_exceeded_tx_idx = txs.len();
@@ -199,12 +205,26 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             );
             return false;
         }
-        // EIP-7702 gates. Pre-Prague: reject the whole tx type (revm fires
-        // `Eip7702NotSupported`; `calculate_initial_tx_gas` below also ignores auth-list
-        // cost pre-Prague, so a 21k-gas TxEip7702 would slip the intrinsic check).
-        // Post-Prague: reject empty authorization_list (revm fires
-        // `EmptyAuthorizationList`). Closes audit#696 P-2 and audit#710 gap 3.
+        // EIP-7702 gates.
+        //
+        // Base (always): reject a pre-Prague type-4 tx (revm `Eip7702NotSupported`) and a
+        // post-Prague type-4 tx with an empty `authorization_list` (`EmptyAuthorizationList`);
+        // both would otherwise reach the executor as InvalidTransaction. Closes audit#696 P-2
+        // and audit#710 gap 3.
+        //
+        // EMERGENCY LOCKDOWN — L1 (audit#838 + #822, gated on `eip7702_lockdown` / pre-Beta):
+        // when enabled, reject the ENTIRE type-4 tx type wholesale (a strict superset of the
+        // base gate) so no NEW delegations can be created. Together with the from-/to-delegated
+        // drops (L2/L3) below this closes the 7702 nonce-bump halt surface.
         if tx.is_eip7702() {
+            if eip7702_lockdown {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    sender=?sender,
+                    "7702-lockdown: EIP-7702 (SetCode) tx rejected wholesale (audit#838)"
+                );
+                return false;
+            }
             if !spec_id.is_enabled_in(SpecId::PRAGUE) {
                 info!(target: "filter_invalid_txs",
                     tx_hash=?tx.hash(),
@@ -324,6 +344,25 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                 .unwrap_or(false)
     };
 
+    // EMERGENCY EIP-7702 LOCKDOWN — L2/L3 helper. `true` if the account CURRENTLY
+    // carries a 7702 delegation designator (`0xef 0x01 0x00 || address`), read from
+    // block-start state. Used to drop any tx originated BY (L2) or sent TO (L3) a
+    // delegated account. Differs from `code_permits`: an empty-code EOA is NOT delegated.
+    // Fail-closed: DB errors on code load panic (same spirit as sender `basic_ref`), so a
+    // transient DB fault cannot silently classify a delegated account as non-delegated.
+    let is_delegated = |acct: &AccountInfo| -> bool {
+        if acct.code_hash == KECCAK_EMPTY {
+            return false;
+        }
+        let code = match &acct.code {
+            Some(c) => c.clone(),
+            None => db
+                .code_by_hash_ref(acct.code_hash)
+                .expect("7702-lockdown: db.code_by_hash_ref for delegated check"),
+        };
+        code.is_eip7702()
+    };
+
     // Block-order sequential simulation. `sim[addr]` is the address's account evolved
     // in-block (nonce + balance), seeded lazily from the certified parent state; `None`
     // marks an address absent from state. It holds BOTH tx senders AND EIP-7702
@@ -342,6 +381,29 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         let tx = &txs[idx];
         let sender = senders[idx];
 
+        // EMERGENCY EIP-7702 LOCKDOWN — L3 (pre-Beta): drop any tx whose recipient is a
+        // currently-delegated account, so no inbound CALL can trigger the callee's
+        // delegated CREATE (audit#838). Read against block-start state (L1 rejects all
+        // type-4, so no delegation is created in-block). `to()` is `None` for Create.
+        // Fail-closed on DB error (same spirit as the sender `basic_ref` path below).
+        if eip7702_lockdown && let Some(to) = tx.to() {
+            let to_delegated = db
+                .basic_ref(to)
+                .expect("7702-lockdown L3: db.basic_ref for recipient")
+                .as_ref()
+                .map(is_delegated)
+                .unwrap_or(false);
+            if to_delegated {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    to=?to,
+                    "7702-lockdown: tx to delegated account rejected (audit#838)"
+                );
+                invalid_tx_idxs.insert(idx);
+                continue;
+            }
+        }
+
         // Validate the tx against the simulated sender account and apply the caller nonce
         // bump + balance deduction. Scoped so the `sim[sender]` borrow is released before
         // the authorization loop re-borrows `sim` (an authority may be any account).
@@ -351,7 +413,18 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                 // Sender absent from state -> cannot pay for / originate the tx.
                 None => false,
                 Some(account) => {
-                    if !code_permits(account) {
+                    if eip7702_lockdown && is_delegated(account) {
+                        // EMERGENCY EIP-7702 LOCKDOWN — L2 (pre-Beta): the delegated
+                        // sender's own execution-time CREATE can bump its nonce (not
+                        // modelled by this filter's auth-list simulation), making this
+                        // current-nonce tx `NonceTooLow` -> executor halt (audit#838).
+                        info!(target: "filter_invalid_txs",
+                            tx_hash=?tx.hash(),
+                            sender=?sender,
+                            "7702-lockdown: tx from delegated account rejected (audit#838)"
+                        );
+                        false
+                    } else if !code_permits(account) {
                         info!(target: "filter_invalid_txs",
                             sender=?sender,
                             code_hash=?account.code_hash,
@@ -416,7 +489,9 @@ mod tests {
     use alloy_consensus::{TxEip4844, TxEip7702, TxLegacy};
     use alloy_eips::eip7702::{Authorization, SignedAuthorization};
     use alloy_primitives::{Address, Bytes, Signature, TxKind, B256};
-    use reth_chainspec::{ChainSpec, ChainSpecBuilder, MAINNET};
+    use reth_chainspec::{
+        ChainHardforks, ChainSpec, ChainSpecBuilder, ForkCondition, GravityHardfork, MAINNET,
+    };
     use reth_ethereum_primitives::{Transaction, TransactionSigned};
     use reth_revm::state::{AccountInfo, Bytecode};
     use revm::{
@@ -430,10 +505,25 @@ mod tests {
     /// `chain_id` doesn't match the chainspec.
     const MAINNET_CHAIN_ID: u64 = 1;
 
-    /// Chainspec with Prague active from genesis — the canonical test fixture for
-    /// every case that wants the filter to apply 7702 intrinsic-gas rules.
+    /// Chainspec with Prague active from genesis but **no** Gravity Beta — the default
+    /// fixture. EIP-7702 lockdown is ON (fail-closed: missing `betaTime` keeps lockdown
+    /// active). Use [`prague_chain_spec_with_beta`] for cases that need type-4 to pass.
     fn prague_chain_spec() -> Arc<ChainSpec> {
         Arc::new(ChainSpecBuilder::from(&*MAINNET).prague_activated().build())
+    }
+
+    /// Prague + Gravity Beta active from timestamp 0 — lockdown OFF. Required by every
+    /// test that expects a type-4 tx (or a tx from a delegated account) to be admitted.
+    fn prague_chain_spec_with_beta() -> Arc<ChainSpec> {
+        prague_chain_spec_with_beta_at(0)
+    }
+
+    /// Prague + Gravity Beta activating at the given timestamp (fork-boundary tests).
+    fn prague_chain_spec_with_beta_at(beta_time: u64) -> Arc<ChainSpec> {
+        let mut spec = ChainSpecBuilder::from(&*MAINNET).prague_activated().build();
+        spec.gravity_hardforks =
+            ChainHardforks::from([(GravityHardfork::Beta, ForkCondition::Timestamp(beta_time))]);
+        Arc::new(spec)
     }
 
     /// Chainspec with Shanghai active from genesis but Prague unset — the
@@ -504,6 +594,37 @@ mod tests {
             }),
             Signature::test_signature(),
         )
+    }
+
+    /// Legacy tx with a caller-chosen recipient — for the 7702-lockdown L3
+    /// (tx-to-delegated) tests.
+    fn create_test_transaction_to(
+        nonce: u64,
+        gas_limit: u64,
+        gas_price: u128,
+        to: Address,
+    ) -> TransactionSigned {
+        TransactionSigned::new_unhashed(
+            Transaction::Legacy(TxLegacy {
+                nonce,
+                gas_price,
+                gas_limit,
+                to: TxKind::Call(to),
+                ..Default::default()
+            }),
+            Signature::test_signature(),
+        )
+    }
+
+    /// A block-start-state account carrying a 7702 delegation designator to `target`.
+    fn delegated_account(target: Address) -> AccountInfo {
+        AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000u64),
+            nonce: 0,
+            code_hash: B256::repeat_byte(0xcd),
+            code: Some(Bytecode::new_eip7702(target)),
+            account_id: None,
+        }
     }
 
     fn create_test_transaction_with_value(
@@ -900,7 +1021,9 @@ mod tests {
         assert!(invalid_idxs.contains(&0));
     }
 
-    /// Sanity check: same 7702 tx with a `gas_limit` at or above the floor passes the filter.
+    /// Sanity check (lockdown OFF / Beta active): same 7702 tx with a `gas_limit` at or
+    /// above the floor passes the filter. Uses `prague_chain_spec_with_beta` so L1 does
+    /// not wholesale-reject type-4.
     #[test]
     fn test_filter_invalid_txs_eip7702_intrinsic_gas_just_enough_under_prague() {
         let mut db = MockDatabase::new();
@@ -916,7 +1039,7 @@ mod tests {
             },
         );
 
-        // exactly 21000 + 25000 = 46000 — at the floor, should pass
+        // exactly 21000 + 25000 = 46000 — at the floor, should pass post-Beta
         let tx = create_test_7702_transaction(0, 46_000, 1);
         let txs = vec![tx];
         let senders = vec![sender];
@@ -929,15 +1052,15 @@ mod tests {
             &senders,
             base_fee_per_gas,
             gas_limit,
-            &prague_chain_spec(),
+            &prague_chain_spec_with_beta(),
             0,
             0,
         );
         assert!(invalid_idxs.is_empty(), "got: {invalid_idxs:?}");
     }
 
-    /// U-1 (acceptance design §3.1): a 7702 tx with `authorization_list.len() == 2` and
-    /// `gas_limit = 21000 + 25000 * 2 + 1000 = 72000` passes the filter under Prague.
+    /// U-1 (acceptance design §3.1, lockdown OFF / Beta active): a 7702 tx with
+    /// `authorization_list.len() == 2` and `gas_limit = 72000` passes under Prague+Beta.
     #[test]
     fn test_filter_invalid_txs_eip7702_two_auths_gas_sufficient() {
         let mut db = MockDatabase::new();
@@ -957,11 +1080,19 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
-            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            0,
+            30_000_000,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
         assert!(
             invalid_idxs.is_empty(),
-            "two-auth 7702 tx with 72k gas must pass: {invalid_idxs:?}"
+            "two-auth 7702 tx with 72k gas must pass post-Beta: {invalid_idxs:?}"
         );
     }
 
@@ -1564,24 +1695,141 @@ mod tests {
         assert!(invalid_idxs.contains(&1));
     }
 
-    /// EIP-3607 delegation exception: sender whose code is an EIP-7702 delegation
-    /// designator (`0xef 0x01 0x00 + address`) is allowed to send txs — Pectra
-    /// relaxed 3607 precisely to permit delegated EOAs.
+    /// EIP-3607 delegation exception (lockdown OFF / Beta active): sender whose code
+    /// is an EIP-7702 delegation designator (`0xef 0x01 0x00 + address`) is allowed
+    /// to send txs — Pectra relaxed 3607 precisely to permit delegated EOAs.
     #[test]
     fn test_filter_invalid_txs_sender_with_7702_delegation_accepted() {
         let mut db = MockDatabase::new();
         let sender = Address::random();
         let target = Address::repeat_byte(0x42);
+        db.insert_account(sender, delegated_account(target));
+
+        let tx = create_test_transaction(0, 21_000, 25_000_000_000);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            0,
+            30_000_000,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert!(
+            invalid_idxs.is_empty(),
+            "tx from EIP-7702-delegated sender must pass post-Beta: {invalid_idxs:?}"
+        );
+    }
+
+    // ===== EIP-7702 lockdown (audit#838) — gated on Gravity Beta ===============
+
+    /// L1: type-4 (SetCode) is rejected wholesale while lockdown is active
+    /// (Prague without Beta). Intrinsic gas is sufficient so only L1 fires.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_rejected_under_lockdown_pre_beta() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
         db.insert_account(
             sender,
             AccountInfo {
                 balance: U256::from(1_000_000_000_000_000_000u64),
                 nonce: 0,
-                code_hash: B256::repeat_byte(0xcd),
-                code: Some(Bytecode::new_eip7702(target)),
+                code_hash: KECCAK_EMPTY,
+                code: None,
                 account_id: None,
             },
         );
+
+        let tx = create_test_7702_transaction(0, 46_000, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        // Default prague_chain_spec has no betaTime → lockdown ON.
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(
+            invalid_idxs.len(),
+            1,
+            "L1 must wholesale-reject type-4 pre-Beta: {invalid_idxs:?}"
+        );
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// L1 post-Beta: same type-4 with sufficient gas is admitted once Beta is active.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_accepted_post_beta() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        let tx = create_test_7702_transaction(0, 46_000, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            0,
+            30_000_000,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert!(invalid_idxs.is_empty(), "type-4 at floor must pass post-Beta: {invalid_idxs:?}");
+    }
+
+    /// Fork boundary: betaTime = T; block_timestamp T-1 rejects type-4, T accepts.
+    #[test]
+    fn test_filter_invalid_txs_eip7702_lockdown_fork_boundary() {
+        const BETA_TIME: u64 = 1_700_000_000;
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        let tx = create_test_7702_transaction(0, 46_000, 1);
+        let txs = vec![tx];
+        let senders = vec![sender];
+        let chain_spec = prague_chain_spec_with_beta_at(BETA_TIME);
+
+        let pre =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &chain_spec, BETA_TIME - 1, 0);
+        assert_eq!(pre.len(), 1, "T-1 must still be under lockdown: {pre:?}");
+        assert!(pre.contains(&0));
+
+        let at = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &chain_spec, BETA_TIME, 0);
+        assert!(at.is_empty(), "T must release lockdown: {at:?}");
+    }
+
+    /// L2: under lockdown a tx FROM a delegated account is dropped.
+    #[test]
+    fn test_filter_invalid_txs_sender_with_7702_delegation_rejected_under_lockdown() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        let target = Address::repeat_byte(0x42);
+        db.insert_account(sender, delegated_account(target));
 
         let tx = create_test_transaction(0, 21_000, 25_000_000_000);
         let txs = vec![tx];
@@ -1589,9 +1837,117 @@ mod tests {
 
         let invalid_idxs =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(
+            invalid_idxs.len(),
+            1,
+            "7702-lockdown L2 must drop a tx from a delegated sender: {invalid_idxs:?}"
+        );
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// L3: under lockdown a tx TO a delegated account is dropped.
+    #[test]
+    fn test_filter_invalid_txs_recipient_delegated_rejected_under_lockdown() {
+        let mut db = MockDatabase::new();
+        let caller = Address::random();
+        let delegated = Address::repeat_byte(0xa1);
+        db.insert_account(
+            caller,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+        db.insert_account(delegated, delegated_account(Address::repeat_byte(0x42)));
+
+        let tx = create_test_transaction_to(0, 21_000, 25_000_000_000, delegated);
+        let txs = vec![tx];
+        let senders = vec![caller];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(
+            invalid_idxs.len(),
+            1,
+            "7702-lockdown L3 must drop a tx to a delegated recipient: {invalid_idxs:?}"
+        );
+        assert!(invalid_idxs.contains(&0));
+    }
+
+    /// audit#838 attack shape: [funder→A, A@nonce] — both dropped under lockdown
+    /// (L3 then L2).
+    #[test]
+    fn test_filter_invalid_txs_audit838_attack_shape_neutralised() {
+        let mut db = MockDatabase::new();
+        let funder = Address::random();
+        let a = Address::repeat_byte(0xaa);
+        db.insert_account(
+            funder,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+        db.insert_account(a, delegated_account(Address::repeat_byte(0xcc)));
+
+        let x = create_test_transaction_to(0, 21_000, 25_000_000_000, a);
+        let a_at_m = create_test_transaction(0, 21_000, 25_000_000_000);
+        let txs = vec![x, a_at_m];
+        let senders = vec![funder, a];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
+        assert_eq!(
+            invalid_idxs.len(),
+            2,
+            "both legs of the audit#838 attack shape must be dropped: {invalid_idxs:?}"
+        );
+        assert!(invalid_idxs.contains(&0) && invalid_idxs.contains(&1));
+    }
+
+    /// Lockdown precision: non-delegated traffic (ordinary contract recipient) is
+    /// unaffected while lockdown is on.
+    #[test]
+    fn test_filter_invalid_txs_non_delegated_traffic_unaffected_by_lockdown() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        let contract = Address::repeat_byte(0xbe);
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+        db.insert_account(
+            contract,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 1,
+                code_hash: B256::repeat_byte(0x11),
+                code: Some(Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00, 0x60, 0x00]))),
+                account_id: None,
+            },
+        );
+
+        let tx = create_test_transaction_to(0, 21_000, 25_000_000_000, contract);
+        let txs = vec![tx];
+        let senders = vec![sender];
+
+        let invalid_idxs =
+            filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
             invalid_idxs.is_empty(),
-            "tx from EIP-7702-delegated sender must pass: {invalid_idxs:?}"
+            "non-delegated traffic must be unaffected by the 7702 lockdown: {invalid_idxs:?}"
         );
     }
 

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_bls_precompile_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_bls_precompile_test.rs
@@ -83,6 +83,10 @@ const BLS_INPUT_LEN: usize = 144;
 /// POP_VERIFY_GAS=110_000 → triggers the pre-fix panic.
 const POISON_GAS_LIMIT: u64 = 100_000;
 
+/// Build a Gravity chainspec JSON by loading `gravity_hardfork.json` and
+/// patching `pragueTime`. Always sets `betaTime = 0` so Gravity's EIP-7702
+/// lockdown (active until Beta) is off — this test needs a type-4 poison tx
+/// to reach the BLS precompile OOG path without being filter-dropped.
 fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
     let mut json: serde_json::Value =
         serde_json::from_str(include_str!("../gravity_hardfork.json"))
@@ -90,6 +94,9 @@ fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
     if let Some(ts) = prague_time {
         json["config"]["pragueTime"] = serde_json::json!(ts);
     }
+    // Default gravity_hardfork.json uses a far-future betaTime (lockdown ON).
+    // Mirror gravity_eip7702_test: Beta at genesis so type-4 txs can execute.
+    json["config"]["betaTime"] = serde_json::json!(0);
     json.to_string()
 }
 

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip2935_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip2935_test.rs
@@ -871,7 +871,7 @@ async fn run_pipe_p6_transient_parent_hash(
 
     // (c) The real hash must differ from the transient mock_block_id(99) —
     //     otherwise the test below would not actually prove anything. Block 99
-    //     contains gravity hardfork bytecode (gammaBlock=20, deltaBlock=25) so
+    //     contains gravity hardfork genesis config (betaTime timestamp gate) so
     //     its real keccak hash cannot collide with a left-padded block number.
     let transient_99 = mock_block_id(P3_ACTIVATION_BLOCK - 1);
     assert_ne!(

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_eip7702_test.rs
@@ -96,6 +96,10 @@ const PRAGUE_TS_BLOCK_100: u64 = P3_TS_BASE + P3_ACTIVATION_BLOCK;
 /// - `Some(ts)` ⇒ Prague fires at `ts` (`ForkCondition::Timestamp(ts)`).
 /// - `None` ⇒ field omitted ⇒ Prague never fires (`ForkCondition::Never`).
 ///
+/// Always sets `betaTime = 0` so Gravity's EIP-7702 lockdown (active until
+/// Beta) is released from genesis. Without that, L1 wholesale-rejects every
+/// type-4 tx and the P-12/P-13 paths would silently test the wrong gate.
+///
 /// `chain_value_parser` (`crates/ethereum/cli/src/chainspec.rs`) accepts
 /// in-memory JSON for `--chain`, so no tempfile / no IO overhead.
 fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
@@ -105,6 +109,8 @@ fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
     if let Some(ts) = prague_time {
         json["config"]["pragueTime"] = serde_json::json!(ts);
     }
+    // Release EIP-7702 lockdown so these tests exercise Prague 7702 behavior.
+    json["config"]["betaTime"] = serde_json::json!(0);
     json.to_string()
 }
 

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_hardfork_test.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_hardfork_test.rs
@@ -1,12 +1,11 @@
 #![allow(missing_docs)]
 
-//! Integration test for Gravity hardfork framework activation.
+//! Integration smoke for Gravity hardfork genesis parsing + pipe boot.
 //!
-//! This test boots a single reth node using a genesis generated from
-//! `gravity-testnet-v1.0.0` contracts (via `generate_genesis_single.sh`).
-//! It pushes blocks through the MockConsensus/PipeExecLayerApi pipeline
-//! and verifies that the hardfork dispatch infrastructure correctly parses
-//! and activates hardforks at the configured block numbers.
+//! Boots a single reth node from `gravity_hardfork.json`, verifies that
+//! `betaTime` is parsed as a timestamp fork condition (the EIP-7702 lockdown
+//! release gate), and pushes empty blocks through the MockConsensus /
+//! PipeExecLayerApi pipeline.
 
 use alloy_primitives::{address, Address, B256, U256};
 use alloy_rpc_types_eth::TransactionRequest;
@@ -40,11 +39,12 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-/// Block number at which Gamma hardfork activates (must match gravity_hardfork.json).
-const GAMMA_BLOCK: u64 = 20;
+/// `betaTime` in `gravity_hardfork.json` — far-future so lockdown stays on during the
+/// empty-block push; this test only verifies parse, not the Beta transition itself.
+const BETA_TIME: u64 = 9_999_999_999;
 
-/// Block number at which Delta hardfork activates (must match gravity_hardfork.json).
-const DELTA_BLOCK: u64 = 25;
+/// How many blocks past genesis to push (smoke that the pipe still works).
+const TARGET_BLOCKS_PAST_GENESIS: u64 = 30;
 
 fn mock_block_id(block_number: u64) -> B256 {
     B256::left_padding_from(&block_number.to_be_bytes())
@@ -97,13 +97,13 @@ where
             .try_into()
             .unwrap();
         println!(
-            "[hardfork_test] latest_block_number={latest_block_number}, epoch={epoch}, gammaBlock={GAMMA_BLOCK}"
+            "[hardfork_test] latest_block_number={latest_block_number}, epoch={epoch}, betaTime={BETA_TIME}"
         );
 
         tokio::time::sleep(Duration::from_secs(3)).await;
 
-        // Push blocks past the hardfork boundary
-        let target_block = GAMMA_BLOCK + 30;
+        // Push a short empty-block run to exercise the pipe under the current hardfork schedule.
+        let target_block = latest_block_number + TARGET_BLOCKS_PAST_GENESIS;
         for block_number in latest_block_number + 1..=target_block {
             let block_id = mock_block_id(block_number);
             let parent_block_id = mock_block_id(block_number - 1);
@@ -153,7 +153,7 @@ where
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
-        println!("[hardfork_test] ✅ Pushed {target_block} blocks past gammaBlock.");
+        println!("[hardfork_test] ✅ Pushed through block {target_block}.");
     }
 }
 
@@ -176,40 +176,25 @@ async fn run_pipe(
 
     let chain_spec = handle.node.chain_spec();
 
-    // Verify gammaBlock is parsed correctly
+    // Verify betaTime is parsed as a timestamp fork condition (lockdown release gate).
     assert!(
         chain_spec
             .gravity_hardforks()
-            .fork(GravityHardfork::Gamma)
-            .transitions_at_block(GAMMA_BLOCK),
-        "gamma transitions_at_block({GAMMA_BLOCK}) should be true"
+            .is_fork_active_at_timestamp(GravityHardfork::Beta, BETA_TIME),
+        "Beta must be active at betaTime={BETA_TIME}"
     );
     assert!(
         !chain_spec
             .gravity_hardforks()
-            .fork(GravityHardfork::Gamma)
-            .transitions_at_block(GAMMA_BLOCK - 1),
-        "gamma transitions_at_block({}) should be false",
-        GAMMA_BLOCK - 1
+            .is_fork_active_at_timestamp(GravityHardfork::Beta, BETA_TIME - 1),
+        "Beta must be inactive at betaTime-1"
     );
-    println!("[hardfork_test] ✅ ChainSpec correctly parsed gammaBlock={GAMMA_BLOCK}");
-
+    // Fail-closed check: with far-future betaTime, lockdown is still active at "now".
     assert!(
-        chain_spec
-            .gravity_hardforks()
-            .fork(GravityHardfork::Delta)
-            .transitions_at_block(DELTA_BLOCK),
-        "delta transitions_at_block({DELTA_BLOCK}) should be true"
+        reth_chainspec::is_eip7702_lockdown_active(chain_spec.as_ref(), 0),
+        "lockdown must stay on before betaTime"
     );
-    assert!(
-        !chain_spec
-            .gravity_hardforks()
-            .fork(GravityHardfork::Delta)
-            .transitions_at_block(DELTA_BLOCK - 1),
-        "delta transitions_at_block({}) should be false",
-        DELTA_BLOCK - 1
-    );
-    println!("[hardfork_test] ✅ ChainSpec correctly parsed deltaBlock={DELTA_BLOCK}");
+    println!("[hardfork_test] ✅ ChainSpec correctly parsed betaTime={BETA_TIME}");
 
     let eth_api = handle.node.rpc_registry.eth_api().clone();
     let provider = handle.node.provider;
@@ -245,7 +230,7 @@ async fn run_pipe(
 }
 
 #[test]
-fn test_gamma_hardfork() {
+fn test_beta_hardfork_parse_smoke() {
     std::panic::set_hook(Box::new({
         |panic_info| {
             let backtrace = std::backtrace::Backtrace::capture();

--- a/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_pipe_panic_smoke.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/tests/gravity_pipe_panic_smoke.rs
@@ -81,6 +81,8 @@ const FUNDED_PRIVKEY_HEX: &[u8; 32] = &[
 ];
 const TARGET_ADDR: Address = address!("0x0000000000000000000000000000000000001234");
 
+/// Patch `pragueTime` on the embedded chainspec. Always sets `betaTime = 0`
+/// so EIP-7702 lockdown is released (this smoke test includes type-4 txs).
 fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
     let mut json: serde_json::Value =
         serde_json::from_str(include_str!("../gravity_hardfork.json"))
@@ -88,6 +90,7 @@ fn gravity_prague_chainspec(prague_time: Option<u64>) -> String {
     if let Some(ts) = prague_time {
         json["config"]["pragueTime"] = serde_json::json!(ts);
     }
+    json["config"]["betaTime"] = serde_json::json!(0);
     json.to_string()
 }
 


### PR DESCRIPTION
## Summary

Restores mainnet's EIP-7702 emergency filter lockdown on `main`, but behind a hardfork gate so rolling upgrades are possible.

1. **Hardfork cleanup**: drop empty-shell `Gamma`/`Delta`; parse `betaTime` (timestamp) for `GravityHardfork::Beta`; add `is_eip7702_lockdown_active`.
2. **Filter lockdown**: port L1/L2/L3 drops into `filter_invalid_txs`, computing the gate **inside** the filter (no bool / compile-time const). Missing `betaTime` → lockdown stays on (fail-closed, matches current mainnet filter behavior).

Skip / `DelegatedSafetyConfig` are unchanged and not gated. History-path default executor is intentionally left as-is.

## Deploy note

- Ship binary **without** `betaTime` first → lockdown on, no semantic change vs mainnet filter.
- After fleet is upgraded, set `betaTime` to unlock 7702.

## Test plan

- [x] `cargo test -p reth-chainspec --lib`
- [x] `cargo test -p reth-pipe-exec-layer-ext-v2 --lib filter_invalid_txs` (38 passed, includes pre-Beta L1/L2/L3, fork boundary, audit#838 shape)
- [x] `cargo check -p reth-evm-ethereum -p reth-pipe-exec-layer-ext-v2`
- [ ] CI