### PR TITLE
fix(oracle): discover price feed relayer tasks

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_consensus_config.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_consensus_config.rs
@@ -92,18 +92,18 @@ where
         providers
     }
 
-    /// Fetch and parse blockchain providers (sourceType=0)
+    /// Fetch and parse relayer-backed providers (sourceType=0, sourceType=3, ...)
     /// Uses shared OracleTaskClient for task enumeration
-    fn fetch_blockchain_providers(
+    fn fetch_relayer_providers(
         &self,
         block_id: BlockId,
     ) -> Vec<gravity_api_types::on_chain_config::jwks::OIDCProvider> {
-        let task_uris = self.oracle_client().fetch_blockchain_task_uris(block_id);
+        let task_uris = self.oracle_client().fetch_relayer_task_uris(block_id);
 
         task_uris
             .into_iter()
             .map(|(uri, nonce)| {
-                info!(uri = %uri, nonce = nonce, "Found blockchain monitoring task");
+                info!(uri = %uri, nonce = nonce, "Found relayer-backed oracle task");
                 gravity_api_types::on_chain_config::jwks::OIDCProvider {
                     name: uri.clone(),
                     config_url: uri,
@@ -125,8 +125,8 @@ where
         // 1. Fetch JWK providers (sourceType=1)
         all_providers.extend(self.fetch_jwk_providers(block_id));
 
-        // 2. Fetch blockchain providers (sourceType=0)
-        all_providers.extend(self.fetch_blockchain_providers(block_id));
+        // 2. Fetch providers implemented by the relayer (sourceType=0, sourceType=3, ...)
+        all_providers.extend(self.fetch_relayer_providers(block_id));
 
         info!(provider_count = all_providers.len(), "Fetched oracle task providers");
 

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/oracle_task_helpers.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/oracle_task_helpers.rs
@@ -23,12 +23,15 @@ use tracing::{info, warn};
 /// Source type for blockchain events in NativeOracle
 pub const SOURCE_TYPE_BLOCKCHAIN: u32 = 0;
 
+/// Source type for deterministic price-feed rounds.
+pub const SOURCE_TYPE_PRICE_FEED: u32 = 3;
+
 /// Source types implemented by this relayer build.
 ///
 /// Provider PRs extend this list together with their runtime dispatch. Keeping
 /// discovery and execution support in one list prevents publishing tasks that
 /// the local relayer cannot execute.
-pub const RELAYER_BACKED_SOURCE_TYPES: &[u32] = &[SOURCE_TYPE_BLOCKCHAIN];
+pub const RELAYER_BACKED_SOURCE_TYPES: &[u32] = &[SOURCE_TYPE_BLOCKCHAIN, SOURCE_TYPE_PRICE_FEED];
 
 fn has_valid_task_cardinality(source_type: u32, task_count: usize) -> bool {
     !RELAYER_BACKED_SOURCE_TYPES.contains(&source_type) || task_count == 1
@@ -43,6 +46,8 @@ mod tests {
 
     #[test]
     fn relayer_backed_sources_require_exactly_one_task() {
+        assert_eq!(RELAYER_BACKED_SOURCE_TYPES, &[SOURCE_TYPE_BLOCKCHAIN, SOURCE_TYPE_PRICE_FEED]);
+
         for source_type in RELAYER_BACKED_SOURCE_TYPES {
             assert!(!has_valid_task_cardinality(*source_type, 0));
             assert!(has_valid_task_cardinality(*source_type, 1));


### PR DESCRIPTION
## Summary

Fixes the dynamic discovery gap exposed by the deterministic four-validator Binance E2E after #418 merged.

- includes `sourceType=3` in `RELAYER_BACKED_SOURCE_TYPES`
- builds JWK consensus providers through `fetch_relayer_task_uris()` instead of the source-type-0-only helper
- locks the supported discovery set to `[BLOCKCHAIN, PRICE_FEED]` in a focused regression test

Without this wiring, the Binance provider and execution callback from #418 compile and run, but epoch reconfiguration publishes an empty JWK provider set for price tasks, so no validator starts a `gravity://3/...` observer.

## Scope and compatibility

- two execute-layer files, one commit
- no provider parsing, HTTP, payload, nonce, callback gas, or contract ABI changes
- source type 0 discovery remains unchanged
- no Polygon/source type 6, SDK, live-network, credential, or operator-specific files

## Validation

- `cargo test -p reth-pipe-exec-layer-ext-v2 onchain_config::oracle_task_helpers::tests`: passed
- `cargo fmt --all -- --check`: passed
- deterministic SDK integration against this exact commit: four equal-power validators independently observed two localhost Binance index-kline feeds, formed JWK voting-power quorum, wrote NativeOracle, updated PriceFeedResolver, and returned identical state from all four RPCs (`1 passed` in 40.15s)
- full execute `--lib`: 95 passed; the only failure is the pre-existing `system_caller_migration::tests::test_migration_defensive_when_system_caller_absent` already documented on #416/#418 and unrelated to these files
- diff hygiene and credential/path scan: passed

Refs Galxe/gravity-audit#1038 and Galxe/gravity-audit#1033.