### PR TITLE
fix(pruner): keep history checkpoint from rewinding on static file walks

### DIFF
--- a/crates/prune/prune/src/segments/user/account_history.rs
+++ b/crates/prune/prune/src/segments/user/account_history.rs
@@ -112,11 +112,17 @@ impl AccountHistory {
 
         let walker = provider.static_file_provider().walk_account_changeset_range(range);
         for result in walker {
-            if limiter.is_limit_reached() {
+            let (block_number, changeset) = result?;
+            // The walk itself deletes nothing, so an interrupted block cannot be resumed: giving
+            // up the budget inside block N reports checkpoint N-1 and the next run rereads the
+            // same entries, forever. Stop on block boundaries only, overshooting the budget by at
+            // most the rest of one block.
+            if limiter.is_limit_reached() &&
+                last_changeset_pruned_block.is_some_and(|last| last != block_number)
+            {
                 done = false;
                 break
             }
-            let (block_number, changeset) = result?;
             highest_deleted_accounts.insert(changeset.address, block_number);
             last_changeset_pruned_block = Some(block_number);
             pruned_changesets += 1;
@@ -195,9 +201,19 @@ impl AccountHistory {
             )?;
         trace!(target: "pruner", pruned = %pruned_changesets, %done, "Pruned account history (changesets from database)");
 
+        // The table walk can stop in the middle of a block, so the interrupted block has to be
+        // pruned again on the next run.
+        let last_pruned_block = last_changeset_pruned_block.map(|block_number| {
+            if done {
+                block_number
+            } else {
+                block_number.saturating_sub(1)
+            }
+        });
+
         let result = HistoryPruneResult {
             highest_deleted: highest_deleted_accounts,
-            last_pruned_block: last_changeset_pruned_block,
+            last_pruned_block,
             pruned_count: pruned_changesets,
             done,
         };
@@ -487,5 +503,118 @@ mod tests {
                 .get_highest_static_file_block(StaticFileSegment::AccountChangeSets),
             Some(100)
         );
+    }
+
+    /// A block holding at least a whole run's budget of changesets must not stall the static-file
+    /// path: the walk deletes no changesets, so a checkpoint rewound below such a block would make
+    /// every later run reread it and never advance.
+    #[test]
+    fn dense_block_advances_static_file_checkpoint() {
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=20,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        let accounts = random_eoa_accounts(&mut rng, 2).into_iter().collect::<BTreeMap<_, _>>();
+        let (changesets, _) = random_changeset_range(
+            &mut rng,
+            blocks.iter(),
+            accounts.into_iter().map(|(addr, acc)| (addr, (acc, Vec::new()))),
+            0..0,
+            0..0,
+        );
+        // `random_changeset_range` emits exactly 2 account changesets per block (sender +
+        // recipient), so a budget of 2 makes every block "dense".
+        assert!(changesets.iter().all(|changeset| changeset.len() == 2));
+
+        db.insert_changesets_to_static_files(changesets.clone(), None)
+            .expect("insert changesets to static files");
+        db.insert_history(changesets, None).expect("insert history");
+        assert!(db.table::<tables::AccountChangeSets>().unwrap().is_empty());
+
+        let to_block: BlockNumber = 15;
+        let prune_mode = PruneMode::Before(to_block);
+        let segment = AccountHistory::new(prune_mode);
+
+        // Start from a checkpoint in the middle so a rewind can't be masked by block 0.
+        let mut checkpoint = PruneCheckpoint { block_number: Some(4), tx_number: None, prune_mode };
+
+        db.factory.set_storage_settings_cache(GravityStorageSettings {
+            changesets_in_static_files: true,
+        });
+
+        for _ in 0..3 {
+            let previous = checkpoint.block_number;
+            let input = PruneInput {
+                previous_checkpoint: Some(checkpoint),
+                to_block,
+                // Halved internally by ACCOUNT_HISTORY_TABLES_TO_PRUNE, so 4 == one dense block.
+                limiter: PruneLimiter::default()
+                    .set_deleted_entries_limit(2 * ACCOUNT_HISTORY_TABLES_TO_PRUNE),
+            };
+
+            let provider = db.factory.database_provider_rw().unwrap();
+            provider.set_storage_settings_cache(GravityStorageSettings {
+                changesets_in_static_files: true,
+            });
+            let result = segment.prune(&provider, input).unwrap();
+            segment
+                .save_checkpoint(
+                    &provider,
+                    result.checkpoint.unwrap().as_prune_checkpoint(prune_mode),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+
+            checkpoint = db
+                .factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::AccountHistory)
+                .unwrap()
+                .unwrap();
+
+            assert!(
+                !result.progress.is_finished(),
+                "the range is longer than one run's budget allows"
+            );
+            assert!(
+                checkpoint.block_number > previous,
+                "checkpoint must advance past the dense block, got {:?} after {previous:?}",
+                checkpoint.block_number
+            );
+        }
+        assert_eq!(checkpoint.block_number, Some(7), "one dense block cleared per run");
+
+        // With enough budget the remainder of the range completes in one run.
+        let input = PruneInput {
+            previous_checkpoint: Some(checkpoint),
+            to_block,
+            limiter: PruneLimiter::default().set_deleted_entries_limit(1000),
+        };
+        let provider = db.factory.database_provider_rw().unwrap();
+        provider.set_storage_settings_cache(GravityStorageSettings {
+            changesets_in_static_files: true,
+        });
+        let result = segment.prune(&provider, input).unwrap();
+        segment
+            .save_checkpoint(&provider, result.checkpoint.unwrap().as_prune_checkpoint(prune_mode))
+            .unwrap();
+        provider.commit().expect("commit");
+
+        let checkpoint = db
+            .factory
+            .provider()
+            .unwrap()
+            .get_prune_checkpoint(PruneSegment::AccountHistory)
+            .unwrap()
+            .unwrap();
+        assert!(result.progress.is_finished());
+        assert_eq!(checkpoint.block_number, Some(to_block));
     }
 }

--- a/crates/prune/prune/src/segments/user/history.rs
+++ b/crates/prune/prune/src/segments/user/history.rs
@@ -29,7 +29,10 @@ pub(crate) struct PrunedIndices {
 pub(crate) struct HistoryPruneResult<K> {
     /// Map of the highest deleted changeset keys to their block numbers.
     pub(crate) highest_deleted: FxHashMap<K, BlockNumber>,
-    /// The last block number that had changesets pruned.
+    /// The highest block number whose changesets are fully pruned, becoming the checkpoint.
+    ///
+    /// Checkpoints have block granularity, so a caller that can stop in the middle of a block
+    /// must report the block before it, and prune the interrupted block again on the next run.
     pub(crate) last_pruned_block: Option<BlockNumber>,
     /// Number of changesets pruned.
     pub(crate) pruned_count: usize,
@@ -42,6 +45,10 @@ pub(crate) struct HistoryPruneResult<K> {
 /// Shared between the static-file and database changeset paths for both account and storage
 /// history: the changeset source differs, but computing the checkpoint block, pruning the history
 /// index shards, and assembling [`SegmentOutput`] is identical.
+///
+/// Callers that can leave a block half-pruned (database table walks) must apply the block-level
+/// rewind themselves before calling this. Static-file walks delete nothing and must report the last
+/// fully walked block so the checkpoint does not stall.
 pub(crate) fn finalize_history_prune<Provider, T, K, SK>(
     provider: &Provider,
     result: HistoryPruneResult<K>,
@@ -58,11 +65,8 @@ where
 {
     let HistoryPruneResult { highest_deleted, last_pruned_block, pruned_count, done } = result;
 
-    // If there's more changesets to prune, set the checkpoint block number to the previous one, so
-    // we can finish pruning its changesets on the next run.
-    let last_changeset_pruned_block = last_pruned_block
-        .map(|block_number| if done { block_number } else { block_number.saturating_sub(1) })
-        .unwrap_or(range_end);
+    // Nothing was pruned only when the range held no changesets at all, so the whole range is done.
+    let last_changeset_pruned_block = last_pruned_block.unwrap_or(range_end);
 
     // Sort highest deleted block numbers and turn them into sharded keys.
     // `sorted_unstable` is fine because no equal keys exist in the map.

--- a/crates/prune/prune/src/segments/user/storage_history.rs
+++ b/crates/prune/prune/src/segments/user/storage_history.rs
@@ -114,11 +114,17 @@ impl StorageHistory {
 
         let walker = provider.static_file_provider().walk_storage_changeset_range(range);
         for result in walker {
-            if limiter.is_limit_reached() {
+            let (BlockNumberAddress((block_number, address)), entry) = result?;
+            // The walk itself deletes nothing, so an interrupted block cannot be resumed: giving
+            // up the budget inside block N reports checkpoint N-1 and the next run rereads the
+            // same entries, forever. Stop on block boundaries only, overshooting the budget by at
+            // most the rest of one block.
+            if limiter.is_limit_reached() &&
+                last_changeset_pruned_block.is_some_and(|last| last != block_number)
+            {
                 done = false;
                 break
             }
-            let (BlockNumberAddress((block_number, address)), entry) = result?;
             highest_deleted_storages.insert((address, entry.key), block_number);
             last_changeset_pruned_block = Some(block_number);
             pruned_changesets += 1;
@@ -199,9 +205,19 @@ impl StorageHistory {
             )?;
         trace!(target: "pruner", deleted = %pruned_changesets, %done, "Pruned storage history (changesets from database)");
 
+        // The table walk can stop in the middle of a block, so the interrupted block has to be
+        // pruned again on the next run.
+        let last_pruned_block = last_changeset_pruned_block.map(|block_number| {
+            if done {
+                block_number
+            } else {
+                block_number.saturating_sub(1)
+            }
+        });
+
         let result = HistoryPruneResult {
             highest_deleted: highest_deleted_storages,
-            last_pruned_block: last_changeset_pruned_block,
+            last_pruned_block,
             pruned_count: pruned_changesets,
             done,
         };
@@ -499,5 +515,125 @@ mod tests {
                 .get_highest_static_file_block(StaticFileSegment::StorageChangeSets),
             Some(100)
         );
+    }
+
+    /// A block holding at least a whole run's budget of changesets must not stall pruning: the
+    /// walk deletes no changesets, so a checkpoint rewound below such a block would make every
+    /// later run reread it and never advance.
+    #[test]
+    fn dense_block_advances_static_file_checkpoint() {
+        use alloy_primitives::U256;
+        use reth_primitives_traits::StorageEntry;
+
+        let db = TestStageDB::default();
+        let mut rng = generators::rng();
+
+        let blocks = random_block_range(
+            &mut rng,
+            0..=20,
+            BlockRangeParams { parent: Some(B256::ZERO), tx_count: 0..1, ..Default::default() },
+        );
+        db.insert_blocks(blocks.iter(), StorageKind::Database(None)).expect("insert blocks");
+
+        // Two storage changesets per block, so a budget of two (after table split) makes every
+        // block "dense".
+        const ENTRIES_PER_BLOCK: usize = 2;
+        let (address, account) = random_eoa_accounts(&mut rng, 1).into_iter().next().unwrap();
+        let keys = [B256::with_last_byte(1), B256::with_last_byte(2)];
+        let changesets = (0..=20)
+            .map(|_| {
+                vec![(
+                    address,
+                    account,
+                    keys.iter()
+                        .map(|key| StorageEntry { key: *key, value: U256::from(1) })
+                        .collect(),
+                )]
+            })
+            .collect::<Vec<_>>();
+        db.insert_changesets_to_static_files(changesets.clone(), None)
+            .expect("insert changesets to static files");
+        db.insert_history(changesets, None).expect("insert history");
+        assert!(db.table::<tables::StorageChangeSets>().unwrap().is_empty());
+
+        let to_block = 15u64;
+        let prune_mode = PruneMode::Before(to_block);
+        let segment = StorageHistory::new(prune_mode);
+
+        // Start from a checkpoint in the middle so a rewind can't be masked by block 0.
+        let mut checkpoint = PruneCheckpoint { block_number: Some(4), tx_number: None, prune_mode };
+
+        db.factory.set_storage_settings_cache(GravityStorageSettings {
+            changesets_in_static_files: true,
+        });
+
+        for _ in 0..3 {
+            let previous = checkpoint.block_number;
+            let input = PruneInput {
+                previous_checkpoint: Some(checkpoint),
+                to_block,
+                // Halved internally by STORAGE_HISTORY_TABLES_TO_PRUNE.
+                limiter: PruneLimiter::default()
+                    .set_deleted_entries_limit(ENTRIES_PER_BLOCK * STORAGE_HISTORY_TABLES_TO_PRUNE),
+            };
+
+            let provider = db.factory.database_provider_rw().unwrap();
+            provider.set_storage_settings_cache(GravityStorageSettings {
+                changesets_in_static_files: true,
+            });
+            let result = segment.prune(&provider, input).unwrap();
+            segment
+                .save_checkpoint(
+                    &provider,
+                    result.checkpoint.unwrap().as_prune_checkpoint(prune_mode),
+                )
+                .unwrap();
+            provider.commit().expect("commit");
+
+            checkpoint = db
+                .factory
+                .provider()
+                .unwrap()
+                .get_prune_checkpoint(PruneSegment::StorageHistory)
+                .unwrap()
+                .unwrap();
+
+            assert!(
+                !result.progress.is_finished(),
+                "the range is longer than one run's budget allows"
+            );
+            assert!(
+                checkpoint.block_number > previous,
+                "checkpoint must advance past the dense block, got {:?} after {previous:?}",
+                checkpoint.block_number
+            );
+        }
+        assert_eq!(checkpoint.block_number, Some(7), "one dense block cleared per run");
+
+        // With enough budget the remainder of the range completes in one run.
+        let input = PruneInput {
+            previous_checkpoint: Some(checkpoint),
+            to_block,
+            limiter: PruneLimiter::default().set_deleted_entries_limit(1000),
+        };
+        let provider = db.factory.database_provider_rw().unwrap();
+        provider.set_storage_settings_cache(GravityStorageSettings {
+            changesets_in_static_files: true,
+        });
+        let result = segment.prune(&provider, input).unwrap();
+        segment
+            .save_checkpoint(&provider, result.checkpoint.unwrap().as_prune_checkpoint(prune_mode))
+            .unwrap();
+        provider.commit().expect("commit");
+
+        let checkpoint = db
+            .factory
+            .provider()
+            .unwrap()
+            .get_prune_checkpoint(PruneSegment::StorageHistory)
+            .unwrap()
+            .unwrap();
+        assert!(result.progress.is_finished());
+        assert_eq!(checkpoint.block_number, Some(to_block));
     }
 }


### PR DESCRIPTION
## Summary

Ports [paradigmxyz/reth#26505](https://github.com/paradigmxyz/reth/pull/26505) onto greth `main` (on top of #403 static-file changeset reclamation).

Static-file account/storage history walks visit changesets without deleting them. Rewinding the checkpoint below an interrupted block made every later run reread the same entries — a block holding a whole run's budget of changesets stalled the segment permanently, and no changeset jar was reclaimed while it was stalled.

This change:
- Stops those walks on **block boundaries** only (overshoot budget by at most the rest of one block)
- Drops the shared `-1` rewind in `finalize_history_prune`
- Keeps the `-1` rewind only in `prune_database`, the only path that can leave a block half-pruned

RocksDB history path from upstream reth is not present here; only the greth `changesets_in_static_files` + database paths are updated.

## Test plan

- [x] `cargo nextest run -p reth-prune -- dense_block_advances_static_file_checkpoint prune_static_files_path segments::user::account_history::tests::prune segments::user::storage_history::tests::prune`
- Regression tests assert a dense block's checkpoint advances under a tight budget (fails on unfixed `main` with `checkpoint must advance past the dense block, got Some(4) after Some(4)`)