### PR TITLE
fix(tx-filter): apply block gas as last gate at Beta (discard non-fitting)

### DIFF
--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -22,9 +22,11 @@ hardfork!(
         ///   and treat the suffix as discarded (pre-Beta STF).
         ///
         /// From Beta onward, lockdown is released and gas packing becomes last-gate
-        /// with pool-safe deferral (see [`is_block_gas_last_gate_active`]). Activation
-        /// is via genesis `betaTime` (timestamp). Missing/unknown key → Beta never
-        /// active → pre-Beta policy stays on (fail-closed).
+        /// (invalid txs do not steal budget; packing continues after a non-fit). Gas
+        /// exclusions still **discard** (pool remove + `is_discarded`) — no new defer
+        /// state — see [`is_block_gas_last_gate_active`]. Activation is via genesis
+        /// `betaTime` (timestamp). Missing/unknown key → Beta never active → pre-Beta
+        /// policy stays on (fail-closed).
         Beta,
     }
 );
@@ -92,9 +94,10 @@ pub fn is_eip7702_lockdown_active<S: EthChainSpec>(chain_spec: &S, block_ts: u64
 /// Block-gas packing policy for `filter_invalid_txs` (audit#646). Active from Beta.
 ///
 /// Returns `true` when the pre-execution filter must apply **gas as the last gate**:
-/// invalid txs do not consume block budget, packing continues after a non-fitting
-/// tx, and gas-only exclusions are **deferred** (kept in the pool) rather than
-/// discarded.
+/// invalid txs do not consume block budget, and packing continues after a non-fitting
+/// tx (later smaller txs may still enter the body). Non-fitting / same-sender blocked
+/// txs are still **discarded** from the pool (`is_discarded`) — this release does not
+/// introduce a keep-in-pool "defer" outcome (SDK only understands the discard bit).
 ///
 /// Pre-Beta (`false`): legacy prefix-cut on cumulative `tx.gas_limit()` — the first
 /// overflow index and every later index are discarded. That behaviour is consensus-

--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -95,9 +95,9 @@ pub fn is_eip7702_lockdown_active<S: EthChainSpec>(chain_spec: &S, block_ts: u64
 ///
 /// Returns `true` when the pre-execution filter must apply **gas as the last gate**:
 /// invalid txs do not consume block budget, and packing continues after a non-fitting
-/// tx (later smaller txs may still enter the body). Non-fitting / same-sender blocked
-/// txs are still **discarded** from the pool (`is_discarded`) — this release does not
-/// introduce a keep-in-pool "defer" outcome (SDK only understands the discard bit).
+/// tx (later smaller txs may still enter the body). Non-fitting txs are still
+/// **discarded** from the pool (`is_discarded`) — this release does not introduce a
+/// keep-in-pool "defer" outcome (SDK only understands the discard bit).
 ///
 /// Pre-Beta (`false`): legacy prefix-cut on cumulative `tx.gas_limit()` — the first
 /// overflow index and every later index are discarded. That behaviour is consensus-

--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -13,12 +13,18 @@ hardfork!(
         /// Activation is via genesis `alphaTime` (timestamp). See
         /// [`is_system_tx_gas_exempt`].
         Alpha,
-        /// Beta hardfork: EIP-7702 lockdown release gate (audit#838).
+        /// Beta hardfork: consensus-critical filter policy changes.
         ///
-        /// Until Beta activates, the pre-execution filter rejects all type-4 txs and
-        /// txs from/to currently-delegated accounts. Activation is via genesis
-        /// `betaTime` (timestamp). Missing/unknown key → Beta never active → lockdown
-        /// stays on (fail-closed).
+        /// Until Beta activates:
+        /// - EIP-7702 lockdown (audit#838): reject type-4 txs and txs from/to
+        ///   currently-delegated accounts.
+        /// - Block-gas packing (audit#646): prefix-cut on cumulative `tx.gas_limit()`
+        ///   and treat the suffix as discarded (pre-Beta STF).
+        ///
+        /// From Beta onward, lockdown is released and gas packing becomes last-gate
+        /// with pool-safe deferral (see [`is_block_gas_last_gate_active`]). Activation
+        /// is via genesis `betaTime` (timestamp). Missing/unknown key → Beta never
+        /// active → pre-Beta policy stays on (fail-closed).
         Beta,
     }
 );
@@ -81,6 +87,23 @@ pub fn is_system_tx_gas_exempt<S: EthChainSpec>(chain_spec: &S, block_ts: u64) -
 #[inline]
 pub fn is_eip7702_lockdown_active<S: EthChainSpec>(chain_spec: &S, block_ts: u64) -> bool {
     !chain_spec.gravity_hardforks().is_fork_active_at_timestamp(GravityHardfork::Beta, block_ts)
+}
+
+/// Block-gas packing policy for `filter_invalid_txs` (audit#646). Active from Beta.
+///
+/// Returns `true` when the pre-execution filter must apply **gas as the last gate**:
+/// invalid txs do not consume block budget, packing continues after a non-fitting
+/// tx, and gas-only exclusions are **deferred** (kept in the pool) rather than
+/// discarded.
+///
+/// Pre-Beta (`false`): legacy prefix-cut on cumulative `tx.gas_limit()` — the first
+/// overflow index and every later index are discarded. That behaviour is consensus-
+/// critical and must not change on already-running chains without a hardfork.
+///
+/// Fail-closed: missing `betaTime` keeps the legacy prefix-cut forever.
+#[inline]
+pub fn is_block_gas_last_gate_active<S: EthChainSpec>(chain_spec: &S, block_ts: u64) -> bool {
+    chain_spec.gravity_hardforks().is_fork_active_at_timestamp(GravityHardfork::Beta, block_ts)
 }
 
 /// Verifies the protocol invariant that every [`SYSTEM_CALLER`]-signed

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -30,8 +30,9 @@ pub use reth_ethereum_forks::*;
 pub use alloy_evm::EvmLimitParams;
 pub use api::EthChainSpec;
 pub use gravity::{
-    is_eip7702_lockdown_active, is_gravity_system_caller, is_system_tx_gas_exempt,
-    system_txs_form_head_prefix, GravityHardfork, GRAVITY_TX_SKIPPED_LOG_ADDRESS, SYSTEM_CALLER,
+    is_block_gas_last_gate_active, is_eip7702_lockdown_active, is_gravity_system_caller,
+    is_system_tx_gas_exempt, system_txs_form_head_prefix, GravityHardfork,
+    GRAVITY_TX_SKIPPED_LOG_ADDRESS, SYSTEM_CALLER,
 };
 pub use info::ChainInfo;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -1480,10 +1480,9 @@ impl<Storage: GravityStorage> Core<Storage> {
     /// Return the filtered valid transactions with sender without changing the relative order of
     /// the transactions.
     ///
-    /// Validation failures are discarded from the pool (`is_discarded` + `discard_txs_tx`).
-    /// From Beta (`is_block_gas_last_gate_active`), gas-only exclusions are deferred — excluded
-    /// from this block body but kept in the pool (`is_discarded = false`, not sent on the discard
-    /// channel) — audit#646. Pre-Beta gas prefix-cut still discards the suffix (legacy STF).
+    /// All excluded txs are discarded from the pool (`is_discarded` + `discard_txs_tx`), including
+    /// Beta+ gas-budget exclusions. Pre-Beta uses legacy gas prefix-cut; Beta+ packs with gas as
+    /// last gate but still discards non-fitting txs (audit#646 packing fix, no keep-in-pool defer).
     fn filter_invalid_txs(
         &self,
         db: &Storage::StateView,
@@ -1494,7 +1493,7 @@ impl<Storage: GravityStorage> Core<Storage> {
         block_timestamp: u64,
         block_number: u64,
     ) -> (Vec<TransactionSigned>, Vec<Address>, Vec<TxInfo>) {
-        let filtered = tx_filter::filter_invalid_txs(
+        let invalid_idxs = tx_filter::filter_invalid_txs(
             db,
             &txs,
             &senders,
@@ -1504,7 +1503,7 @@ impl<Storage: GravityStorage> Core<Storage> {
             block_timestamp,
             block_number,
         );
-        if filtered.discard.is_empty() && filtered.defer.is_empty() {
+        if invalid_idxs.is_empty() {
             let mut txs_info = Vec::with_capacity(txs.len());
             for (tx, sender) in txs.iter().zip(senders.iter()) {
                 txs_info.push(TxInfo {
@@ -1516,38 +1515,20 @@ impl<Storage: GravityStorage> Core<Storage> {
             }
             (txs, senders, txs_info)
         } else {
-            if !filtered.discard.is_empty() {
-                let _ = self.discard_txs_tx.send(
-                    filtered
-                        .discard
-                        .iter()
-                        .map(|&idx| txs[idx].hash())
-                        .copied()
-                        .collect::<Vec<_>>(),
-                );
-            }
+            let _ = self
+                .discard_txs_tx
+                .send(invalid_idxs.iter().map(|&idx| txs[idx].hash()).copied().collect::<Vec<_>>());
 
-            let excluded = filtered.discard.len() + filtered.defer.len();
-            let mut filtered_txs = Vec::with_capacity(txs.len().saturating_sub(excluded));
+            let mut filtered_txs = Vec::with_capacity(txs.len() - invalid_idxs.len());
             let mut filtered_senders = Vec::with_capacity(filtered_txs.capacity());
             let mut txs_info = Vec::with_capacity(txs.len());
             for (i, (tx, sender)) in txs.into_iter().zip(senders.into_iter()).enumerate() {
-                if filtered.discard.contains(&i) {
+                if invalid_idxs.contains(&i) {
                     txs_info.push(TxInfo {
                         tx_hash: *tx.hash(),
                         sender,
                         nonce: tx.nonce(),
                         is_discarded: true,
-                    });
-                    continue;
-                }
-                if filtered.defer.contains(&i) {
-                    // Valid but not packed this block — leave pool alone.
-                    txs_info.push(TxInfo {
-                        tx_hash: *tx.hash(),
-                        sender,
-                        nonce: tx.nonce(),
-                        is_discarded: false,
                     });
                     continue;
                 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -1481,8 +1481,9 @@ impl<Storage: GravityStorage> Core<Storage> {
     /// the transactions.
     ///
     /// Validation failures are discarded from the pool (`is_discarded` + `discard_txs_tx`).
-    /// Gas-deferred txs are excluded from this block body but kept in the pool
-    /// (`is_discarded = false`, not sent on the discard channel) — audit#646.
+    /// From Beta (`is_block_gas_last_gate_active`), gas-only exclusions are deferred — excluded
+    /// from this block body but kept in the pool (`is_discarded = false`, not sent on the discard
+    /// channel) — audit#646. Pre-Beta gas prefix-cut still discards the suffix (legacy STF).
     fn filter_invalid_txs(
         &self,
         db: &Storage::StateView,

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -1479,6 +1479,10 @@ impl<Storage: GravityStorage> Core<Storage> {
 
     /// Return the filtered valid transactions with sender without changing the relative order of
     /// the transactions.
+    ///
+    /// Validation failures are discarded from the pool (`is_discarded` + `discard_txs_tx`).
+    /// Gas-deferred txs are excluded from this block body but kept in the pool
+    /// (`is_discarded = false`, not sent on the discard channel) — audit#646.
     fn filter_invalid_txs(
         &self,
         db: &Storage::StateView,
@@ -1489,7 +1493,7 @@ impl<Storage: GravityStorage> Core<Storage> {
         block_timestamp: u64,
         block_number: u64,
     ) -> (Vec<TransactionSigned>, Vec<Address>, Vec<TxInfo>) {
-        let invalid_idxs = tx_filter::filter_invalid_txs(
+        let filtered = tx_filter::filter_invalid_txs(
             db,
             &txs,
             &senders,
@@ -1499,7 +1503,7 @@ impl<Storage: GravityStorage> Core<Storage> {
             block_timestamp,
             block_number,
         );
-        if invalid_idxs.is_empty() {
+        if filtered.discard.is_empty() && filtered.defer.is_empty() {
             let mut txs_info = Vec::with_capacity(txs.len());
             for (tx, sender) in txs.iter().zip(senders.iter()) {
                 txs_info.push(TxInfo {
@@ -1511,20 +1515,38 @@ impl<Storage: GravityStorage> Core<Storage> {
             }
             (txs, senders, txs_info)
         } else {
-            let _ = self
-                .discard_txs_tx
-                .send(invalid_idxs.iter().map(|&idx| txs[idx].hash()).copied().collect::<Vec<_>>());
+            if !filtered.discard.is_empty() {
+                let _ = self.discard_txs_tx.send(
+                    filtered
+                        .discard
+                        .iter()
+                        .map(|&idx| txs[idx].hash())
+                        .copied()
+                        .collect::<Vec<_>>(),
+                );
+            }
 
-            let mut filtered_txs = Vec::with_capacity(txs.len() - invalid_idxs.len());
+            let excluded = filtered.discard.len() + filtered.defer.len();
+            let mut filtered_txs = Vec::with_capacity(txs.len().saturating_sub(excluded));
             let mut filtered_senders = Vec::with_capacity(filtered_txs.capacity());
             let mut txs_info = Vec::with_capacity(txs.len());
             for (i, (tx, sender)) in txs.into_iter().zip(senders.into_iter()).enumerate() {
-                if invalid_idxs.contains(&i) {
+                if filtered.discard.contains(&i) {
                     txs_info.push(TxInfo {
                         tx_hash: *tx.hash(),
                         sender,
                         nonce: tx.nonce(),
                         is_discarded: true,
+                    });
+                    continue;
+                }
+                if filtered.defer.contains(&i) {
+                    // Valid but not packed this block — leave pool alone.
+                    txs_info.push(TxInfo {
+                        tx_hash: *tx.hash(),
+                        sender,
+                        nonce: tx.nonce(),
+                        is_discarded: false,
                     });
                     continue;
                 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -61,7 +61,9 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, U256,
 };
-use reth_chainspec::{is_eip7702_lockdown_active, ChainSpec, EthChainSpec};
+use reth_chainspec::{
+    is_block_gas_last_gate_active, is_eip7702_lockdown_active, ChainSpec, EthChainSpec,
+};
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm::ParallelDatabase;
 use reth_evm_ethereum::revm_spec_by_timestamp_and_block_number;
@@ -73,26 +75,32 @@ use tracing::info;
 /// Outcome of pre-execution filtering for one ordered block.
 ///
 /// - [`Self::discard`]: validation failures — remove from the local pool and report `is_discarded`
-///   to consensus.
-/// - [`Self::defer`]: otherwise-valid txs that do not fit the remaining block gas budget (or depend
-///   on a same-sender gas-deferred predecessor). Excluded from this block body but **kept** in the
-///   pool for a later block (audit#646).
+///   to consensus. Pre-Beta, gas prefix-cut suffixes also land here (legacy STF).
+/// - [`Self::defer`]: **Beta+ only.** Otherwise-valid txs that do not fit the remaining block gas
+///   budget (or depend on a same-sender gas-deferred predecessor). Excluded from this block body
+///   but **kept** in the pool for a later block (audit#646).
 /// - Neither set: include in the block in original relative order.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct TxFilterResult {
     /// Indices of txs that failed validation and must be discarded from the pool.
     pub discard: HashSet<usize>,
-    /// Indices of valid txs skipped only for block-gas packing.
+    /// Indices of valid txs skipped only for block-gas packing (Beta+).
     pub defer: HashSet<usize>,
 }
 
 /// Filter ordered txs before grevm execution.
 ///
 /// Walks the ordered list **serially** (required for EIP-7702 cross-account auth
-/// nonce simulation). Per-tx order is: admission guards + in-block state sim first,
-/// then block gas budget as the **last** gate. Invalid txs never consume gas budget,
-/// so a junk high-`gas_limit` tx cannot prefix-cut later valid txs that still fit
-/// (gravity-audit#646). Gas-deferred txs are not discarded from the pool.
+/// nonce simulation).
+///
+/// ## Block-gas packing (audit#646) — gated by [`is_block_gas_last_gate_active`] / Beta
+///
+/// - **Pre-Beta (legacy STF):** prefix-cut on cumulative worst-case `tx.gas_limit()`; every index
+///   from the first overflow through the end is **discarded**. This matches historical Gravity
+///   behaviour and must not change without a hardfork.
+/// - **Beta+:** admission + in-block state sim first, then gas as the **last** gate. Invalid txs
+///   never consume budget; non-fitting valid txs are **deferred** (pool kept) and later smaller txs
+///   from other senders may still pack.
 ///
 /// `chain_spec`, `block_timestamp`, `block_number` are taken instead of a
 /// pre-computed `SpecId` because the only consumer of `spec_id` here is the
@@ -120,8 +128,35 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     block_number: u64,
 ) -> TxFilterResult {
     let eip7702_lockdown = is_eip7702_lockdown_active(chain_spec, block_timestamp);
+    // Consensus-critical packing change: only after Beta (same gate as 7702 lockdown release).
+    let gas_last_gate = is_block_gas_last_gate_active(chain_spec, block_timestamp);
     let spec_id =
         revm_spec_by_timestamp_and_block_number(chain_spec, block_timestamp, block_number);
+
+    // Pre-Beta: first overflow index; `txs.len()` means no cutoff. Unused post-Beta.
+    let mut gas_limit_exceeded_tx_idx = txs.len();
+    if !gas_last_gate {
+        let mut tx_gas_limit_sum: u64 = 0;
+        for (idx, tx) in txs.iter().enumerate() {
+            let tx_gas_limit = tx.gas_limit();
+            match tx_gas_limit_sum.checked_add(tx_gas_limit) {
+                Some(new_sum) if new_sum <= gas_limit => {
+                    tx_gas_limit_sum = new_sum;
+                }
+                _ => {
+                    info!(target: "filter_invalid_txs",
+                        tx_hash=?txs[idx].hash(),
+                        sender=?senders[idx],
+                        block_gas_limit=?gas_limit,
+                        "pre-Beta gas limit exceeded, truncated to {}",
+                        idx,
+                    );
+                    gas_limit_exceeded_tx_idx = idx;
+                    break;
+                }
+            }
+        }
+    }
 
     let cfg_chain_id = chain_spec.chain_id();
     let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &mut AccountInfo| {
@@ -377,18 +412,21 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     // block order. The per-tx guards are cheap; the extra `recover_authority()` ECDSA
     // recovery runs only for type-4 txs.
     //
-    // Block gas is applied as the **last** gate after a tx has passed admission + sim:
-    // invalid txs do not consume budget, and a tx that does not fit is deferred (kept in
-    // pool) while later smaller txs from other senders may still pack (audit#646).
+    // Beta+ (`gas_last_gate`): block gas is the **last** gate after admission + sim —
+    // invalid txs do not consume budget; non-fitting valid txs are deferred (audit#646).
+    // Pre-Beta: only the gas prefix is walked; suffix indices are discarded below.
     let mut sim: HashMap<Address, Option<AccountInfo>> = HashMap::default();
     let mut result = TxFilterResult::default();
-    // Senders whose next in-block nonce was gas-deferred: later same-sender txs cannot
-    // execute without a nonce gap, so they are deferred too (not discarded).
+    // Senders whose next in-block nonce was gas-deferred (Beta+ only).
     let mut gas_blocked_senders: HashSet<Address> = HashSet::default();
     let mut remaining_gas = gas_limit;
 
-    for (idx, (tx, &sender)) in txs.iter().zip(senders.iter()).enumerate() {
-        if gas_blocked_senders.contains(&sender) {
+    let walk_end = if gas_last_gate { txs.len() } else { gas_limit_exceeded_tx_idx };
+    for idx in 0..walk_end {
+        let tx = &txs[idx];
+        let sender = senders[idx];
+
+        if gas_last_gate && gas_blocked_senders.contains(&sender) {
             info!(target: "filter_invalid_txs",
                 tx_hash=?tx.hash(),
                 sender=?sender,
@@ -424,8 +462,8 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         // Validate the tx against the simulated sender account and apply the caller nonce
         // bump + balance deduction. Scoped so the `sim[sender]` borrow is released before
         // the authorization loop re-borrows `sim` (an authority may be any account).
-        // On success the sim account is mutated; if we later defer for gas we must roll
-        // that mutation back so a same-sender follow-up still sees the pre-tx account.
+        // On success the sim account is mutated; if we later defer for gas (Beta+) we must
+        // roll that mutation back so a same-sender follow-up still sees the pre-tx account.
         let sender_snapshot = sim.get(&sender).cloned();
         let valid = {
             let sender_acct = sim.entry(sender).or_insert_with(|| db.basic_ref(sender).unwrap());
@@ -463,31 +501,34 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             continue;
         }
 
-        // Last gate: block gas budget (worst-case `tx.gas_limit()`). Does not discard.
-        let tx_gas = tx.gas_limit();
-        if tx_gas > remaining_gas {
-            info!(target: "filter_invalid_txs",
-                tx_hash=?tx.hash(),
-                sender=?sender,
-                tx_gas_limit=?tx_gas,
-                remaining_gas=?remaining_gas,
-                block_gas_limit=?gas_limit,
-                "deferred: tx does not fit remaining block gas budget"
-            );
-            // Roll back the optimistic sim mutation from `is_tx_valid`.
-            match sender_snapshot {
-                Some(prev) => {
-                    sim.insert(sender, prev);
+        // Beta+: last gate is block gas (worst-case `tx.gas_limit()`). Does not discard.
+        // Pre-Beta: prefix already guaranteed to fit; no re-check.
+        if gas_last_gate {
+            let tx_gas = tx.gas_limit();
+            if tx_gas > remaining_gas {
+                info!(target: "filter_invalid_txs",
+                    tx_hash=?tx.hash(),
+                    sender=?sender,
+                    tx_gas_limit=?tx_gas,
+                    remaining_gas=?remaining_gas,
+                    block_gas_limit=?gas_limit,
+                    "deferred: tx does not fit remaining block gas budget"
+                );
+                // Roll back the optimistic sim mutation from `is_tx_valid`.
+                match sender_snapshot {
+                    Some(prev) => {
+                        sim.insert(sender, prev);
+                    }
+                    None => {
+                        sim.remove(&sender);
+                    }
                 }
-                None => {
-                    sim.remove(&sender);
-                }
+                result.defer.insert(idx);
+                gas_blocked_senders.insert(sender);
+                continue;
             }
-            result.defer.insert(idx);
-            gas_blocked_senders.insert(sender);
-            continue;
+            remaining_gas -= tx_gas;
         }
-        remaining_gas -= tx_gas;
 
         // Mirror revm `apply_auth_list`: for a type-4 tx every valid authorization bumps
         // ITS authority's nonce once — self (authority == sender) AND cross-account. The
@@ -524,6 +565,12 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                 }
             }
         }
+    }
+
+    // Pre-Beta legacy: every index from the cumulative-gas cutoff through the end is
+    // discarded (not deferred). Post-Beta never sets a cutoff short of `txs.len()`.
+    if !gas_last_gate {
+        result.discard.extend(gas_limit_exceeded_tx_idx..txs.len());
     }
     result
 }
@@ -846,14 +893,12 @@ mod tests {
         assert!(result.discard.contains(&2));
     }
 
-    /// audit#646: a valid tx that does not fit remaining block gas is deferred (kept in
-    /// pool), not discarded. Same-sender follow-ups are deferred too (nonce gap).
+    /// Pre-Beta (legacy STF): cumulative gas overflow discards the suffix.
     #[test]
-    fn test_filter_invalid_txs_gas_limit_exceeded() {
+    fn test_filter_invalid_txs_gas_limit_exceeded_pre_beta_discards_suffix() {
         let mut db = MockDatabase::new();
         let sender = Address::random();
 
-        // the account has enough balance
         let account = AccountInfo {
             balance: U256::from(1_000_000_000_000_000_000u64), // 1 ETH
             nonce: 0,
@@ -863,7 +908,6 @@ mod tests {
         };
         db.insert_account(sender, account);
 
-        // create multiple transactions, the cumulative gas limit exceeds the block limit
         let tx1 = create_test_transaction(0, 20_000_000, 25_000_000_000); // 20M gas
         let tx2 = create_test_transaction(1, 20_000_000, 25_000_000_000); // 20M gas
         let txs = vec![tx1, tx2];
@@ -871,6 +915,7 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64; // 30M gas limit
 
+        // Default prague fixture has no betaTime → pre-Beta prefix-cut.
         let result = filter_invalid_txs(
             &db,
             &txs,
@@ -881,7 +926,42 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty(), "gas overflow must not discard: {result:?}");
+        assert!(result.defer.is_empty(), "pre-Beta must not defer: {result:?}");
+        assert_eq!(result.discard.len(), 1);
+        assert!(result.discard.contains(&1));
+    }
+
+    /// Beta+ (audit#646): non-fitting valid tx is deferred (kept in pool), not discarded.
+    #[test]
+    fn test_filter_invalid_txs_gas_limit_exceeded_post_beta_defers() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+
+        let account = AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000u64),
+            nonce: 0,
+            code_hash: KECCAK_EMPTY,
+            code: None,
+            account_id: None,
+        };
+        db.insert_account(sender, account);
+
+        let tx1 = create_test_transaction(0, 20_000_000, 25_000_000_000);
+        let tx2 = create_test_transaction(1, 20_000_000, 25_000_000_000);
+        let txs = vec![tx1, tx2];
+        let senders = vec![sender, sender];
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert!(result.discard.is_empty(), "gas overflow must not discard post-Beta: {result:?}");
         assert_eq!(result.defer.len(), 1);
         assert!(result.defer.contains(&1));
     }
@@ -890,9 +970,9 @@ mod tests {
     // when `sum_system_gas ≥ block.gas_limit`, the call site's `saturating_sub` collapses
     // the user-tx budget to 0, and the filter must exclude *every* user tx — otherwise
     // `header.gas_used > header.gas_limit` once system-txn receipts are appended.
-    // Under audit#646 those exclusions are deferred (pool-safe), not discarded.
+    // Pre-Beta: discard. Post-Beta: defer (pool-safe).
     #[test]
-    fn test_filter_invalid_txs_zero_budget_drops_all() {
+    fn test_filter_invalid_txs_zero_budget_drops_all_pre_beta() {
         let mut db = MockDatabase::new();
         let sender = Address::random();
         db.insert_account(
@@ -921,7 +1001,46 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty(), "zero budget must not wipe the pool: {result:?}");
+        assert!(result.defer.is_empty(), "{result:?}");
+        assert_eq!(result.discard.len(), 2);
+        assert!(result.discard.contains(&0));
+        assert!(result.discard.contains(&1));
+    }
+
+    #[test]
+    fn test_filter_invalid_txs_zero_budget_defers_all_post_beta() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        let tx1 = create_test_transaction(0, 21_000, 25_000_000_000);
+        let tx2 = create_test_transaction(1, 21_000, 25_000_000_000);
+        let txs = vec![tx1, tx2];
+        let senders = vec![sender, sender];
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            0,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert!(
+            result.discard.is_empty(),
+            "zero budget must not wipe the pool post-Beta: {result:?}"
+        );
         assert_eq!(result.defer.len(), 2);
         assert!(result.defer.contains(&0));
         assert!(result.defer.contains(&1));
@@ -1013,6 +1132,7 @@ mod tests {
         let base_fee_per_gas = 0u64;
         let gas_limit = 30_000_000u64;
 
+        // Pre-Beta fixture: gas prefix-cut at idx5 (30M) discards suffix (5 and 6).
         let result = filter_invalid_txs(
             &db,
             &txs,
@@ -1023,16 +1143,33 @@ mod tests {
             0,
             0,
         );
-        // Validation failures only — gas packing uses defer (audit#646).
-        // idx1/2/4: nonce/balance failures; idx5 (30M) deferred for gas; idx6 still packs.
-        assert_eq!(result.discard.len(), 3, "discard: {result:?}");
+        assert_eq!(result.discard.len(), 5, "discard: {result:?}");
         assert!(result.discard.contains(&1));
         assert!(result.discard.contains(&2));
         assert!(result.discard.contains(&4));
-        assert!(result.defer.contains(&5), "30M tx deferred for gas: {result:?}");
+        assert!(result.discard.contains(&5));
+        assert!(result.discard.contains(&6));
+        assert!(result.defer.is_empty());
+
+        // Post-Beta: validation discards only; gas defers idx5; idx6 still packs.
+        let result_beta = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            base_fee_per_gas,
+            gas_limit,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert_eq!(result_beta.discard.len(), 3, "discard: {result_beta:?}");
+        assert!(result_beta.discard.contains(&1));
+        assert!(result_beta.discard.contains(&2));
+        assert!(result_beta.discard.contains(&4));
+        assert!(result_beta.defer.contains(&5), "30M tx deferred for gas: {result_beta:?}");
         assert!(
-            !result.discard.contains(&6) && !result.defer.contains(&6),
-            "later small valid tx must still pack: {result:?}"
+            !result_beta.discard.contains(&6) && !result_beta.defer.contains(&6),
+            "later small valid tx must still pack post-Beta: {result_beta:?}"
         );
     }
 
@@ -2133,8 +2270,8 @@ mod tests {
         assert!(result.discard.contains(&0));
     }
 
-    /// audit#646: gas is the last gate. An invalid early tx must not consume block gas
-    /// budget, so a later valid tx that still fits is included (not prefix-cut / discarded).
+    /// audit#646 / Beta+: gas is the last gate. An invalid early tx must not consume
+    /// block gas budget, so a later valid tx that still fits is included.
     #[test]
     fn test_filter_invalid_txs_invalid_does_not_steal_gas_budget() {
         let mut db = MockDatabase::new();
@@ -2154,15 +2291,15 @@ mod tests {
         }
 
         // Order: valid 10M, invalid (wrong nonce) claiming 25M, valid 5M from another sender.
-        // Budget 30M. Old prefix-cut would stop at idx1 (10+25>30) and discard idx1+idx2.
-        // New: idx1 discarded for nonce, does not consume gas; idx2 packs (10+5 <= 30).
+        // Budget 30M. Pre-Beta prefix-cut would stop at idx1 (10+25>30) and discard idx1+idx2.
+        // Post-Beta: idx1 discarded for nonce, does not consume gas; idx2 packs (10+5 <= 30).
         let tx0 = create_test_transaction(0, 10_000_000, 25_000_000_000);
         let tx1 = create_test_transaction(9, 25_000_000, 25_000_000_000); // bad nonce
         let tx2 = create_test_transaction(0, 5_000_000, 25_000_000_000);
         let txs = vec![tx0, tx1, tx2];
         let senders = vec![sender_a, sender_a, sender_b];
 
-        let result = filter_invalid_txs(
+        let pre = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -2172,12 +2309,27 @@ mod tests {
             0,
             0,
         );
+        assert!(
+            pre.discard.contains(&1) && pre.discard.contains(&2),
+            "pre-Beta prefix-cut: {pre:?}"
+        );
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
         assert_eq!(result.discard.len(), 1);
         assert!(result.discard.contains(&1));
         assert!(result.defer.is_empty(), "later valid tx must pack, not defer: {result:?}");
     }
 
-    /// audit#646: continue packing smaller txs after a large one does not fit remaining gas.
+    /// audit#646 / Beta+: continue packing smaller txs after a large one does not fit.
     #[test]
     fn test_filter_invalid_txs_continues_packing_after_gas_skip() {
         let mut db = MockDatabase::new();
@@ -2210,7 +2362,7 @@ mod tests {
             &senders,
             20_000_000_000u64,
             30_000_000u64,
-            &prague_chain_spec(),
+            &prague_chain_spec_with_beta(),
             0,
             0,
         );
@@ -2218,5 +2370,52 @@ mod tests {
         assert_eq!(result.defer.len(), 1);
         assert!(result.defer.contains(&1));
         assert!(!result.defer.contains(&2), "small later tx must pack: {result:?}");
+    }
+
+    /// Fork boundary: betaTime = T; T-1 uses legacy discard, T uses defer.
+    #[test]
+    fn test_filter_invalid_txs_gas_pack_gate_at_beta_boundary() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+        let tx1 = create_test_transaction(0, 20_000_000, 25_000_000_000);
+        let tx2 = create_test_transaction(1, 20_000_000, 25_000_000_000);
+        let txs = vec![tx1, tx2];
+        let senders = vec![sender, sender];
+        const BETA_TIME: u64 = 1_000_000;
+        let chain_spec = prague_chain_spec_with_beta_at(BETA_TIME);
+
+        let pre = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &chain_spec,
+            BETA_TIME - 1,
+            0,
+        );
+        assert!(pre.discard.contains(&1) && pre.defer.is_empty(), "T-1 legacy discard: {pre:?}");
+
+        let at = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &chain_spec,
+            BETA_TIME,
+            0,
+        );
+        assert!(at.defer.contains(&1) && at.discard.is_empty(), "T must defer: {at:?}");
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -70,7 +70,29 @@ use revm::state::AccountInfo;
 use revm_primitives::{eip3860::MAX_INITCODE_SIZE, hardfork::SpecId};
 use tracing::info;
 
-/// Return the invalid transaction indexes.
+/// Outcome of pre-execution filtering for one ordered block.
+///
+/// - [`Self::discard`]: validation failures — remove from the local pool and report `is_discarded`
+///   to consensus.
+/// - [`Self::defer`]: otherwise-valid txs that do not fit the remaining block gas budget (or depend
+///   on a same-sender gas-deferred predecessor). Excluded from this block body but **kept** in the
+///   pool for a later block (audit#646).
+/// - Neither set: include in the block in original relative order.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct TxFilterResult {
+    /// Indices of txs that failed validation and must be discarded from the pool.
+    pub discard: HashSet<usize>,
+    /// Indices of valid txs skipped only for block-gas packing.
+    pub defer: HashSet<usize>,
+}
+
+/// Filter ordered txs before grevm execution.
+///
+/// Walks the ordered list **serially** (required for EIP-7702 cross-account auth
+/// nonce simulation). Per-tx order is: admission guards + in-block state sim first,
+/// then block gas budget as the **last** gate. Invalid txs never consume gas budget,
+/// so a junk high-`gas_limit` tx cannot prefix-cut later valid txs that still fit
+/// (gravity-audit#646). Gas-deferred txs are not discarded from the pool.
 ///
 /// `chain_spec`, `block_timestamp`, `block_number` are taken instead of a
 /// pre-computed `SpecId` because the only consumer of `spec_id` here is the
@@ -96,31 +118,10 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     chain_spec: &ChainSpec,
     block_timestamp: u64,
     block_number: u64,
-) -> HashSet<usize> {
+) -> TxFilterResult {
     let eip7702_lockdown = is_eip7702_lockdown_active(chain_spec, block_timestamp);
     let spec_id =
         revm_spec_by_timestamp_and_block_number(chain_spec, block_timestamp, block_number);
-    let mut gas_limit_exceeded_tx_idx = txs.len();
-    let mut tx_gas_limit_sum: u64 = 0;
-    for (idx, tx) in txs.iter().enumerate() {
-        let tx_gas_limit = tx.gas_limit();
-        match tx_gas_limit_sum.checked_add(tx_gas_limit) {
-            Some(new_sum) if new_sum <= gas_limit => {
-                tx_gas_limit_sum = new_sum;
-            }
-            _ => {
-                info!(target: "filter_invalid_txs",
-                    tx_hash=?txs[idx].hash(),
-                    sender=?senders[idx],
-                    block_gas_limit=?gas_limit,
-                    "gas limit exceeded, truncated to {}",
-                    idx,
-                );
-                gas_limit_exceeded_tx_idx = idx;
-                break;
-            }
-        }
-    }
 
     let cfg_chain_id = chain_spec.chain_id();
     let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &mut AccountInfo| {
@@ -375,11 +376,27 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     // nonce effects cross sender groups, so the simulation must advance in a single global
     // block order. The per-tx guards are cheap; the extra `recover_authority()` ECDSA
     // recovery runs only for type-4 txs.
+    //
+    // Block gas is applied as the **last** gate after a tx has passed admission + sim:
+    // invalid txs do not consume budget, and a tx that does not fit is deferred (kept in
+    // pool) while later smaller txs from other senders may still pack (audit#646).
     let mut sim: HashMap<Address, Option<AccountInfo>> = HashMap::default();
-    let mut invalid_tx_idxs: HashSet<usize> = HashSet::default();
-    for idx in 0..gas_limit_exceeded_tx_idx {
-        let tx = &txs[idx];
-        let sender = senders[idx];
+    let mut result = TxFilterResult::default();
+    // Senders whose next in-block nonce was gas-deferred: later same-sender txs cannot
+    // execute without a nonce gap, so they are deferred too (not discarded).
+    let mut gas_blocked_senders: HashSet<Address> = HashSet::default();
+    let mut remaining_gas = gas_limit;
+
+    for (idx, (tx, &sender)) in txs.iter().zip(senders.iter()).enumerate() {
+        if gas_blocked_senders.contains(&sender) {
+            info!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                "deferred: same-sender predecessor excluded by block gas budget"
+            );
+            result.defer.insert(idx);
+            continue;
+        }
 
         // EMERGENCY EIP-7702 LOCKDOWN — L3 (pre-Beta): drop any tx whose recipient is a
         // currently-delegated account, so no inbound CALL can trigger the callee's
@@ -399,7 +416,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                     to=?to,
                     "7702-lockdown: tx to delegated account rejected (audit#838)"
                 );
-                invalid_tx_idxs.insert(idx);
+                result.discard.insert(idx);
                 continue;
             }
         }
@@ -407,6 +424,9 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         // Validate the tx against the simulated sender account and apply the caller nonce
         // bump + balance deduction. Scoped so the `sim[sender]` borrow is released before
         // the authorization loop re-borrows `sim` (an authority may be any account).
+        // On success the sim account is mutated; if we later defer for gas we must roll
+        // that mutation back so a same-sender follow-up still sees the pre-tx account.
+        let sender_snapshot = sim.get(&sender).cloned();
         let valid = {
             let sender_acct = sim.entry(sender).or_insert_with(|| db.basic_ref(sender).unwrap());
             match sender_acct.as_mut() {
@@ -439,9 +459,35 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             }
         };
         if !valid {
-            invalid_tx_idxs.insert(idx);
+            result.discard.insert(idx);
             continue;
         }
+
+        // Last gate: block gas budget (worst-case `tx.gas_limit()`). Does not discard.
+        let tx_gas = tx.gas_limit();
+        if tx_gas > remaining_gas {
+            info!(target: "filter_invalid_txs",
+                tx_hash=?tx.hash(),
+                sender=?sender,
+                tx_gas_limit=?tx_gas,
+                remaining_gas=?remaining_gas,
+                block_gas_limit=?gas_limit,
+                "deferred: tx does not fit remaining block gas budget"
+            );
+            // Roll back the optimistic sim mutation from `is_tx_valid`.
+            match sender_snapshot {
+                Some(prev) => {
+                    sim.insert(sender, prev);
+                }
+                None => {
+                    sim.remove(&sender);
+                }
+            }
+            result.defer.insert(idx);
+            gas_blocked_senders.insert(sender);
+            continue;
+        }
+        remaining_gas -= tx_gas;
 
         // Mirror revm `apply_auth_list`: for a type-4 tx every valid authorization bumps
         // ITS authority's nonce once — self (authority == sender) AND cross-account. The
@@ -479,8 +525,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             }
         }
     }
-    invalid_tx_idxs.extend(gas_limit_exceeded_tx_idx..txs.len());
-    invalid_tx_idxs
+    result
 }
 
 #[cfg(test)]
@@ -686,7 +731,7 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64; // 20 gwei
         let gas_limit = 30_000_000u64; // 30M gas
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -696,7 +741,7 @@ mod tests {
             0,
             0,
         );
-        assert!(invalid_idxs.is_empty());
+        assert!(result.discard.is_empty());
     }
 
     #[test]
@@ -711,7 +756,7 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -721,8 +766,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 1);
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1);
+        assert!(result.discard.contains(&0));
     }
 
     #[test]
@@ -747,7 +792,7 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -757,8 +802,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 1);
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1);
+        assert!(result.discard.contains(&0));
     }
 
     #[test]
@@ -786,7 +831,7 @@ mod tests {
         let base_fee_per_gas = 1_000;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -796,11 +841,13 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 2);
-        assert!(invalid_idxs.contains(&0));
-        assert!(invalid_idxs.contains(&2));
+        assert_eq!(result.discard.len(), 2);
+        assert!(result.discard.contains(&0));
+        assert!(result.discard.contains(&2));
     }
 
+    /// audit#646: a valid tx that does not fit remaining block gas is deferred (kept in
+    /// pool), not discarded. Same-sender follow-ups are deferred too (nonce gap).
     #[test]
     fn test_filter_invalid_txs_gas_limit_exceeded() {
         let mut db = MockDatabase::new();
@@ -824,7 +871,7 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64; // 30M gas limit
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -834,14 +881,16 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 1);
-        assert!(invalid_idxs.contains(&1));
+        assert!(result.discard.is_empty(), "gas overflow must not discard: {result:?}");
+        assert_eq!(result.defer.len(), 1);
+        assert!(result.defer.contains(&1));
     }
 
     // Models the `create_block_for_executor` byzantine path from gravity-audit#621 Fix A:
     // when `sum_system_gas ≥ block.gas_limit`, the call site's `saturating_sub` collapses
-    // the user-tx budget to 0, and the filter must reject *every* user tx — otherwise
+    // the user-tx budget to 0, and the filter must exclude *every* user tx — otherwise
     // `header.gas_used > header.gas_limit` once system-txn receipts are appended.
+    // Under audit#646 those exclusions are deferred (pool-safe), not discarded.
     #[test]
     fn test_filter_invalid_txs_zero_budget_drops_all() {
         let mut db = MockDatabase::new();
@@ -862,7 +911,7 @@ mod tests {
         let txs = vec![tx1, tx2];
         let senders = vec![sender, sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -872,9 +921,10 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 2);
-        assert!(invalid_idxs.contains(&0));
-        assert!(invalid_idxs.contains(&1));
+        assert!(result.discard.is_empty(), "zero budget must not wipe the pool: {result:?}");
+        assert_eq!(result.defer.len(), 2);
+        assert!(result.defer.contains(&0));
+        assert!(result.defer.contains(&1));
     }
 
     #[test]
@@ -900,7 +950,7 @@ mod tests {
         let base_fee_per_gas = 20_000_000_000u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -910,7 +960,7 @@ mod tests {
             0,
             0,
         );
-        assert!(invalid_idxs.is_empty());
+        assert!(result.discard.is_empty());
     }
 
     #[test]
@@ -963,7 +1013,7 @@ mod tests {
         let base_fee_per_gas = 0u64;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -973,12 +1023,17 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 5, "invalid_idxs: {invalid_idxs:?}");
-        assert!(invalid_idxs.contains(&1));
-        assert!(invalid_idxs.contains(&2));
-        assert!(invalid_idxs.contains(&4));
-        assert!(invalid_idxs.contains(&5));
-        assert!(invalid_idxs.contains(&6));
+        // Validation failures only — gas packing uses defer (audit#646).
+        // idx1/2/4: nonce/balance failures; idx5 (30M) deferred for gas; idx6 still packs.
+        assert_eq!(result.discard.len(), 3, "discard: {result:?}");
+        assert!(result.discard.contains(&1));
+        assert!(result.discard.contains(&2));
+        assert!(result.discard.contains(&4));
+        assert!(result.defer.contains(&5), "30M tx deferred for gas: {result:?}");
+        assert!(
+            !result.discard.contains(&6) && !result.defer.contains(&6),
+            "later small valid tx must still pack: {result:?}"
+        );
     }
 
     /// Regression: a type-0x04 tx whose `gas_limit` is below `21000 + PER_EMPTY_ACCOUNT_COST * N`
@@ -1007,7 +1062,7 @@ mod tests {
         let base_fee_per_gas = 0;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1017,8 +1072,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 1, "intrinsic-gas-too-low 7702 tx should be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "intrinsic-gas-too-low 7702 tx should be discarded");
+        assert!(result.discard.contains(&0));
     }
 
     /// Sanity check (lockdown OFF / Beta active): same 7702 tx with a `gas_limit` at or
@@ -1046,7 +1101,7 @@ mod tests {
         let base_fee_per_gas = 0;
         let gas_limit = 30_000_000u64;
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1056,7 +1111,7 @@ mod tests {
             0,
             0,
         );
-        assert!(invalid_idxs.is_empty(), "got: {invalid_idxs:?}");
+        assert!(result.discard.is_empty(), "got: {result:?}");
     }
 
     /// U-1 (acceptance design §3.1, lockdown OFF / Beta active): a 7702 tx with
@@ -1080,7 +1135,7 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1091,8 +1146,8 @@ mod tests {
             0,
         );
         assert!(
-            invalid_idxs.is_empty(),
-            "two-auth 7702 tx with 72k gas must pass post-Beta: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "two-auth 7702 tx with 72k gas must pass post-Beta: {result:?}"
         );
     }
 
@@ -1117,10 +1172,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
+        assert!(result.discard.contains(&0));
     }
 
     /// Pre-Prague boundary (acceptance design P-2): a TxEip7702 with otherwise-fine intrinsic
@@ -1149,10 +1204,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &shanghai_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "7702 tx must be discarded when spec_id < PRAGUE");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "7702 tx must be discarded when spec_id < PRAGUE");
+        assert!(result.discard.contains(&0));
     }
 
     /// U-3 (acceptance design §3.1): the #668 fix must not regress legacy/1559 filtering.
@@ -1177,11 +1232,11 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            invalid_idxs.is_empty(),
-            "legacy 21k-gas tx must not be regressed by the 7702 intrinsic fix: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "legacy 21k-gas tx must not be regressed by the 7702 intrinsic fix: {result:?}"
         );
     }
 
@@ -1248,10 +1303,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "type-3 (blob) tx must be discarded on Gravity");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "type-3 (blob) tx must be discarded on Gravity");
+        assert!(result.discard.contains(&0));
     }
 
     /// gravity-audit#696 trigger 4: a Create tx with init code larger than
@@ -1278,14 +1333,14 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            invalid_idxs.len(),
+            result.discard.len(),
             1,
             "Create tx with init_code.len() > MAX_INITCODE_SIZE must be discarded"
         );
-        assert!(invalid_idxs.contains(&0));
+        assert!(result.discard.contains(&0));
     }
 
     /// Boundary: a Create tx with `input.len() == MAX_INITCODE_SIZE` is within EIP-3860
@@ -1313,11 +1368,11 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 10_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            invalid_idxs.is_empty(),
-            "Create tx at exactly MAX_INITCODE_SIZE must pass the size gate: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "Create tx at exactly MAX_INITCODE_SIZE must pass the size gate: {result:?}"
         );
     }
 
@@ -1410,7 +1465,7 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1420,8 +1475,12 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 1, "legacy tx with gas_price < base_fee must be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(
+            result.discard.len(),
+            1,
+            "legacy tx with gas_price < base_fee must be discarded"
+        );
+        assert!(result.discard.contains(&0));
     }
 
     /// 1559 tx whose `max_fee_per_gas` is below the prevailing base fee must be
@@ -1446,7 +1505,7 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1456,8 +1515,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(invalid_idxs.len(), 1, "1559 tx with max_fee < base_fee must be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "1559 tx with max_fee < base_fee must be discarded");
+        assert!(result.discard.contains(&0));
     }
 
     // ===== audit#710 gap 2: priority > max =====================================
@@ -1484,10 +1543,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "1559 tx with prio > max must be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "1559 tx with prio > max must be discarded");
+        assert!(result.discard.contains(&0));
     }
 
     // ===== audit#710 gap 3: 7702 empty authorization_list ======================
@@ -1515,14 +1574,14 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            invalid_idxs.len(),
+            result.discard.len(),
             1,
             "7702 tx with empty authorization_list must be discarded"
         );
-        assert!(invalid_idxs.contains(&0));
+        assert!(result.discard.contains(&0));
     }
 
     // ===== audit#710 gap 4: balance must use max_fee, not effective ============
@@ -1557,7 +1616,7 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1568,11 +1627,11 @@ mod tests {
             0,
         );
         assert_eq!(
-            invalid_idxs.len(),
+            result.discard.len(),
             1,
             "balance covers effective but not max — must be discarded by max-fee gate"
         );
-        assert!(invalid_idxs.contains(&0));
+        assert!(result.discard.contains(&0));
     }
 
     // ===== audit#710 gap 5: chain_id =========================================
@@ -1598,10 +1657,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "1559 tx with wrong chain_id must be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "1559 tx with wrong chain_id must be discarded");
+        assert!(result.discard.contains(&0));
     }
 
     /// Legacy tx with explicit `chain_id` that doesn't match config is rejected.
@@ -1624,10 +1683,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "legacy tx with chain_id=Some(2) must be discarded");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "legacy tx with chain_id=Some(2) must be discarded");
+        assert!(result.discard.contains(&0));
     }
 
     /// Boundary: legacy pre-EIP-155 tx (`chain_id = None`) is accepted — matches
@@ -1651,11 +1710,11 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            invalid_idxs.is_empty(),
-            "pre-EIP-155 legacy tx must pass the chain-id gate: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "pre-EIP-155 legacy tx must pass the chain-id gate: {result:?}"
         );
     }
 
@@ -1688,11 +1747,11 @@ mod tests {
         let txs = vec![tx1, tx2];
         let senders = vec![sender, sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 2, "all txs from coded sender must be discarded");
-        assert!(invalid_idxs.contains(&0));
-        assert!(invalid_idxs.contains(&1));
+        assert_eq!(result.discard.len(), 2, "all txs from coded sender must be discarded");
+        assert!(result.discard.contains(&0));
+        assert!(result.discard.contains(&1));
     }
 
     /// EIP-3607 delegation exception (lockdown OFF / Beta active): sender whose code
@@ -1709,7 +1768,7 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1720,8 +1779,8 @@ mod tests {
             0,
         );
         assert!(
-            invalid_idxs.is_empty(),
-            "tx from EIP-7702-delegated sender must pass post-Beta: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "tx from EIP-7702-delegated sender must pass post-Beta: {result:?}"
         );
     }
 
@@ -1749,14 +1808,10 @@ mod tests {
         let senders = vec![sender];
 
         // Default prague_chain_spec has no betaTime → lockdown ON.
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(
-            invalid_idxs.len(),
-            1,
-            "L1 must wholesale-reject type-4 pre-Beta: {invalid_idxs:?}"
-        );
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "L1 must wholesale-reject type-4 pre-Beta: {result:?}");
+        assert!(result.discard.contains(&0));
     }
 
     /// L1 post-Beta: same type-4 with sufficient gas is admitted once Beta is active.
@@ -1779,7 +1834,7 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs = filter_invalid_txs(
+        let result = filter_invalid_txs(
             &db,
             &txs,
             &senders,
@@ -1789,7 +1844,7 @@ mod tests {
             0,
             0,
         );
-        assert!(invalid_idxs.is_empty(), "type-4 at floor must pass post-Beta: {invalid_idxs:?}");
+        assert!(result.discard.is_empty(), "type-4 at floor must pass post-Beta: {result:?}");
     }
 
     /// Fork boundary: betaTime = T; block_timestamp T-1 rejects type-4, T accepts.
@@ -1816,11 +1871,11 @@ mod tests {
 
         let pre =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &chain_spec, BETA_TIME - 1, 0);
-        assert_eq!(pre.len(), 1, "T-1 must still be under lockdown: {pre:?}");
-        assert!(pre.contains(&0));
+        assert_eq!(pre.discard.len(), 1, "T-1 must still be under lockdown: {pre:?}");
+        assert!(pre.discard.contains(&0));
 
         let at = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &chain_spec, BETA_TIME, 0);
-        assert!(at.is_empty(), "T must release lockdown: {at:?}");
+        assert!(at.discard.is_empty(), "T must release lockdown: {at:?}");
     }
 
     /// L2: under lockdown a tx FROM a delegated account is dropped.
@@ -1835,14 +1890,14 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            invalid_idxs.len(),
+            result.discard.len(),
             1,
-            "7702-lockdown L2 must drop a tx from a delegated sender: {invalid_idxs:?}"
+            "7702-lockdown L2 must drop a tx from a delegated sender: {result:?}"
         );
-        assert!(invalid_idxs.contains(&0));
+        assert!(result.discard.contains(&0));
     }
 
     /// L3: under lockdown a tx TO a delegated account is dropped.
@@ -1867,14 +1922,14 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![caller];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            invalid_idxs.len(),
+            result.discard.len(),
             1,
-            "7702-lockdown L3 must drop a tx to a delegated recipient: {invalid_idxs:?}"
+            "7702-lockdown L3 must drop a tx to a delegated recipient: {result:?}"
         );
-        assert!(invalid_idxs.contains(&0));
+        assert!(result.discard.contains(&0));
     }
 
     /// audit#838 attack shape: [funder→A, A@nonce] — both dropped under lockdown
@@ -1901,14 +1956,14 @@ mod tests {
         let txs = vec![x, a_at_m];
         let senders = vec![funder, a];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            invalid_idxs.len(),
+            result.discard.len(),
             2,
-            "both legs of the audit#838 attack shape must be dropped: {invalid_idxs:?}"
+            "both legs of the audit#838 attack shape must be dropped: {result:?}"
         );
-        assert!(invalid_idxs.contains(&0) && invalid_idxs.contains(&1));
+        assert!(result.discard.contains(&0) && result.discard.contains(&1));
     }
 
     /// Lockdown precision: non-delegated traffic (ordinary contract recipient) is
@@ -1943,11 +1998,11 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            invalid_idxs.is_empty(),
-            "non-delegated traffic must be unaffected by the 7702 lockdown: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "non-delegated traffic must be unaffected by the 7702 lockdown: {result:?}"
         );
     }
 
@@ -1984,11 +2039,11 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
         assert!(
-            invalid_idxs.is_empty(),
-            "30M tx at the cap boundary must pass under Osaka: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "30M tx at the cap boundary must pass under Osaka: {result:?}"
         );
     }
 
@@ -2012,10 +2067,10 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "tx above the 30M cap must be discarded under Osaka");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "tx above the 30M cap must be discarded under Osaka");
+        assert!(result.discard.contains(&0));
     }
 
     /// The gate is OSAKA-gated: the same over-cap tx passes under Prague (no per-tx cap exists
@@ -2039,11 +2094,11 @@ mod tests {
         let txs = vec![tx];
         let senders = vec![sender];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            invalid_idxs.is_empty(),
-            "pre-Osaka has no per-tx gas cap, over-cap tx must pass: {invalid_idxs:?}"
+            result.discard.is_empty(),
+            "pre-Osaka has no per-tx gas cap, over-cap tx must pass: {result:?}"
         );
     }
 
@@ -2072,9 +2127,96 @@ mod tests {
         let txs = vec![tx_a, tx_b];
         let senders = vec![sender_a, sender_b];
 
-        let invalid_idxs =
+        let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
-        assert_eq!(invalid_idxs.len(), 1, "only sender A's over-cap tx must be dropped");
-        assert!(invalid_idxs.contains(&0));
+        assert_eq!(result.discard.len(), 1, "only sender A's over-cap tx must be dropped");
+        assert!(result.discard.contains(&0));
+    }
+
+    /// audit#646: gas is the last gate. An invalid early tx must not consume block gas
+    /// budget, so a later valid tx that still fits is included (not prefix-cut / discarded).
+    #[test]
+    fn test_filter_invalid_txs_invalid_does_not_steal_gas_budget() {
+        let mut db = MockDatabase::new();
+        let sender_a = Address::random();
+        let sender_b = Address::random();
+        for s in [sender_a, sender_b] {
+            db.insert_account(
+                s,
+                AccountInfo {
+                    balance: U256::from(1_000_000_000_000_000_000u64),
+                    nonce: 0,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                },
+            );
+        }
+
+        // Order: valid 10M, invalid (wrong nonce) claiming 25M, valid 5M from another sender.
+        // Budget 30M. Old prefix-cut would stop at idx1 (10+25>30) and discard idx1+idx2.
+        // New: idx1 discarded for nonce, does not consume gas; idx2 packs (10+5 <= 30).
+        let tx0 = create_test_transaction(0, 10_000_000, 25_000_000_000);
+        let tx1 = create_test_transaction(9, 25_000_000, 25_000_000_000); // bad nonce
+        let tx2 = create_test_transaction(0, 5_000_000, 25_000_000_000);
+        let txs = vec![tx0, tx1, tx2];
+        let senders = vec![sender_a, sender_a, sender_b];
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
+        assert_eq!(result.discard.len(), 1);
+        assert!(result.discard.contains(&1));
+        assert!(result.defer.is_empty(), "later valid tx must pack, not defer: {result:?}");
+    }
+
+    /// audit#646: continue packing smaller txs after a large one does not fit remaining gas.
+    #[test]
+    fn test_filter_invalid_txs_continues_packing_after_gas_skip() {
+        let mut db = MockDatabase::new();
+        let sender_big = Address::random();
+        let sender_small = Address::random();
+        for s in [sender_big, sender_small] {
+            db.insert_account(
+                s,
+                AccountInfo {
+                    balance: U256::from(1_000_000_000_000_000_000u64),
+                    nonce: 0,
+                    code_hash: KECCAK_EMPTY,
+                    code: None,
+                    account_id: None,
+                },
+            );
+        }
+
+        // Budget 30M: pack 20M, skip next same-sender 20M (defer), still pack 5M from
+        // another sender under the remaining 10M.
+        let tx0 = create_test_transaction(0, 20_000_000, 25_000_000_000);
+        let tx1 = create_test_transaction(1, 20_000_000, 25_000_000_000);
+        let tx2 = create_test_transaction(0, 5_000_000, 25_000_000_000);
+        let txs = vec![tx0, tx1, tx2];
+        let senders = vec![sender_big, sender_big, sender_small];
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &prague_chain_spec(),
+            0,
+            0,
+        );
+        assert!(result.discard.is_empty(), "{result:?}");
+        assert_eq!(result.defer.len(), 1);
+        assert!(result.defer.contains(&1));
+        assert!(!result.defer.contains(&2), "small later tx must pack: {result:?}");
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -87,7 +87,9 @@ use tracing::info;
 ///   from the first overflow through the end is discarded.
 /// - **Beta+:** admission + in-block state sim first, then gas as the **last** gate. Invalid txs
 ///   never consume budget; packing continues after a non-fit (later smaller txs may still enter the
-///   body). Non-fitting / same-sender-blocked txs are still **discarded**.
+///   body). Non-fitting txs are still **discarded**. Same-sender higher nonces then fail the
+///   simulated nonce check (`sim` is only advanced after gas admits the tx) and discard the same
+///   way — no separate sender-block set.
 ///
 /// `chain_spec`, `block_timestamp`, `block_number` are taken instead of a
 /// pre-computed `SpecId` because the only consumer of `spec_id` here is the
@@ -146,7 +148,10 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     }
 
     let cfg_chain_id = chain_spec.chain_id();
-    let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &mut AccountInfo| {
+    // Read-only admission checks against the current simulated account. Does **not** mutate
+    // `sim` — caller sim (nonce/balance) and 7702 auth bumps are applied only after every
+    // gate including Beta+ block-gas has passed, so gas non-fits never need rollback.
+    let is_tx_valid = |tx: &TransactionSigned, sender: &Address, account: &AccountInfo| -> bool {
         if account.nonce != tx.nonce() {
             info!(target: "filter_invalid_txs",
                 tx_hash=?tx.hash(),
@@ -323,8 +328,8 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         // refunded post-execution). The filter must check against the same worst-case
         // bound, otherwise a tx where `effective < max_fee` and `balance < max * limit`
         // would pass here and panic in revm with `LackOfFundForMaxFee`. Closes audit#710
-        // gap 4. The per-sender simulated balance is then reduced by the *effective*
-        // cost so subsequent txs from the same sender see what revm sees post-refund.
+        // gap 4. Sim balance is reduced by *effective* cost only in `apply_caller_to_sim`
+        // after this tx is fully admitted (including gas).
         //
         // The `saturating_*` arithmetic below is also load-bearing for a second revm variant:
         // `validate_against_state_and_deduct_caller` calls `tx.max_balance_spending()`
@@ -347,12 +352,17 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             );
             return false;
         }
+        true
+    };
+
+    // Commit caller nonce/balance into `sim` after admission + gas gates. Uses effective
+    // gas price so subsequent same-sender txs see what revm sees post-refund.
+    let apply_caller_to_sim = |tx: &TransactionSigned, account: &mut AccountInfo| {
         let gas_spent = U256::from(tx.effective_gas_price(Some(base_fee_per_gas)))
             .saturating_mul(U256::from(tx.gas_limit()));
         let total_spent = gas_spent.saturating_add(tx.value());
         account.balance -= total_spent;
         account.nonce += 1;
-        true
     };
 
     // `true` if the account's code is empty or a valid EIP-7702 delegation designator —
@@ -399,31 +409,23 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     // block order. The per-tx guards are cheap; the extra `recover_authority()` ECDSA
     // recovery runs only for type-4 txs.
     //
-    // Beta+ (`gas_last_gate`): block gas is the **last** gate after admission + sim —
+    // Beta+ (`gas_last_gate`): block gas is the **last** gate after admission —
     // invalid txs do not consume budget; packing continues after a non-fit (audit#646).
     // Non-fitting txs are still discarded (pool remove). Pre-Beta: only the gas prefix is
     // walked; suffix indices are discarded below.
+    //
+    // `sim` is written only after admission + gas both pass (see `apply_caller_to_sim`
+    // below). Gas non-fits therefore leave sender nonce/balance unchanged; higher nonces
+    // fail the exact-nonce check and discard, while a same-nonce smaller replacement that
+    // fits may still pack.
     let mut sim: HashMap<Address, Option<AccountInfo>> = HashMap::default();
     let mut invalid_tx_idxs: HashSet<usize> = HashSet::default();
-    // Senders whose next in-block nonce was gas-excluded (Beta+ only): later same-sender
-    // txs cannot execute without a nonce gap — discard them too (not keep-in-pool).
-    let mut gas_blocked_senders: HashSet<Address> = HashSet::default();
     let mut remaining_gas = gas_limit;
 
     let walk_end = if gas_last_gate { txs.len() } else { gas_limit_exceeded_tx_idx };
     for idx in 0..walk_end {
         let tx = &txs[idx];
         let sender = senders[idx];
-
-        if gas_last_gate && gas_blocked_senders.contains(&sender) {
-            info!(target: "filter_invalid_txs",
-                tx_hash=?tx.hash(),
-                sender=?sender,
-                "discarded: same-sender predecessor excluded by block gas budget"
-            );
-            invalid_tx_idxs.insert(idx);
-            continue;
-        }
 
         // EMERGENCY EIP-7702 LOCKDOWN — L3 (pre-Beta): drop any tx whose recipient is a
         // currently-delegated account, so no inbound CALL can trigger the callee's
@@ -448,16 +450,11 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             }
         }
 
-        // Validate the tx against the simulated sender account and apply the caller nonce
-        // bump + balance deduction. Scoped so the `sim[sender]` borrow is released before
-        // the authorization loop re-borrows `sim` (an authority may be any account).
-        // On success the sim account is mutated; if we later exclude for gas (Beta+) we
-        // must roll that mutation back so a same-sender follow-up still sees the pre-tx
-        // account before we discard it too.
-        let sender_snapshot = sim.get(&sender).cloned();
+        // Read-only admission against simulated sender. Seeding `sim` from DB is fine
+        // (cache only); nonce/balance are not advanced until every gate passes.
         let valid = {
             let sender_acct = sim.entry(sender).or_insert_with(|| db.basic_ref(sender).unwrap());
-            match sender_acct.as_mut() {
+            match sender_acct.as_ref() {
                 // Sender absent from state -> cannot pay for / originate the tx.
                 None => false,
                 Some(account) => {
@@ -480,7 +477,6 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                         );
                         false
                     } else {
-                        // Mutates `account` (caller nonce bump + balance deduct) on success.
                         is_tx_valid(tx, &sender, account)
                     }
                 }
@@ -493,6 +489,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
 
         // Beta+: last gate is block gas (worst-case `tx.gas_limit()`). Still discards.
         // Pre-Beta: prefix already guaranteed to fit; no re-check.
+        // Checked before any sim write so a non-fit never touches sender state.
         if gas_last_gate {
             let tx_gas = tx.gas_limit();
             if tx_gas > remaining_gas {
@@ -504,20 +501,19 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                     block_gas_limit=?gas_limit,
                     "discarded: tx does not fit remaining block gas budget"
                 );
-                // Roll back the optimistic sim mutation from `is_tx_valid`.
-                match sender_snapshot {
-                    Some(prev) => {
-                        sim.insert(sender, prev);
-                    }
-                    None => {
-                        sim.remove(&sender);
-                    }
-                }
                 invalid_tx_idxs.insert(idx);
-                gas_blocked_senders.insert(sender);
                 continue;
             }
             remaining_gas -= tx_gas;
+        }
+
+        // Fully admitted: advance caller sim, then 7702 authority nonces.
+        // Scoped so `sim[sender]` is released before the auth loop re-borrows `sim`.
+        {
+            let sender_acct = sim.get_mut(&sender).expect("sender seeded during admission");
+            if let Some(account) = sender_acct.as_mut() {
+                apply_caller_to_sim(tx, account);
+            }
         }
 
         // Mirror revm `apply_auth_list`: for a type-4 tx every valid authorization bumps
@@ -2308,8 +2304,8 @@ mod tests {
             );
         }
 
-        // Budget 30M: pack 20M, discard next same-sender 20M, still pack 5M from
-        // another sender under the remaining 10M.
+        // Budget 30M: pack 20M, discard same-sender nonce-1 20M (gas), still pack 5M
+        // from another sender under remaining 10M.
         let tx0 = create_test_transaction(0, 20_000_000, 25_000_000_000);
         let tx1 = create_test_transaction(1, 20_000_000, 25_000_000_000);
         let tx2 = create_test_transaction(0, 5_000_000, 25_000_000_000);
@@ -2329,6 +2325,84 @@ mod tests {
         assert_eq!(result.len(), 1, "{result:?}");
         assert!(result.contains(&1));
         assert!(!result.contains(&2), "small later tx must pack: {result:?}");
+    }
+
+    /// After a gas non-fit, sim was never advanced: a later same-nonce smaller replacement
+    /// that fits must pack (no sender-wide gas block list).
+    #[test]
+    fn test_filter_invalid_txs_same_nonce_smaller_replacement_packs_after_gas_skip() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        // Budget 30M: pack 20M (nonce 0); 20M nonce-1 does not fit; smaller 5M nonce-1 packs.
+        let tx0 = create_test_transaction(0, 20_000_000, 25_000_000_000);
+        let tx1 = create_test_transaction(1, 20_000_000, 25_000_000_000);
+        let tx2 = create_test_transaction(1, 5_000_000, 25_000_000_000);
+        let txs = vec![tx0, tx1, tx2];
+        let senders = vec![sender, sender, sender];
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert_eq!(result.len(), 1, "{result:?}");
+        assert!(result.contains(&1), "large nonce-1 discarded for gas: {result:?}");
+        assert!(!result.contains(&2), "smaller same-nonce replacement must pack: {result:?}");
+    }
+
+    /// Higher nonces after a gas non-fit still discard via simulated nonce mismatch
+    /// (`apply_caller_to_sim` never ran for the skipped nonce).
+    #[test]
+    fn test_filter_invalid_txs_higher_nonce_discards_after_gas_skip() {
+        let mut db = MockDatabase::new();
+        let sender = Address::random();
+        db.insert_account(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000u64),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: None,
+                account_id: None,
+            },
+        );
+
+        // Budget 30M: pack 20M; nonce-1 20M gas-skip (sim unchanged); nonce-2 fails nonce check.
+        let tx0 = create_test_transaction(0, 20_000_000, 25_000_000_000);
+        let tx1 = create_test_transaction(1, 20_000_000, 25_000_000_000);
+        let tx2 = create_test_transaction(2, 5_000_000, 25_000_000_000);
+        let txs = vec![tx0, tx1, tx2];
+        let senders = vec![sender, sender, sender];
+
+        let result = filter_invalid_txs(
+            &db,
+            &txs,
+            &senders,
+            20_000_000_000u64,
+            30_000_000u64,
+            &prague_chain_spec_with_beta(),
+            0,
+            0,
+        );
+        assert_eq!(result.len(), 2, "{result:?}");
+        assert!(result.contains(&1), "nonce-1 gas non-fit: {result:?}");
+        assert!(result.contains(&2), "nonce-2 discarded via nonce gap: {result:?}");
     }
 
     /// Fork boundary: betaTime = T; both sides discard non-fit, but packing differs

--- a/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/tx_filter.rs
@@ -72,23 +72,11 @@ use revm::state::AccountInfo;
 use revm_primitives::{eip3860::MAX_INITCODE_SIZE, hardfork::SpecId};
 use tracing::info;
 
-/// Outcome of pre-execution filtering for one ordered block.
+/// Return the discarded transaction indexes (not included in the block body).
 ///
-/// - [`Self::discard`]: validation failures — remove from the local pool and report `is_discarded`
-///   to consensus. Pre-Beta, gas prefix-cut suffixes also land here (legacy STF).
-/// - [`Self::defer`]: **Beta+ only.** Otherwise-valid txs that do not fit the remaining block gas
-///   budget (or depend on a same-sender gas-deferred predecessor). Excluded from this block body
-///   but **kept** in the pool for a later block (audit#646).
-/// - Neither set: include in the block in original relative order.
-#[derive(Debug, Default, Clone)]
-pub(crate) struct TxFilterResult {
-    /// Indices of txs that failed validation and must be discarded from the pool.
-    pub discard: HashSet<usize>,
-    /// Indices of valid txs skipped only for block-gas packing (Beta+).
-    pub defer: HashSet<usize>,
-}
-
-/// Filter ordered txs before grevm execution.
+/// All returned indices are pool discards (`is_discarded` + `discard_txs` channel).
+/// There is no keep-in-pool "defer" outcome in this release — gas packing exclusions
+/// still discard so SDK `TxnStatus.is_discarded` stays a faithful two-state signal.
 ///
 /// Walks the ordered list **serially** (required for EIP-7702 cross-account auth
 /// nonce simulation).
@@ -96,11 +84,10 @@ pub(crate) struct TxFilterResult {
 /// ## Block-gas packing (audit#646) — gated by [`is_block_gas_last_gate_active`] / Beta
 ///
 /// - **Pre-Beta (legacy STF):** prefix-cut on cumulative worst-case `tx.gas_limit()`; every index
-///   from the first overflow through the end is **discarded**. This matches historical Gravity
-///   behaviour and must not change without a hardfork.
+///   from the first overflow through the end is discarded.
 /// - **Beta+:** admission + in-block state sim first, then gas as the **last** gate. Invalid txs
-///   never consume budget; non-fitting valid txs are **deferred** (pool kept) and later smaller txs
-///   from other senders may still pack.
+///   never consume budget; packing continues after a non-fit (later smaller txs may still enter the
+///   body). Non-fitting / same-sender-blocked txs are still **discarded**.
 ///
 /// `chain_spec`, `block_timestamp`, `block_number` are taken instead of a
 /// pre-computed `SpecId` because the only consumer of `spec_id` here is the
@@ -126,7 +113,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     chain_spec: &ChainSpec,
     block_timestamp: u64,
     block_number: u64,
-) -> TxFilterResult {
+) -> HashSet<usize> {
     let eip7702_lockdown = is_eip7702_lockdown_active(chain_spec, block_timestamp);
     // Consensus-critical packing change: only after Beta (same gate as 7702 lockdown release).
     let gas_last_gate = is_block_gas_last_gate_active(chain_spec, block_timestamp);
@@ -413,11 +400,13 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     // recovery runs only for type-4 txs.
     //
     // Beta+ (`gas_last_gate`): block gas is the **last** gate after admission + sim —
-    // invalid txs do not consume budget; non-fitting valid txs are deferred (audit#646).
-    // Pre-Beta: only the gas prefix is walked; suffix indices are discarded below.
+    // invalid txs do not consume budget; packing continues after a non-fit (audit#646).
+    // Non-fitting txs are still discarded (pool remove). Pre-Beta: only the gas prefix is
+    // walked; suffix indices are discarded below.
     let mut sim: HashMap<Address, Option<AccountInfo>> = HashMap::default();
-    let mut result = TxFilterResult::default();
-    // Senders whose next in-block nonce was gas-deferred (Beta+ only).
+    let mut invalid_tx_idxs: HashSet<usize> = HashSet::default();
+    // Senders whose next in-block nonce was gas-excluded (Beta+ only): later same-sender
+    // txs cannot execute without a nonce gap — discard them too (not keep-in-pool).
     let mut gas_blocked_senders: HashSet<Address> = HashSet::default();
     let mut remaining_gas = gas_limit;
 
@@ -430,9 +419,9 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             info!(target: "filter_invalid_txs",
                 tx_hash=?tx.hash(),
                 sender=?sender,
-                "deferred: same-sender predecessor excluded by block gas budget"
+                "discarded: same-sender predecessor excluded by block gas budget"
             );
-            result.defer.insert(idx);
+            invalid_tx_idxs.insert(idx);
             continue;
         }
 
@@ -454,7 +443,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                     to=?to,
                     "7702-lockdown: tx to delegated account rejected (audit#838)"
                 );
-                result.discard.insert(idx);
+                invalid_tx_idxs.insert(idx);
                 continue;
             }
         }
@@ -462,8 +451,9 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
         // Validate the tx against the simulated sender account and apply the caller nonce
         // bump + balance deduction. Scoped so the `sim[sender]` borrow is released before
         // the authorization loop re-borrows `sim` (an authority may be any account).
-        // On success the sim account is mutated; if we later defer for gas (Beta+) we must
-        // roll that mutation back so a same-sender follow-up still sees the pre-tx account.
+        // On success the sim account is mutated; if we later exclude for gas (Beta+) we
+        // must roll that mutation back so a same-sender follow-up still sees the pre-tx
+        // account before we discard it too.
         let sender_snapshot = sim.get(&sender).cloned();
         let valid = {
             let sender_acct = sim.entry(sender).or_insert_with(|| db.basic_ref(sender).unwrap());
@@ -497,11 +487,11 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
             }
         };
         if !valid {
-            result.discard.insert(idx);
+            invalid_tx_idxs.insert(idx);
             continue;
         }
 
-        // Beta+: last gate is block gas (worst-case `tx.gas_limit()`). Does not discard.
+        // Beta+: last gate is block gas (worst-case `tx.gas_limit()`). Still discards.
         // Pre-Beta: prefix already guaranteed to fit; no re-check.
         if gas_last_gate {
             let tx_gas = tx.gas_limit();
@@ -512,7 +502,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                     tx_gas_limit=?tx_gas,
                     remaining_gas=?remaining_gas,
                     block_gas_limit=?gas_limit,
-                    "deferred: tx does not fit remaining block gas budget"
+                    "discarded: tx does not fit remaining block gas budget"
                 );
                 // Roll back the optimistic sim mutation from `is_tx_valid`.
                 match sender_snapshot {
@@ -523,7 +513,7 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
                         sim.remove(&sender);
                     }
                 }
-                result.defer.insert(idx);
+                invalid_tx_idxs.insert(idx);
                 gas_blocked_senders.insert(sender);
                 continue;
             }
@@ -568,11 +558,11 @@ pub(crate) fn filter_invalid_txs<DB: ParallelDatabase>(
     }
 
     // Pre-Beta legacy: every index from the cumulative-gas cutoff through the end is
-    // discarded (not deferred). Post-Beta never sets a cutoff short of `txs.len()`.
+    // discarded. Post-Beta never sets a cutoff short of `txs.len()`.
     if !gas_last_gate {
-        result.discard.extend(gas_limit_exceeded_tx_idx..txs.len());
+        invalid_tx_idxs.extend(gas_limit_exceeded_tx_idx..txs.len());
     }
-    result
+    invalid_tx_idxs
 }
 
 #[cfg(test)]
@@ -788,7 +778,7 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty());
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -813,8 +803,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 1);
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&0));
     }
 
     #[test]
@@ -849,8 +839,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 1);
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&0));
     }
 
     #[test]
@@ -888,9 +878,9 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 2);
-        assert!(result.discard.contains(&0));
-        assert!(result.discard.contains(&2));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&0));
+        assert!(result.contains(&2));
     }
 
     /// Pre-Beta (legacy STF): cumulative gas overflow discards the suffix.
@@ -926,14 +916,13 @@ mod tests {
             0,
             0,
         );
-        assert!(result.defer.is_empty(), "pre-Beta must not defer: {result:?}");
-        assert_eq!(result.discard.len(), 1);
-        assert!(result.discard.contains(&1));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&1));
     }
 
-    /// Beta+ (audit#646): non-fitting valid tx is deferred (kept in pool), not discarded.
+    /// Beta+ (audit#646): gas-last packing still discards the non-fitting tx (no defer).
     #[test]
-    fn test_filter_invalid_txs_gas_limit_exceeded_post_beta_defers() {
+    fn test_filter_invalid_txs_gas_limit_exceeded_post_beta_discards_nonfit() {
         let mut db = MockDatabase::new();
         let sender = Address::random();
 
@@ -961,16 +950,15 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty(), "gas overflow must not discard post-Beta: {result:?}");
-        assert_eq!(result.defer.len(), 1);
-        assert!(result.defer.contains(&1));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&1));
     }
 
     // Models the `create_block_for_executor` byzantine path from gravity-audit#621 Fix A:
     // when `sum_system_gas ≥ block.gas_limit`, the call site's `saturating_sub` collapses
     // the user-tx budget to 0, and the filter must exclude *every* user tx — otherwise
     // `header.gas_used > header.gas_limit` once system-txn receipts are appended.
-    // Pre-Beta: discard. Post-Beta: defer (pool-safe).
+    // Both pre/post-Beta discard (this release has no keep-in-pool defer).
     #[test]
     fn test_filter_invalid_txs_zero_budget_drops_all_pre_beta() {
         let mut db = MockDatabase::new();
@@ -1001,14 +989,13 @@ mod tests {
             0,
             0,
         );
-        assert!(result.defer.is_empty(), "{result:?}");
-        assert_eq!(result.discard.len(), 2);
-        assert!(result.discard.contains(&0));
-        assert!(result.discard.contains(&1));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&0));
+        assert!(result.contains(&1));
     }
 
     #[test]
-    fn test_filter_invalid_txs_zero_budget_defers_all_post_beta() {
+    fn test_filter_invalid_txs_zero_budget_drops_all_post_beta() {
         let mut db = MockDatabase::new();
         let sender = Address::random();
         db.insert_account(
@@ -1037,13 +1024,9 @@ mod tests {
             0,
             0,
         );
-        assert!(
-            result.discard.is_empty(),
-            "zero budget must not wipe the pool post-Beta: {result:?}"
-        );
-        assert_eq!(result.defer.len(), 2);
-        assert!(result.defer.contains(&0));
-        assert!(result.defer.contains(&1));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&0));
+        assert!(result.contains(&1));
     }
 
     #[test]
@@ -1079,7 +1062,7 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty());
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -1143,15 +1126,14 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 5, "discard: {result:?}");
-        assert!(result.discard.contains(&1));
-        assert!(result.discard.contains(&2));
-        assert!(result.discard.contains(&4));
-        assert!(result.discard.contains(&5));
-        assert!(result.discard.contains(&6));
-        assert!(result.defer.is_empty());
+        assert_eq!(result.len(), 5, "discard: {result:?}");
+        assert!(result.contains(&1));
+        assert!(result.contains(&2));
+        assert!(result.contains(&4));
+        assert!(result.contains(&5));
+        assert!(result.contains(&6));
 
-        // Post-Beta: validation discards only; gas defers idx5; idx6 still packs.
+        // Post-Beta: validation discards + gas-discards idx5; idx6 still packs.
         let result_beta = filter_invalid_txs(
             &db,
             &txs,
@@ -1162,15 +1144,12 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result_beta.discard.len(), 3, "discard: {result_beta:?}");
-        assert!(result_beta.discard.contains(&1));
-        assert!(result_beta.discard.contains(&2));
-        assert!(result_beta.discard.contains(&4));
-        assert!(result_beta.defer.contains(&5), "30M tx deferred for gas: {result_beta:?}");
-        assert!(
-            !result_beta.discard.contains(&6) && !result_beta.defer.contains(&6),
-            "later small valid tx must still pack post-Beta: {result_beta:?}"
-        );
+        assert_eq!(result_beta.len(), 4, "discard: {result_beta:?}");
+        assert!(result_beta.contains(&1));
+        assert!(result_beta.contains(&2));
+        assert!(result_beta.contains(&4));
+        assert!(result_beta.contains(&5), "30M tx discarded for gas: {result_beta:?}");
+        assert!(!result_beta.contains(&6), "later small valid tx must still pack: {result_beta:?}");
     }
 
     /// Regression: a type-0x04 tx whose `gas_limit` is below `21000 + PER_EMPTY_ACCOUNT_COST * N`
@@ -1209,8 +1188,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 1, "intrinsic-gas-too-low 7702 tx should be discarded");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "intrinsic-gas-too-low 7702 tx should be discarded");
+        assert!(result.contains(&0));
     }
 
     /// Sanity check (lockdown OFF / Beta active): same 7702 tx with a `gas_limit` at or
@@ -1248,7 +1227,7 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty(), "got: {result:?}");
+        assert!(result.is_empty(), "got: {result:?}");
     }
 
     /// U-1 (acceptance design §3.1, lockdown OFF / Beta active): a 7702 tx with
@@ -1282,10 +1261,7 @@ mod tests {
             0,
             0,
         );
-        assert!(
-            result.discard.is_empty(),
-            "two-auth 7702 tx with 72k gas must pass post-Beta: {result:?}"
-        );
+        assert!(result.is_empty(), "two-auth 7702 tx with 72k gas must pass post-Beta: {result:?}");
     }
 
     /// U-2 (acceptance design §3.1): a 7702 tx with three authorizations and
@@ -1311,8 +1287,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "three-auth 7702 tx at 21k gas must be discarded");
+        assert!(result.contains(&0));
     }
 
     /// Pre-Prague boundary (acceptance design P-2): a TxEip7702 with otherwise-fine intrinsic
@@ -1343,8 +1319,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &shanghai_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "7702 tx must be discarded when spec_id < PRAGUE");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "7702 tx must be discarded when spec_id < PRAGUE");
+        assert!(result.contains(&0));
     }
 
     /// U-3 (acceptance design §3.1): the #668 fix must not regress legacy/1559 filtering.
@@ -1372,7 +1348,7 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            result.discard.is_empty(),
+            result.is_empty(),
             "legacy 21k-gas tx must not be regressed by the 7702 intrinsic fix: {result:?}"
         );
     }
@@ -1442,8 +1418,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "type-3 (blob) tx must be discarded on Gravity");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "type-3 (blob) tx must be discarded on Gravity");
+        assert!(result.contains(&0));
     }
 
     /// gravity-audit#696 trigger 4: a Create tx with init code larger than
@@ -1473,11 +1449,11 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            result.discard.len(),
+            result.len(),
             1,
             "Create tx with init_code.len() > MAX_INITCODE_SIZE must be discarded"
         );
-        assert!(result.discard.contains(&0));
+        assert!(result.contains(&0));
     }
 
     /// Boundary: a Create tx with `input.len() == MAX_INITCODE_SIZE` is within EIP-3860
@@ -1508,7 +1484,7 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 10_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            result.discard.is_empty(),
+            result.is_empty(),
             "Create tx at exactly MAX_INITCODE_SIZE must pass the size gate: {result:?}"
         );
     }
@@ -1612,12 +1588,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(
-            result.discard.len(),
-            1,
-            "legacy tx with gas_price < base_fee must be discarded"
-        );
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "legacy tx with gas_price < base_fee must be discarded");
+        assert!(result.contains(&0));
     }
 
     /// 1559 tx whose `max_fee_per_gas` is below the prevailing base fee must be
@@ -1652,8 +1624,8 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 1, "1559 tx with max_fee < base_fee must be discarded");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "1559 tx with max_fee < base_fee must be discarded");
+        assert!(result.contains(&0));
     }
 
     // ===== audit#710 gap 2: priority > max =====================================
@@ -1682,8 +1654,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "1559 tx with prio > max must be discarded");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "1559 tx with prio > max must be discarded");
+        assert!(result.contains(&0));
     }
 
     // ===== audit#710 gap 3: 7702 empty authorization_list ======================
@@ -1713,12 +1685,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(
-            result.discard.len(),
-            1,
-            "7702 tx with empty authorization_list must be discarded"
-        );
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "7702 tx with empty authorization_list must be discarded");
+        assert!(result.contains(&0));
     }
 
     // ===== audit#710 gap 4: balance must use max_fee, not effective ============
@@ -1764,11 +1732,11 @@ mod tests {
             0,
         );
         assert_eq!(
-            result.discard.len(),
+            result.len(),
             1,
             "balance covers effective but not max — must be discarded by max-fee gate"
         );
-        assert!(result.discard.contains(&0));
+        assert!(result.contains(&0));
     }
 
     // ===== audit#710 gap 5: chain_id =========================================
@@ -1796,8 +1764,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "1559 tx with wrong chain_id must be discarded");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "1559 tx with wrong chain_id must be discarded");
+        assert!(result.contains(&0));
     }
 
     /// Legacy tx with explicit `chain_id` that doesn't match config is rejected.
@@ -1822,8 +1790,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "legacy tx with chain_id=Some(2) must be discarded");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "legacy tx with chain_id=Some(2) must be discarded");
+        assert!(result.contains(&0));
     }
 
     /// Boundary: legacy pre-EIP-155 tx (`chain_id = None`) is accepted — matches
@@ -1849,10 +1817,7 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert!(
-            result.discard.is_empty(),
-            "pre-EIP-155 legacy tx must pass the chain-id gate: {result:?}"
-        );
+        assert!(result.is_empty(), "pre-EIP-155 legacy tx must pass the chain-id gate: {result:?}");
     }
 
     // ===== audit#710 gap 6: EIP-3607 (sender has code) =========================
@@ -1886,9 +1851,9 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 2, "all txs from coded sender must be discarded");
-        assert!(result.discard.contains(&0));
-        assert!(result.discard.contains(&1));
+        assert_eq!(result.len(), 2, "all txs from coded sender must be discarded");
+        assert!(result.contains(&0));
+        assert!(result.contains(&1));
     }
 
     /// EIP-3607 delegation exception (lockdown OFF / Beta active): sender whose code
@@ -1916,7 +1881,7 @@ mod tests {
             0,
         );
         assert!(
-            result.discard.is_empty(),
+            result.is_empty(),
             "tx from EIP-7702-delegated sender must pass post-Beta: {result:?}"
         );
     }
@@ -1947,8 +1912,8 @@ mod tests {
         // Default prague_chain_spec has no betaTime → lockdown ON.
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "L1 must wholesale-reject type-4 pre-Beta: {result:?}");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "L1 must wholesale-reject type-4 pre-Beta: {result:?}");
+        assert!(result.contains(&0));
     }
 
     /// L1 post-Beta: same type-4 with sufficient gas is admitted once Beta is active.
@@ -1981,7 +1946,7 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty(), "type-4 at floor must pass post-Beta: {result:?}");
+        assert!(result.is_empty(), "type-4 at floor must pass post-Beta: {result:?}");
     }
 
     /// Fork boundary: betaTime = T; block_timestamp T-1 rejects type-4, T accepts.
@@ -2008,11 +1973,11 @@ mod tests {
 
         let pre =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &chain_spec, BETA_TIME - 1, 0);
-        assert_eq!(pre.discard.len(), 1, "T-1 must still be under lockdown: {pre:?}");
-        assert!(pre.discard.contains(&0));
+        assert_eq!(pre.len(), 1, "T-1 must still be under lockdown: {pre:?}");
+        assert!(pre.contains(&0));
 
         let at = filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &chain_spec, BETA_TIME, 0);
-        assert!(at.discard.is_empty(), "T must release lockdown: {at:?}");
+        assert!(at.is_empty(), "T must release lockdown: {at:?}");
     }
 
     /// L2: under lockdown a tx FROM a delegated account is dropped.
@@ -2030,11 +1995,11 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            result.discard.len(),
+            result.len(),
             1,
             "7702-lockdown L2 must drop a tx from a delegated sender: {result:?}"
         );
-        assert!(result.discard.contains(&0));
+        assert!(result.contains(&0));
     }
 
     /// L3: under lockdown a tx TO a delegated account is dropped.
@@ -2062,11 +2027,11 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            result.discard.len(),
+            result.len(),
             1,
             "7702-lockdown L3 must drop a tx to a delegated recipient: {result:?}"
         );
-        assert!(result.discard.contains(&0));
+        assert!(result.contains(&0));
     }
 
     /// audit#838 attack shape: [funder→A, A@nonce] — both dropped under lockdown
@@ -2096,11 +2061,11 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert_eq!(
-            result.discard.len(),
+            result.len(),
             2,
             "both legs of the audit#838 attack shape must be dropped: {result:?}"
         );
-        assert!(result.discard.contains(&0) && result.discard.contains(&1));
+        assert!(result.contains(&0) && result.contains(&1));
     }
 
     /// Lockdown precision: non-delegated traffic (ordinary contract recipient) is
@@ -2138,7 +2103,7 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 30_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            result.discard.is_empty(),
+            result.is_empty(),
             "non-delegated traffic must be unaffected by the 7702 lockdown: {result:?}"
         );
     }
@@ -2178,10 +2143,7 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
-        assert!(
-            result.discard.is_empty(),
-            "30M tx at the cap boundary must pass under Osaka: {result:?}"
-        );
+        assert!(result.is_empty(), "30M tx at the cap boundary must pass under Osaka: {result:?}");
     }
 
     /// A tx one gas over the cap (30M + 1) is rejected under Osaka.
@@ -2206,8 +2168,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "tx above the 30M cap must be discarded under Osaka");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "tx above the 30M cap must be discarded under Osaka");
+        assert!(result.contains(&0));
     }
 
     /// The gate is OSAKA-gated: the same over-cap tx passes under Prague (no per-tx cap exists
@@ -2234,7 +2196,7 @@ mod tests {
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &prague_chain_spec(), 0, 0);
         assert!(
-            result.discard.is_empty(),
+            result.is_empty(),
             "pre-Osaka has no per-tx gas cap, over-cap tx must pass: {result:?}"
         );
     }
@@ -2266,8 +2228,8 @@ mod tests {
 
         let result =
             filter_invalid_txs(&db, &txs, &senders, 0, 60_000_000, &osaka_chain_spec(), 0, 0);
-        assert_eq!(result.discard.len(), 1, "only sender A's over-cap tx must be dropped");
-        assert!(result.discard.contains(&0));
+        assert_eq!(result.len(), 1, "only sender A's over-cap tx must be dropped");
+        assert!(result.contains(&0));
     }
 
     /// audit#646 / Beta+: gas is the last gate. An invalid early tx must not consume
@@ -2309,10 +2271,7 @@ mod tests {
             0,
             0,
         );
-        assert!(
-            pre.discard.contains(&1) && pre.discard.contains(&2),
-            "pre-Beta prefix-cut: {pre:?}"
-        );
+        assert!(pre.contains(&1) && pre.contains(&2), "pre-Beta prefix-cut: {pre:?}");
 
         let result = filter_invalid_txs(
             &db,
@@ -2324,12 +2283,13 @@ mod tests {
             0,
             0,
         );
-        assert_eq!(result.discard.len(), 1);
-        assert!(result.discard.contains(&1));
-        assert!(result.defer.is_empty(), "later valid tx must pack, not defer: {result:?}");
+        assert_eq!(result.len(), 1);
+        assert!(result.contains(&1));
+        assert!(!result.contains(&2), "later valid tx must pack: {result:?}");
     }
 
-    /// audit#646 / Beta+: continue packing smaller txs after a large one does not fit.
+    /// audit#646 / Beta+: continue packing smaller txs after a large one does not fit;
+    /// the non-fit is discarded (not kept in pool).
     #[test]
     fn test_filter_invalid_txs_continues_packing_after_gas_skip() {
         let mut db = MockDatabase::new();
@@ -2348,7 +2308,7 @@ mod tests {
             );
         }
 
-        // Budget 30M: pack 20M, skip next same-sender 20M (defer), still pack 5M from
+        // Budget 30M: pack 20M, discard next same-sender 20M, still pack 5M from
         // another sender under the remaining 10M.
         let tx0 = create_test_transaction(0, 20_000_000, 25_000_000_000);
         let tx1 = create_test_transaction(1, 20_000_000, 25_000_000_000);
@@ -2366,13 +2326,13 @@ mod tests {
             0,
             0,
         );
-        assert!(result.discard.is_empty(), "{result:?}");
-        assert_eq!(result.defer.len(), 1);
-        assert!(result.defer.contains(&1));
-        assert!(!result.defer.contains(&2), "small later tx must pack: {result:?}");
+        assert_eq!(result.len(), 1, "{result:?}");
+        assert!(result.contains(&1));
+        assert!(!result.contains(&2), "small later tx must pack: {result:?}");
     }
 
-    /// Fork boundary: betaTime = T; T-1 uses legacy discard, T uses defer.
+    /// Fork boundary: betaTime = T; both sides discard non-fit, but packing differs
+    /// (pre: prefix-cut may drop more; post: last-gate can pack later small txs).
     #[test]
     fn test_filter_invalid_txs_gas_pack_gate_at_beta_boundary() {
         let mut db = MockDatabase::new();
@@ -2404,7 +2364,7 @@ mod tests {
             BETA_TIME - 1,
             0,
         );
-        assert!(pre.discard.contains(&1) && pre.defer.is_empty(), "T-1 legacy discard: {pre:?}");
+        assert!(pre.contains(&1), "T-1 legacy prefix-cut discards idx1: {pre:?}");
 
         let at = filter_invalid_txs(
             &db,
@@ -2416,6 +2376,8 @@ mod tests {
             BETA_TIME,
             0,
         );
-        assert!(at.defer.contains(&1) && at.discard.is_empty(), "T must defer: {at:?}");
+        // Same outcome for this two-tx shape, but via gas-last + discard.
+        assert!(at.contains(&1), "T gas-last still discards non-fit: {at:?}");
+        assert_eq!(at.len(), 1);
     }
 }


### PR DESCRIPTION
Closes Galxe/gravity-audit#646

Fix block-gas packing that could prefix-cut the ordered list and empty blocks under adversarial ordering. **Gated by Gravity Beta (`betaTime`).**

## Behaviour

| Phase | Packing | Gas-only exclusion |
|-------|---------|-------------------|
| **Pre-Beta** (legacy STF) | Prefix-cut on cumulative `tx.gas_limit()` | **Discard** entire suffix |
| **Beta+** | Validate first, gas as last gate; continue packing later fits | **Discard** non-fitting / same-sender-blocked (no keep-in-pool defer) |

### Why still discard (not defer)

SDK only consumes `TxnStatus.is_discarded` as a two-state signal (`notify_failed_txn`). A third “not in body, `is_discarded=false`” state would be ambiguous for consumers. This release:

- fixes **body packing** (near-empty blocks from prefix-cut / invalid gas-steal)
- keeps pool/SDK semantics **binary**: excluded ⇒ discarded

Missing `betaTime` → fail-closed pre-Beta prefix-cut.

## Test plan
- [x] `cargo test -p reth-pipe-exec-layer-ext-v2 --lib tx_filter` (44 passed)
- [x] Pre/post-Beta packing + boundary tests
- [ ] CI on this PR