### PR TITLE
fix(deps): require alloy-trie 0.9.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,7 +514,7 @@ alloy-eip2124 = { version = "0.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.0", default-features = false, features = ["rlp"] }
 alloy-evm = { version = "0.36.0", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false, features = ["core-net"] }
-alloy-trie = { version = "0.9.4", default-features = false }
+alloy-trie = { version = "0.9.5", default-features = false }
 
 alloy-hardforks = "0.4.7"
 


### PR DESCRIPTION
## Summary

- raise the workspace minimum `alloy-trie` version from `0.9.4` to `0.9.5`
- prevent downstream lockfiles from selecting an `RlpNode` implementation that is incompatible with Reth's nested-trie const cache mutations on Rust 1.93

## Why

While integrating the merged generic Oracle relayer core into Gravity SDK, the SDK lockfile legally selected `alloy-trie 0.9.4`. Its `RlpNode` owns an `ArrayVec`, so assignments in Reth's `const fn` cache helpers fail with `E0493` on the declared Rust 1.93 toolchain.

`alloy-trie 0.9.5` changed `RlpNode` to a trivially droppable fixed buffer. Reth's own lockfile already resolves to this version, which is why the issue did not appear in the Reth CI graph. Declaring the actual minimum requirement makes downstream resolution deterministic and preserves the intended const API.

This is a dependency-compatibility correction only. It does not change Oracle behavior, trie encoding, database formats, or execution semantics.

## Validation

- `cargo +1.93.0 check -p reth-trie-common --all-features --locked`
- verified the Gravity SDK `gravity_node` test build progresses past `reth-trie-common` after resolving `alloy-trie 0.9.5`

## Tracking

- Galxe/gravity-audit#1038
- follows Galxe/gravity-reth#416
