### PR TITLE
feat(oracle): add finalized Polymarket settlement source

### DIFF
--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/jwk_oracle.rs
@@ -52,7 +52,9 @@ fn parse_source_from_issuer(issuer: &[u8]) -> Option<(u32, u64)> {
 
 fn callback_gas_limit(source_type: u32) -> Result<u64, String> {
     match source_type {
-        source_types::BLOCKCHAIN | source_types::PRICE_FEED => Ok(CALLBACK_GAS_LIMIT),
+        source_types::BLOCKCHAIN |
+        source_types::PRICE_FEED |
+        source_types::POLYMARKET_SETTLEMENT => Ok(CALLBACK_GAS_LIMIT),
         _ => Err(format!("Unsupported oracle source type: {source_type}")),
     }
 }
@@ -200,6 +202,20 @@ mod tests {
             uint8 decimals;
             int256 price;
         }
+
+        struct PolymarketSettlementPayloadForTest {
+            uint256 mirrorId;
+            uint256 polygonChainId;
+            address ctf;
+            address oracle;
+            bytes32 conditionId;
+            bytes32 questionId;
+            uint256 outcomeSlotCount;
+            uint256[] payoutNumerators;
+            bytes32 txHash;
+            uint256 logIndex;
+            uint8 settlementKind;
+        }
     }
 
     fn wrapped_jwk(nonce: u128, position: U256, payload: &[u8]) -> JWKStruct {
@@ -279,13 +295,44 @@ mod tests {
     }
 
     #[test]
+    fn preserves_polymarket_coordinates_payload_and_standard_callback_gas() {
+        let payload = PolymarketSettlementPayloadForTest {
+            mirrorId: U256::from(9001),
+            polygonChainId: U256::from(137),
+            ctf: "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045".parse().unwrap(),
+            oracle: "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296".parse().unwrap(),
+            conditionId: [0x11; 32].into(),
+            questionId: [0x22; 32].into(),
+            outcomeSlotCount: U256::from(2),
+            payoutNumerators: vec![U256::ZERO, U256::from(1)],
+            txHash: [0x33; 32].into(),
+            logIndex: U256::from(17),
+            settlementKind: 1,
+        }
+        .abi_encode();
+        let provider = provider(
+            b"gravity://6/9001/polymarket_settlement?chainId=137",
+            vec![wrapped_jwk(1, U256::from(50_000_000u64), &payload)],
+        );
+
+        let tx = construct_oracle_record_transaction(provider, 0, 0).unwrap();
+        let call = recordBatchCall::abi_decode(tx.input()).unwrap();
+        assert_eq!(call.sourceType, source_types::POLYMARKET_SETTLEMENT);
+        assert_eq!(call.sourceId, U256::from(9001));
+        assert_eq!(call.nonces, vec![1]);
+        assert_eq!(call.blockNumbers, vec![U256::from(50_000_000u64)]);
+        assert_eq!(call.payloads, vec![Bytes::from(payload)]);
+        assert_eq!(call.callbackGasLimits, vec![U256::from(CALLBACK_GAS_LIMIT)]);
+    }
+
+    #[test]
     fn rejects_provider_source_types_not_implemented_by_core() {
         let provider = provider(
-            b"gravity://6/1001/settlement",
+            b"gravity://7/1001/unsupported",
             vec![wrapped_jwk(1, U256::from(60_000), b"settlement")],
         );
         let error = construct_oracle_record_transaction(provider, 0, 0).unwrap_err();
-        assert_eq!(error, "Unsupported oracle source type: 6");
+        assert_eq!(error, "Unsupported oracle source type: 7");
     }
 
     #[test]

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/oracle_task_helpers.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/oracle_task_helpers.rs
@@ -26,12 +26,16 @@ pub const SOURCE_TYPE_BLOCKCHAIN: u32 = 0;
 /// Source type for deterministic price-feed rounds.
 pub const SOURCE_TYPE_PRICE_FEED: u32 = 3;
 
+/// Source type for finalized Polygon CTF settlements.
+pub const SOURCE_TYPE_POLYMARKET_SETTLEMENT: u32 = 6;
+
 /// Source types implemented by this relayer build.
 ///
 /// Provider PRs extend this list together with their runtime dispatch. Keeping
 /// discovery and execution support in one list prevents publishing tasks that
 /// the local relayer cannot execute.
-pub const RELAYER_BACKED_SOURCE_TYPES: &[u32] = &[SOURCE_TYPE_BLOCKCHAIN, SOURCE_TYPE_PRICE_FEED];
+pub const RELAYER_BACKED_SOURCE_TYPES: &[u32] =
+    &[SOURCE_TYPE_BLOCKCHAIN, SOURCE_TYPE_PRICE_FEED, SOURCE_TYPE_POLYMARKET_SETTLEMENT];
 
 fn has_valid_task_cardinality(source_type: u32, task_count: usize) -> bool {
     !RELAYER_BACKED_SOURCE_TYPES.contains(&source_type) || task_count == 1
@@ -46,7 +50,10 @@ mod tests {
 
     #[test]
     fn relayer_backed_sources_require_exactly_one_task() {
-        assert_eq!(RELAYER_BACKED_SOURCE_TYPES, &[SOURCE_TYPE_BLOCKCHAIN, SOURCE_TYPE_PRICE_FEED]);
+        assert_eq!(
+            RELAYER_BACKED_SOURCE_TYPES,
+            &[SOURCE_TYPE_BLOCKCHAIN, SOURCE_TYPE_PRICE_FEED, SOURCE_TYPE_POLYMARKET_SETTLEMENT]
+        );
 
         for source_type in RELAYER_BACKED_SOURCE_TYPES {
             assert!(!has_valid_task_cardinality(*source_type, 0));

--- a/crates/pipe-exec-layer-ext-v2/relayer/POLYMARKET_SETTLEMENT_SOURCE.md
+++ b/crates/pipe-exec-layer-ext-v2/relayer/POLYMARKET_SETTLEMENT_SOURCE.md
@@ -1,0 +1,139 @@
+# Polymarket Settlement Source
+
+This document defines the `gravity-reth` source type `6` boundary for mirroring
+one finalized Polygon Conditional Tokens Framework (CTF) condition into
+Gravity. The source only transports canonical settlement facts. Human-readable
+market metadata, outcome labels, and Gravity betting-product behavior are not
+inferred from Polygon logs.
+
+## Workflow
+
+```mermaid
+flowchart LR
+    A["OracleTaskConfig URI"] --> B["Each validator's Polygon RPC"]
+    B --> C["eth_chainId = 137"]
+    C --> D["finalized block watermark"]
+    D --> E["bounded ConditionResolution log scan"]
+    E --> F["strict event and condition validation"]
+    F --> G["canonical source type 6 bytes"]
+    G --> H["JWK voting-power quorum"]
+    H --> I["NativeOracle recordBatch"]
+    I --> J["PolymarketSettlementResolver"]
+```
+
+## Task URI
+
+```text
+gravity://6/9001/polymarket_settlement?ctf=0x4D97DCd97eC945f40cF65F87097ACe5EA0476045&condition=0x...&fromBlock=89000000&chainId=137&maxBlocksPerPoll=1000
+```
+
+The URI is governance-controlled consensus configuration. It contains no RPC
+URL or credential. Each validator maps this URI to its own Polygon endpoint in
+local node configuration.
+
+| Field | Meaning |
+|---|---|
+| `6` | `NativeOracle` source type for Polygon CTF settlement mirrors |
+| `9001` | Stable `mirrorId` and `NativeOracle.sourceId`, restricted to `uint64` |
+| `ctf` | Polygon CTF contract that must emit the event |
+| `condition` | Exact indexed CTF condition ID to scan |
+| `fromBlock` | Initial scan cursor; the first queried block is `fromBlock + 1` |
+| `chainId` | Optional but, when present, must be `137` |
+| `maxBlocksPerPoll` | Optional bounded scan size, default `1000`, maximum `10000` |
+
+Only the parameters above are accepted. Use a new `mirrorId` and URI when the
+CTF condition identity changes. If the earliest possible event is block `X`, set
+`fromBlock` to `X - 1` so that block `X` is included in the first scan.
+
+## Market Discovery Boundary
+
+A Polygon `ConditionResolution` event identifies a CTF condition and its payout
+vector, but it does not provide a Polymarket question, slug, outcome labels, or
+display rules. Before registering a mirror, an operator must resolve that
+metadata through a reviewed Polymarket discovery path and record the exact
+`ctf`, `conditionId`, outcome count, and product mapping in governance data.
+
+The relayer then watches only that reviewed condition. It does not enumerate all
+Polygon conditions or decide which Polymarket market a condition represents.
+
+## Finality And Idempotency
+
+- The endpoint must report Polygon chain ID `137` before any scan is accepted.
+- The upper watermark comes from `eth_getBlockByNumber("finalized", false)`.
+- Every scan is bounded by `maxBlocksPerPoll`.
+- Returned logs must fall inside the requested finalized range even if the RPC
+  server returns extra data.
+- Logs are ordered by `(blockNumber, logIndex, transactionHash)`.
+- Exact duplicate log identities are deduplicated.
+- More than one distinct terminal log for one condition fails closed without
+  advancing the cursor.
+- Empty finalized scans still advance and persist the cursor, preventing the
+  same empty range from being rescanned after restart.
+- A mirror is terminal. Its only delivery nonce is `1`; after on-chain progress
+  reaches nonce `1`, the source performs no more RPC calls.
+
+`NativeOracle.latestPosition` stores the settlement's finalized Polygon block.
+The relayer persistence file separately stores the later scan cursor. On
+restart, the generic relayer manager reconciles local state against authoritative
+`(latestNonce, latestPosition)` contract state and rescans from the configured
+watermark when an unconfirmed local observation was ahead.
+
+## Canonical Callback Payload
+
+The provider first ABI-encodes the resolver payload:
+
+```solidity
+struct PolymarketSettlementPayload {
+    uint256 mirrorId;
+    uint256 polygonChainId;
+    address ctf;
+    address oracle;
+    bytes32 conditionId;
+    bytes32 questionId;
+    uint256 outcomeSlotCount;
+    uint256[] payoutNumerators;
+    bytes32 txHash;
+    uint256 logIndex;
+    uint8 settlementKind;
+}
+```
+
+`settlementKind` is `1` for CTF `ConditionResolution`. The source validates:
+
+- exact CTF address, event signature, and indexed condition
+- non-removed log with block number, transaction hash, and log index
+- nonzero oracle, question ID, and transaction hash
+- `conditionId == keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount))`
+- outcome count between `2` and `32`
+- payout length equal to outcome count and at least one positive payout
+
+The resolver payload is wrapped as:
+
+```solidity
+abi.encode(uint128(1), uint256(finalizedPolygonBlock), bytes(resolverPayload))
+```
+
+Validators agree on these exact bytes through the existing unsupported-JWK
+consensus path. Execution unwraps the tuple and calls `NativeOracle.recordBatch`
+with the standard `500000` callback gas limit. The Contracts resolver test
+covers the maximum 32-outcome payload under that limit.
+
+## Failure Semantics
+
+Malformed logs, wrong-chain RPCs, noncanonical identity, out-of-range logs,
+ambiguous terminal events, and RPC errors return an error without moving the
+source cursor or terminal nonce. A resolver callback failure reverts the whole
+`NativeOracle` delivery, so on-chain source progress also remains retryable.
+
+## Verification
+
+```bash
+cargo test -p reth-pipe-exec-layer-relayer
+cargo test -p reth-pipe-exec-layer-ext-v2 onchain_config::jwk_oracle
+cargo +nightly fmt --all -- --check
+```
+
+The relayer suite uses an injected deterministic Polygon RPC to test finalized
+watermarks, bounded empty scans, duplicate and ambiguous logs, wrong-chain
+rejection, range validation, restart reconciliation, and byte-for-byte ABI
+compatibility without contacting an external network.

--- a/crates/pipe-exec-layer-ext-v2/relayer/README.md
+++ b/crates/pipe-exec-layer-ext-v2/relayer/README.md
@@ -2,8 +2,9 @@
 
 This crate converts finalized external-source observations into the
 UnsupportedJWK payloads used by Gravity validator consensus. This core slice
-implements source type `0` (`GravityPortal.MessageSent`) and source type `3`
-(Binance USD-M index-price klines). Other providers remain separate slices.
+implements source type `0` (`GravityPortal.MessageSent`), source type `3`
+(Binance USD-M index-price klines), and source type `6` (finalized Polygon CTF
+settlements).
 
 ## Task Identity
 
@@ -29,6 +30,16 @@ Source type `3` example:
 ```text
 gravity://3/2001/price_feed?provider=binance_index_kline_v1&pair=TSLAUSDT&interval=1m&bucketStartMs=1710000000000&decimals=8&graceMs=120000
 ```
+
+Source type `6` example:
+
+```text
+gravity://6/9001/polymarket_settlement?ctf=0x4D97DCd97eC945f40cF65F87097ACe5EA0476045&condition=0x...&fromBlock=89000000&chainId=137&maxBlocksPerPoll=1000
+```
+
+See [POLYMARKET_SETTLEMENT_SOURCE.md](POLYMARKET_SETTLEMENT_SOURCE.md) for the
+market-discovery boundary, finalized scan semantics, cursor/idempotency rules,
+and exact resolver ABI.
 
 RPC URLs are local validator configuration. They are not stored in the task
 URI or committed on-chain.

--- a/crates/pipe-exec-layer-ext-v2/relayer/src/data_source.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/data_source.rs
@@ -7,7 +7,10 @@ use alloy_primitives::{Bytes, U256};
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::{blockchain_source::BlockchainEventSource, price_feed_source::PriceFeedSource};
+use crate::{
+    blockchain_source::BlockchainEventSource,
+    polymarket_settlement_source::PolymarketSettlementSource, price_feed_source::PriceFeedSource,
+};
 
 /// Data returned by oracle data sources
 ///
@@ -35,6 +38,7 @@ pub trait OracleDataSource: Send + Sync {
     /// Get the source type (corresponds to NativeOracle.sourceType)
     /// - 0: BLOCKCHAIN
     /// - 3: `PRICE_FEED`
+    /// - 6: `POLYMARKET_SETTLEMENT`
     fn source_type(&self) -> u32;
 
     /// Get the source ID (corresponds to NativeOracle.sourceId)
@@ -55,6 +59,9 @@ pub mod source_types {
 
     /// Deterministic external price buckets
     pub const PRICE_FEED: u32 = 3;
+
+    /// Finalized Polygon CTF settlements
+    pub const POLYMARKET_SETTLEMENT: u32 = 6;
 }
 
 /// Extensible enum for runtime dispatch of data sources
@@ -70,6 +77,9 @@ pub enum DataSourceKind {
 
     /// Deterministic external price buckets (sourceType=3)
     PriceFeed(PriceFeedSource),
+
+    /// Finalized Polygon CTF settlements (sourceType=6)
+    PolymarketSettlement(PolymarketSettlementSource),
 }
 
 impl DataSourceKind {
@@ -77,6 +87,7 @@ impl DataSourceKind {
         match self {
             Self::Blockchain(source) => source.last_nonce().await,
             Self::PriceFeed(source) => source.last_nonce().await,
+            Self::PolymarketSettlement(source) => source.last_nonce().await,
         }
     }
 
@@ -84,6 +95,7 @@ impl DataSourceKind {
         match self {
             Self::Blockchain(source) => source.last_nonce_block().await,
             Self::PriceFeed(source) => source.last_nonce_position().await,
+            Self::PolymarketSettlement(source) => source.last_nonce_position().await,
         }
     }
 
@@ -94,6 +106,7 @@ impl DataSourceKind {
                 Ok(())
             }
             Self::PriceFeed(source) => source.reconcile_progress(nonce, position).await,
+            Self::PolymarketSettlement(source) => source.reconcile_progress(nonce, position).await,
         }
     }
 
@@ -101,6 +114,7 @@ impl DataSourceKind {
         match self {
             Self::Blockchain(source) => source.cursor(),
             Self::PriceFeed(source) => source.cursor(),
+            Self::PolymarketSettlement(source) => source.cursor(),
         }
     }
 
@@ -108,6 +122,7 @@ impl DataSourceKind {
         match self {
             Self::Blockchain(source) => source.chain_id(),
             Self::PriceFeed(source) => source.feed_id(),
+            Self::PolymarketSettlement(source) => source.mirror_id(),
         }
     }
 }
@@ -118,6 +133,7 @@ impl OracleDataSource for DataSourceKind {
         match self {
             Self::Blockchain(_) => source_types::BLOCKCHAIN,
             Self::PriceFeed(_) => source_types::PRICE_FEED,
+            Self::PolymarketSettlement(_) => source_types::POLYMARKET_SETTLEMENT,
         }
     }
 
@@ -125,6 +141,7 @@ impl OracleDataSource for DataSourceKind {
         match self {
             Self::Blockchain(s) => s.source_id(),
             Self::PriceFeed(s) => s.source_id(),
+            Self::PolymarketSettlement(s) => s.source_id(),
         }
     }
 
@@ -132,6 +149,7 @@ impl OracleDataSource for DataSourceKind {
         match self {
             Self::Blockchain(s) => s.poll().await,
             Self::PriceFeed(s) => s.poll().await,
+            Self::PolymarketSettlement(s) => s.poll().await,
         }
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/relayer/src/eth_client.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/eth_client.rs
@@ -71,6 +71,13 @@ impl EthHttpCli {
             .with_context(|| "Failed to get logs with filter")
     }
 
+    /// Gets the remote chain identifier.
+    pub async fn get_chain_id(&self) -> Result<u64> {
+        self.retry_with_backoff(|| async { self.provider.get_chain_id().await })
+            .await
+            .with_context(|| "Failed to get chain id")
+    }
+
     /// Gets the latest finalized block number
     pub async fn get_finalized_block_number(&self) -> Result<u64> {
         self.retry_with_backoff(|| async {

--- a/crates/pipe-exec-layer-ext-v2/relayer/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/lib.rs
@@ -23,6 +23,9 @@ pub mod blockchain_source;
 /// Binance index-price feed source
 pub mod price_feed_source;
 
+/// Polygon Polymarket CTF settlement source
+pub mod polymarket_settlement_source;
+
 /// Factory for creating data sources
 pub mod factory;
 
@@ -47,5 +50,6 @@ pub use data_source::{source_types, DataSourceKind, OracleData, OracleDataSource
 pub use eth_client::EthHttpCli;
 pub use factory::DataSourceFactory;
 pub use oracle_manager::{JWKStruct, OracleRelayerManager, PollResult};
+pub use polymarket_settlement_source::PolymarketSettlementSource;
 pub use price_feed_source::PriceFeedSource;
 pub use uri_parser::{parse_oracle_uri, ParsedOracleTask};

--- a/crates/pipe-exec-layer-ext-v2/relayer/src/oracle_manager.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/oracle_manager.rs
@@ -6,6 +6,7 @@ use crate::{
     blockchain_source::BlockchainEventSource,
     data_source::{source_types, DataSourceKind, OracleDataSource},
     persistence::{load_state_if_exists, state_file_path, RelayerState, SourceState},
+    polymarket_settlement_source::PolymarketSettlementSource,
     price_feed_source::PriceFeedSource,
     uri_parser::{parse_oracle_uri, ParsedOracleTask},
 };
@@ -319,6 +320,17 @@ impl OracleRelayerManager {
                 )?;
                 Ok(DataSourceKind::PriceFeed(source))
             }
+            source_types::POLYMARKET_SETTLEMENT => {
+                let source = PolymarketSettlementSource::from_task_with_progress(
+                    task,
+                    rpc_url,
+                    latest_onchain_nonce,
+                    latest_onchain_position,
+                    cursor,
+                )
+                .await?;
+                Ok(DataSourceKind::PolymarketSettlement(source))
+            }
             _ => Err(anyhow!("Unknown source type: {}", task.source_type)),
         }
     }
@@ -473,6 +485,8 @@ mod tests {
         "gravity://0/1/events?portal=0x0000000000000000000000000000000000000001&fromBlock=100";
     const PRICE_URI: &str =
         "gravity://3/2001/price_feed?provider=binance_index_kline_v1&pair=TSLAUSDT&interval=1m&bucketStartMs=1710000000000&decimals=8";
+    const POLYMARKET_URI: &str =
+        "gravity://6/9001/polymarket_settlement?ctf=0x4D97DCd97eC945f40cF65F87097ACe5EA0476045&condition=0x2afe86f96be81a0d89ed776bedbd52d1c75bc47b49e6f0f791ddd009f52faf23&fromBlock=89000000&chainId=137";
 
     fn state(last_nonce: u128, last_position: u64, cursor: u64) -> RelayerState {
         let mut state = RelayerState::new();
@@ -563,6 +577,42 @@ mod tests {
         manager.add_uri(PRICE_URI, "https://fapi.binance.com", 0, 0).await.unwrap();
 
         assert!(manager.has_uri(PRICE_URI).await);
+    }
+
+    #[tokio::test]
+    async fn adds_polymarket_settlement_source_without_network_access() {
+        let datadir = tempfile::tempdir().unwrap();
+        let manager = OracleRelayerManager::new(datadir.path().to_path_buf());
+
+        manager.add_uri(POLYMARKET_URI, "http://127.0.0.1:8545", 0, 0).await.unwrap();
+
+        assert!(manager.has_uri(POLYMARKET_URI).await);
+        assert_eq!(manager.source_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn persists_polymarket_empty_scan_watermark_without_inventing_nonce() {
+        let datadir = tempfile::tempdir().unwrap();
+        let manager = OracleRelayerManager::new(datadir.path().to_path_buf());
+
+        manager
+            .update_and_save_state(
+                POLYMARKET_URI,
+                source_types::POLYMARKET_SETTLEMENT,
+                9001,
+                0,
+                0,
+                89_001_000,
+            )
+            .await;
+
+        let state = RelayerState::load(&state_file_path(datadir.path())).unwrap();
+        let source = state.get(POLYMARKET_URI).unwrap();
+        assert_eq!(source.source_type, source_types::POLYMARKET_SETTLEMENT);
+        assert_eq!(source.source_id, 9001);
+        assert_eq!(source.last_nonce, 0);
+        assert_eq!(source.last_nonce_block, 0);
+        assert_eq!(source.cursor_block, 89_001_000);
     }
 
     #[tokio::test]

--- a/crates/pipe-exec-layer-ext-v2/relayer/src/polymarket_settlement_source.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/polymarket_settlement_source.rs
@@ -1,0 +1,1138 @@
+//! Polymarket settlement mirror source.
+//!
+//! This source watches finalized Polygon logs from the Conditional Tokens
+//! Framework (CTF) and mirrors `ConditionResolution` events into the same
+//! UnsupportedJWK bytes path used by other Gravity oracle sources.
+
+use crate::{
+    data_source::{source_types, OracleData, OracleDataSource},
+    eth_client::EthHttpCli,
+    uri_parser::ParsedOracleTask,
+};
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy_rpc_types::{Filter, Log};
+use alloy_sol_macro::sol;
+use alloy_sol_types::{SolEvent, SolValue};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use tokio::sync::Mutex;
+use tracing::{debug, info};
+
+sol! {
+    /// CTF condition resolution emitted by Gnosis Conditional Tokens.
+    event ConditionResolution(
+        bytes32 indexed conditionId,
+        address indexed oracle,
+        bytes32 indexed questionId,
+        uint256 outcomeSlotCount,
+        uint256[] payoutNumerators
+    );
+
+    struct PolymarketSettlementPayloadSol {
+        uint256 mirrorId;
+        uint256 polygonChainId;
+        address ctf;
+        address oracle;
+        bytes32 conditionId;
+        bytes32 questionId;
+        uint256 outcomeSlotCount;
+        uint256[] payoutNumerators;
+        bytes32 txHash;
+        uint256 logIndex;
+        uint8 settlementKind;
+    }
+}
+
+const CTF_CONDITION_RESOLUTION: u8 = 1;
+const DEFAULT_POLYGON_CHAIN_ID: u64 = 137;
+const DEFAULT_MAX_BLOCKS_PER_POLL: u64 = 1_000;
+const MAX_BLOCKS_PER_POLL: u64 = 10_000;
+const MIN_OUTCOME_SLOT_COUNT: usize = 2;
+const MAX_OUTCOME_SLOT_COUNT: usize = 32;
+const POLYMARKET_TASK_TYPE: &str = "polymarket_settlement";
+const POLYMARKET_TASK_PARAMETERS: &[&str] =
+    &["ctf", "condition", "fromBlock", "chainId", "maxBlocksPerPoll"];
+
+#[async_trait]
+trait PolygonRpc: Send + Sync + std::fmt::Debug {
+    async fn chain_id(&self) -> Result<u64>;
+    async fn finalized_block_number(&self) -> Result<u64>;
+    async fn logs(&self, filter: &Filter) -> Result<Vec<Log>>;
+}
+
+#[async_trait]
+impl PolygonRpc for EthHttpCli {
+    async fn chain_id(&self) -> Result<u64> {
+        self.get_chain_id().await
+    }
+
+    async fn finalized_block_number(&self) -> Result<u64> {
+        self.get_finalized_block_number().await
+    }
+
+    async fn logs(&self, filter: &Filter) -> Result<Vec<Log>> {
+        self.get_logs(filter).await
+    }
+}
+
+/// Last CTF settlement returned to the caller.
+#[derive(Debug, Clone, Copy, Default)]
+struct LastSettlement {
+    nonce: u128,
+    source_position: u64,
+}
+
+impl LastSettlement {
+    const fn is_initialized(self) -> bool {
+        self.nonce > 0
+    }
+}
+
+/// A canonical CTF settlement observation decoded from Polygon logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolymarketSettlementObservation {
+    /// `NativeOracle` source ID for this mirror.
+    pub mirror_id: u64,
+    /// Source chain ID, normally Polygon `PoS` mainnet `137`.
+    pub polygon_chain_id: u64,
+    /// CTF contract which emitted the settlement.
+    pub ctf: Address,
+    /// UMA adapter / oracle address recorded in CTF.
+    pub oracle: Address,
+    /// CTF condition id.
+    pub condition_id: B256,
+    /// UMA / CTF question id.
+    pub question_id: B256,
+    /// Number of outcome slots in the CTF condition.
+    pub outcome_slot_count: U256,
+    /// Final payout vector.
+    pub payout_numerators: Vec<U256>,
+    /// Transaction hash containing this settlement log.
+    pub tx_hash: B256,
+    /// Log index in the source block.
+    pub log_index: u64,
+    /// Source block number.
+    pub block_number: u64,
+}
+
+impl PolymarketSettlementObservation {
+    fn resolver_payload(&self) -> Vec<u8> {
+        PolymarketSettlementPayloadSol {
+            mirrorId: U256::from(self.mirror_id),
+            polygonChainId: U256::from(self.polygon_chain_id),
+            ctf: self.ctf,
+            oracle: self.oracle,
+            conditionId: self.condition_id,
+            questionId: self.question_id,
+            outcomeSlotCount: self.outcome_slot_count,
+            payoutNumerators: self.payout_numerators.clone(),
+            txHash: self.tx_hash,
+            logIndex: U256::from(self.log_index),
+            settlementKind: CTF_CONDITION_RESOLUTION,
+        }
+        .abi_encode()
+    }
+
+    fn wrapped_payload(&self, delivery_nonce: u128) -> Bytes {
+        Bytes::from(SolValue::abi_encode(&(
+            delivery_nonce,
+            U256::from(self.block_number),
+            self.resolver_payload().as_slice(),
+        )))
+    }
+}
+
+/// Polygon Polymarket settlement mirror for `sourceType=6`.
+#[derive(Debug)]
+pub struct PolymarketSettlementSource {
+    mirror_id: u64,
+    polygon_chain_id: u64,
+    rpc_client: Arc<dyn PolygonRpc>,
+    ctf_address: Address,
+    condition_id: B256,
+    max_blocks_per_poll: u64,
+    chain_verified: AtomicBool,
+    cursor: AtomicU64,
+    last_settlement: Mutex<LastSettlement>,
+}
+
+impl PolymarketSettlementSource {
+    /// Create a source from a `gravity://6/<mirror_id>/polymarket_settlement`
+    /// URI.
+    pub async fn from_task(
+        task: &ParsedOracleTask,
+        rpc_url: &str,
+        latest_onchain_nonce: u128,
+        cursor: u64,
+    ) -> Result<Self> {
+        let latest_position = if latest_onchain_nonce > 0 { cursor } else { 0 };
+        Self::from_task_with_progress(task, rpc_url, latest_onchain_nonce, latest_position, cursor)
+            .await
+    }
+
+    pub(crate) async fn from_task_with_progress(
+        task: &ParsedOracleTask,
+        rpc_url: &str,
+        latest_onchain_nonce: u128,
+        latest_position: u64,
+        cursor: u64,
+    ) -> Result<Self> {
+        let rpc_client = Arc::new(EthHttpCli::new(rpc_url)?);
+        Self::from_task_with_rpc(task, rpc_client, latest_onchain_nonce, latest_position, cursor)
+    }
+
+    fn from_task_with_rpc(
+        task: &ParsedOracleTask,
+        rpc_client: Arc<dyn PolygonRpc>,
+        latest_onchain_nonce: u128,
+        latest_position: u64,
+        cursor: u64,
+    ) -> Result<Self> {
+        if task.source_type != source_types::POLYMARKET_SETTLEMENT {
+            return Err(anyhow!(
+                "PolymarketSettlementSource requires sourceType={}",
+                source_types::POLYMARKET_SETTLEMENT
+            ));
+        }
+        if task.task_type != POLYMARKET_TASK_TYPE {
+            return Err(anyhow!(
+                "PolymarketSettlementSource requires task type '{POLYMARKET_TASK_TYPE}', got '{}'",
+                task.task_type
+            ));
+        }
+        for parameter in task.params.keys() {
+            if !POLYMARKET_TASK_PARAMETERS.contains(&parameter.as_str()) {
+                return Err(anyhow!("Unsupported Polymarket settlement parameter '{parameter}'"));
+            }
+        }
+
+        let ctf_address = parse_address(task, "ctf")?;
+        let polygon_chain_id = parse_optional(task, "chainId")?.unwrap_or(DEFAULT_POLYGON_CHAIN_ID);
+        let condition_id = parse_required_b256(task, "condition")?;
+        if polygon_chain_id != DEFAULT_POLYGON_CHAIN_ID {
+            return Err(anyhow!(
+                "Polymarket settlement chainId must be {}",
+                DEFAULT_POLYGON_CHAIN_ID
+            ));
+        }
+        if ctf_address == Address::ZERO {
+            return Err(anyhow!("Polymarket settlement ctf cannot be zero"));
+        }
+        if condition_id == B256::ZERO {
+            return Err(anyhow!("Polymarket settlement condition cannot be zero"));
+        }
+        let from_block = parse_required::<u64>(task, "fromBlock")?;
+        if cursor < from_block {
+            return Err(anyhow!(
+                "Polymarket settlement cursor {cursor} precedes configured fromBlock {from_block}"
+            ));
+        }
+        let max_blocks_per_poll =
+            parse_optional(task, "maxBlocksPerPoll")?.unwrap_or(DEFAULT_MAX_BLOCKS_PER_POLL);
+        if max_blocks_per_poll == 0 || max_blocks_per_poll > MAX_BLOCKS_PER_POLL {
+            return Err(anyhow!("maxBlocksPerPoll must be between 1 and {}", MAX_BLOCKS_PER_POLL));
+        }
+        if latest_onchain_nonce > 1 {
+            return Err(anyhow!(
+                "Polymarket settlement mirror is terminal and cannot have nonce {latest_onchain_nonce}"
+            ));
+        }
+        if latest_onchain_nonce == 0 && latest_position != 0 {
+            return Err(anyhow!(
+                "Polymarket settlement task has zero nonce with nonzero source position"
+            ));
+        }
+        if latest_position > cursor {
+            return Err(anyhow!(
+                "Polymarket settlement source position {latest_position} exceeds scan cursor {cursor}"
+            ));
+        }
+
+        info!(
+            target: "polymarket_settlement_source",
+            mirror_id = task.source_id,
+            polygon_chain_id,
+            ctf_address = ?ctf_address,
+            condition_id = ?condition_id,
+            max_blocks_per_poll,
+            cursor,
+            latest_onchain_nonce,
+            latest_position,
+            "Created PolymarketSettlementSource"
+        );
+
+        Ok(Self {
+            mirror_id: task.source_id,
+            polygon_chain_id,
+            rpc_client,
+            ctf_address,
+            condition_id,
+            max_blocks_per_poll,
+            chain_verified: AtomicBool::new(false),
+            cursor: AtomicU64::new(cursor),
+            last_settlement: Mutex::new(LastSettlement {
+                nonce: latest_onchain_nonce,
+                source_position: latest_position,
+            }),
+        })
+    }
+
+    /// Current block cursor used for relayer persistence.
+    pub fn cursor(&self) -> u64 {
+        self.cursor.load(Ordering::Relaxed)
+    }
+
+    /// Mirror identifier used as the `NativeOracle` source ID.
+    pub const fn mirror_id(&self) -> u64 {
+        self.mirror_id
+    }
+
+    /// Maximum finalized Polygon blocks scanned in one poll.
+    pub const fn max_blocks_per_poll(&self) -> u64 {
+        self.max_blocks_per_poll
+    }
+
+    /// Last nonce returned or reconciled from `NativeOracle`.
+    pub async fn last_nonce(&self) -> Option<u128> {
+        let state = *self.last_settlement.lock().await;
+        state.is_initialized().then_some(state.nonce)
+    }
+
+    /// Block number associated with the last returned or reconciled event.
+    pub async fn last_nonce_position(&self) -> Option<u64> {
+        let state = *self.last_settlement.lock().await;
+        state.is_initialized().then_some(state.source_position)
+    }
+
+    /// Reconcile local state with the terminal settlement recorded by `NativeOracle`.
+    pub async fn reconcile_progress(&self, nonce: u128, source_position: u64) -> Result<()> {
+        if nonce > 1 {
+            return Err(anyhow!(
+                "Polymarket settlement mirror is terminal and cannot reconcile nonce {nonce}"
+            ));
+        }
+        if nonce == 0 {
+            if source_position != 0 {
+                return Err(anyhow!(
+                    "Polymarket settlement task has zero nonce with nonzero source position"
+                ));
+            }
+            return Ok(());
+        }
+
+        let mut state = self.last_settlement.lock().await;
+        if nonce < state.nonce {
+            return Err(anyhow!(
+                "Polymarket settlement task cannot reconcile backwards from nonce {} to {nonce}",
+                state.nonce
+            ));
+        }
+        *state = LastSettlement { nonce, source_position };
+        if source_position > 0 {
+            self.cursor.fetch_max(source_position, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
+    fn filter(&self, from_block: u64, to_block: u64) -> Filter {
+        Filter::new()
+            .address(self.ctf_address)
+            .event_signature(ConditionResolution::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block)
+            .topic1(self.condition_id)
+    }
+
+    fn decode_log(&self, log: &Log) -> Result<PolymarketSettlementObservation> {
+        decode_condition_resolution_log(
+            log,
+            self.mirror_id,
+            self.polygon_chain_id,
+            self.ctf_address,
+            self.condition_id,
+        )
+    }
+
+    async fn ensure_polygon_chain(&self) -> Result<()> {
+        if self.chain_verified.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        let actual_chain_id = self.rpc_client.chain_id().await?;
+        if actual_chain_id != self.polygon_chain_id {
+            return Err(anyhow!(
+                "Polymarket RPC chain id mismatch: expected {}, got {}",
+                self.polygon_chain_id,
+                actual_chain_id
+            ));
+        }
+        self.chain_verified.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl OracleDataSource for PolymarketSettlementSource {
+    fn source_type(&self) -> u32 {
+        source_types::POLYMARKET_SETTLEMENT
+    }
+
+    fn source_id(&self) -> U256 {
+        U256::from(self.mirror_id)
+    }
+
+    async fn poll(&self) -> Result<Vec<OracleData>> {
+        let mut state = self.last_settlement.lock().await;
+        if state.is_initialized() {
+            return Ok(vec![]);
+        }
+        self.ensure_polygon_chain().await?;
+        let cursor = self.cursor.load(Ordering::Relaxed);
+        let finalized_block = self.rpc_client.finalized_block_number().await?;
+        let scan_limit = cursor
+            .checked_add(self.max_blocks_per_poll)
+            .ok_or_else(|| anyhow!("Polymarket block cursor overflow"))?;
+        let to_block = std::cmp::min(scan_limit, finalized_block);
+
+        if to_block <= cursor {
+            return Ok(vec![]);
+        }
+
+        let from_block =
+            cursor.checked_add(1).ok_or_else(|| anyhow!("Polymarket block cursor overflow"))?;
+        let filter = self.filter(from_block, to_block);
+        debug!(
+            target: "polymarket_settlement_source",
+            mirror_id = self.mirror_id,
+            from_block,
+            to_block,
+            "Polling finalized Polygon CTF settlement logs"
+        );
+
+        let logs = self.rpc_client.logs(&filter).await?;
+        let mut observations = Vec::with_capacity(logs.len());
+
+        for log in logs {
+            let observation = self.decode_log(&log)?;
+            if observation.block_number < from_block || observation.block_number > to_block {
+                return Err(anyhow!(
+                    "Polymarket RPC returned settlement block {} outside requested finalized range [{from_block}, {to_block}]",
+                    observation.block_number
+                ));
+            }
+            observations.push(observation);
+        }
+
+        sort_and_dedup_observations(&mut observations);
+        if observations.len() > 1 {
+            return Err(anyhow!("multiple distinct settlements found for one Polymarket condition"));
+        }
+
+        let results: Vec<OracleData> =
+            observations.first().map(observation_to_oracle_data).into_iter().collect();
+
+        self.cursor.store(to_block, Ordering::Relaxed);
+
+        if let Some(last) = observations.last() {
+            let delivered_nonce = results.last().map(|item| item.nonce).unwrap_or(state.nonce);
+            *state = LastSettlement { nonce: delivered_nonce, source_position: last.block_number };
+        }
+
+        info!(
+            target: "polymarket_settlement_source",
+            mirror_id = self.mirror_id,
+            events_found = results.len(),
+            new_cursor = to_block,
+            "Poll completed"
+        );
+
+        Ok(results)
+    }
+}
+
+fn sort_and_dedup_observations(observations: &mut Vec<PolymarketSettlementObservation>) {
+    observations.sort_by(|a, b| {
+        a.block_number
+            .cmp(&b.block_number)
+            .then(a.log_index.cmp(&b.log_index))
+            .then_with(|| a.tx_hash.as_slice().cmp(b.tx_hash.as_slice()))
+    });
+    observations.dedup_by(|a, b| {
+        a.block_number == b.block_number && a.log_index == b.log_index && a.tx_hash == b.tx_hash
+    });
+}
+
+fn observation_to_oracle_data(observation: &PolymarketSettlementObservation) -> OracleData {
+    const TERMINAL_SETTLEMENT_NONCE: u128 = 1;
+    OracleData {
+        nonce: TERMINAL_SETTLEMENT_NONCE,
+        source_position: observation.block_number,
+        payload: observation.wrapped_payload(TERMINAL_SETTLEMENT_NONCE),
+    }
+}
+
+fn decode_condition_resolution_log(
+    log: &Log,
+    mirror_id: u64,
+    polygon_chain_id: u64,
+    ctf_address: Address,
+    condition_id: B256,
+) -> Result<PolymarketSettlementObservation> {
+    if log.removed {
+        return Err(anyhow!("finalized Polymarket settlement log cannot be removed"));
+    }
+    if log.address() != ctf_address {
+        return Err(anyhow!("Polymarket settlement log CTF address mismatch"));
+    }
+
+    let decoded = ConditionResolution::decode_log_validate(&log.inner)
+        .map_err(|_| anyhow!("failed to decode filtered Polymarket settlement log"))?;
+
+    let block_number = log
+        .block_number
+        .ok_or_else(|| anyhow!("Polymarket settlement log is missing block_number"))?;
+    let log_index =
+        log.log_index.ok_or_else(|| anyhow!("Polymarket settlement log is missing log_index"))?;
+    let tx_hash = log
+        .transaction_hash
+        .ok_or_else(|| anyhow!("Polymarket settlement log is missing transaction_hash"))?;
+
+    let event = decoded.data;
+    if event.conditionId != condition_id {
+        return Err(anyhow!("Polymarket settlement log condition mismatch"));
+    }
+    if event.oracle == Address::ZERO || event.questionId == B256::ZERO {
+        return Err(anyhow!("Polymarket settlement log has zero oracle or questionId"));
+    }
+    if tx_hash == B256::ZERO {
+        return Err(anyhow!("Polymarket settlement log has zero transaction_hash"));
+    }
+
+    let derived_condition_id =
+        derive_condition_id(event.oracle, event.questionId, event.outcomeSlotCount);
+    if derived_condition_id != event.conditionId {
+        return Err(anyhow!(
+            "Polymarket settlement condition does not match oracle, questionId, and outcomeSlotCount"
+        ));
+    }
+
+    validate_payouts(event.outcomeSlotCount, &event.payoutNumerators)?;
+
+    Ok(PolymarketSettlementObservation {
+        mirror_id,
+        polygon_chain_id,
+        ctf: ctf_address,
+        oracle: event.oracle,
+        condition_id: event.conditionId,
+        question_id: event.questionId,
+        outcome_slot_count: event.outcomeSlotCount,
+        payout_numerators: event.payoutNumerators,
+        tx_hash,
+        log_index,
+        block_number,
+    })
+}
+
+fn derive_condition_id(oracle: Address, question_id: B256, outcome_slot_count: U256) -> B256 {
+    let mut preimage = Vec::with_capacity(84);
+    preimage.extend_from_slice(oracle.as_slice());
+    preimage.extend_from_slice(question_id.as_slice());
+    preimage.extend_from_slice(&outcome_slot_count.to_be_bytes::<32>());
+    keccak256(preimage)
+}
+
+fn validate_payouts(outcome_slot_count: U256, payout_numerators: &[U256]) -> Result<()> {
+    let count: usize = outcome_slot_count
+        .try_into()
+        .map_err(|_| anyhow!("outcomeSlotCount too large for local validation"))?;
+    if count < MIN_OUTCOME_SLOT_COUNT {
+        return Err(anyhow!(
+            "condition resolution outcomeSlotCount must be at least {MIN_OUTCOME_SLOT_COUNT}"
+        ));
+    }
+    if count > MAX_OUTCOME_SLOT_COUNT {
+        return Err(anyhow!(
+            "condition resolution outcomeSlotCount exceeds maximum {}",
+            MAX_OUTCOME_SLOT_COUNT
+        ));
+    }
+    if count != payout_numerators.len() {
+        return Err(anyhow!(
+            "condition resolution payout length mismatch: outcomeSlotCount={}, payoutNumerators={}",
+            count,
+            payout_numerators.len()
+        ));
+    }
+    if payout_numerators.iter().all(|payout| *payout == U256::ZERO) {
+        return Err(anyhow!("condition resolution payout vector cannot be all zero"));
+    }
+
+    Ok(())
+}
+
+fn parse_address(task: &ParsedOracleTask, key: &str) -> Result<Address> {
+    task.params
+        .get(key)
+        .ok_or_else(|| anyhow!("Missing '{key}' parameter in Polymarket settlement URI"))?
+        .parse()
+        .map_err(|e| anyhow!("Invalid {key} address in Polymarket settlement URI: {e}"))
+}
+
+fn parse_required<T>(task: &ParsedOracleTask, key: &str) -> Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    task.params
+        .get(key)
+        .ok_or_else(|| anyhow!("Missing '{key}' parameter in Polymarket settlement URI"))?
+        .parse()
+        .map_err(|e| anyhow!("Invalid {key} in Polymarket settlement URI: {e}"))
+}
+
+fn parse_required_b256(task: &ParsedOracleTask, key: &str) -> Result<B256> {
+    task.params
+        .get(key)
+        .ok_or_else(|| anyhow!("Missing '{key}' parameter in Polymarket settlement URI"))?
+        .parse()
+        .map_err(|e| anyhow!("Invalid {key} bytes32 in Polymarket settlement URI: {e}"))
+}
+
+fn parse_optional<T>(task: &ParsedOracleTask, key: &str) -> Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    task.params
+        .get(key)
+        .map(|value| value.parse::<T>().map_err(|e| anyhow!("Invalid {key}: {e}")))
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{data_source::OracleDataSource, uri_parser::parse_oracle_uri};
+    use alloy_primitives::{address, b256, Log as PrimitiveLog};
+    use alloy_rpc_types::Log as RpcLog;
+    use alloy_sol_types::SolValue;
+    use std::sync::atomic::AtomicU64;
+
+    const MIRROR_ID: u64 = 42;
+    const BLOCK_NUMBER: u64 = 50_000_000;
+    const LOG_INDEX: u64 = 17;
+
+    fn ctf_address() -> Address {
+        address!("4D97DCd97eC945f40cF65F87097ACe5EA0476045")
+    }
+
+    fn oracle_address() -> Address {
+        address!("d91E80cF2E7be2e162c6513ceD06f1dD0dA35296")
+    }
+
+    fn tx_hash() -> B256 {
+        b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    }
+
+    fn second_tx_hash() -> B256 {
+        b256!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+    }
+
+    fn question_id() -> B256 {
+        b256!("2222222222222222222222222222222222222222222222222222222222222222")
+    }
+
+    fn condition_id() -> B256 {
+        derive_condition_id(oracle_address(), question_id(), U256::from(2))
+    }
+
+    #[test]
+    fn condition_derivation_matches_solidity_packed_encoding() {
+        assert_eq!(
+            condition_id(),
+            b256!("d874d3b83fa09e192fdda031b6a3b3ec78be60cb82678aa67b23f8fd027c86ae")
+        );
+    }
+
+    fn settlement_log() -> RpcLog {
+        settlement_log_at(BLOCK_NUMBER, LOG_INDEX, tx_hash())
+    }
+
+    fn settlement_log_at(block_number: u64, log_index: u64, transaction_hash: B256) -> RpcLog {
+        settlement_log_with_condition(condition_id(), block_number, log_index, transaction_hash)
+    }
+
+    fn settlement_log_with_condition(
+        event_condition_id: B256,
+        block_number: u64,
+        log_index: u64,
+        transaction_hash: B256,
+    ) -> RpcLog {
+        let event = ConditionResolution {
+            conditionId: event_condition_id,
+            oracle: oracle_address(),
+            questionId: question_id(),
+            outcomeSlotCount: U256::from(2),
+            payoutNumerators: vec![U256::ZERO, U256::from(1)],
+        };
+        let inner = ConditionResolution::encode_log(&PrimitiveLog::new_from_event_unchecked(
+            ctf_address(),
+            event,
+        ));
+
+        RpcLog {
+            inner,
+            block_number: Some(block_number),
+            transaction_hash: Some(transaction_hash),
+            log_index: Some(log_index),
+            ..Default::default()
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockPolygonRpc {
+        chain_id: u64,
+        finalized_block: AtomicU64,
+        logs: Mutex<Vec<Log>>,
+        chain_id_calls: AtomicU64,
+        finalized_calls: AtomicU64,
+        log_calls: AtomicU64,
+    }
+
+    impl MockPolygonRpc {
+        fn new(chain_id: u64, finalized_block: u64, logs: Vec<Log>) -> Arc<Self> {
+            Arc::new(Self {
+                chain_id,
+                finalized_block: AtomicU64::new(finalized_block),
+                logs: Mutex::new(logs),
+                chain_id_calls: AtomicU64::new(0),
+                finalized_calls: AtomicU64::new(0),
+                log_calls: AtomicU64::new(0),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl PolygonRpc for MockPolygonRpc {
+        async fn chain_id(&self) -> Result<u64> {
+            self.chain_id_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.chain_id)
+        }
+
+        async fn finalized_block_number(&self) -> Result<u64> {
+            self.finalized_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.finalized_block.load(Ordering::Relaxed))
+        }
+
+        async fn logs(&self, _filter: &Filter) -> Result<Vec<Log>> {
+            self.log_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.logs.lock().await.clone())
+        }
+    }
+
+    fn source_uri(from_block: u64, max_blocks_per_poll: u64) -> String {
+        format!(
+            "gravity://6/{MIRROR_ID}/polymarket_settlement?ctf={}&condition={}&fromBlock={from_block}&chainId=137&maxBlocksPerPoll={max_blocks_per_poll}",
+            ctf_address(),
+            condition_id()
+        )
+    }
+
+    fn source_with_rpc(
+        rpc: Arc<MockPolygonRpc>,
+        latest_nonce: u128,
+        latest_position: u64,
+        cursor: u64,
+        max_blocks_per_poll: u64,
+    ) -> Result<PolymarketSettlementSource> {
+        let task = parse_oracle_uri(&source_uri(cursor, max_blocks_per_poll))?;
+        PolymarketSettlementSource::from_task_with_rpc(
+            &task,
+            rpc,
+            latest_nonce,
+            latest_position,
+            cursor,
+        )
+    }
+
+    #[test]
+    fn decodes_condition_resolution_and_derives_identity() {
+        let observation = decode_condition_resolution_log(
+            &settlement_log(),
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            condition_id(),
+        )
+        .unwrap();
+
+        assert_eq!(observation.mirror_id, MIRROR_ID);
+        assert_eq!(observation.polygon_chain_id, DEFAULT_POLYGON_CHAIN_ID);
+        assert_eq!(observation.condition_id, condition_id());
+        assert_eq!(observation.question_id, question_id());
+        assert_eq!(observation.outcome_slot_count, U256::from(2));
+        assert_eq!(observation.payout_numerators, vec![U256::ZERO, U256::from(1)]);
+        assert_eq!(observation.tx_hash, tx_hash());
+        assert_eq!(observation.log_index, LOG_INDEX);
+        assert_eq!(observation.block_number, BLOCK_NUMBER);
+    }
+
+    #[test]
+    fn resolver_payload_matches_final_contract_abi_field_for_field() {
+        let observation = decode_condition_resolution_log(
+            &settlement_log(),
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            condition_id(),
+        )
+        .unwrap();
+        let data = observation_to_oracle_data(&observation);
+
+        let (nonce, position, resolver_payload) =
+            <(u128, U256, Bytes)>::abi_decode(&data.payload).unwrap();
+        assert_eq!((nonce, position, resolver_payload.clone()).abi_encode(), data.payload);
+        assert_eq!(nonce, 1);
+        assert_eq!(position, U256::from(BLOCK_NUMBER));
+
+        let payload = PolymarketSettlementPayloadSol::abi_decode(&resolver_payload).unwrap();
+        assert_eq!(payload.abi_encode(), resolver_payload);
+        assert_eq!(payload.mirrorId, U256::from(MIRROR_ID));
+        assert_eq!(payload.polygonChainId, U256::from(DEFAULT_POLYGON_CHAIN_ID));
+        assert_eq!(payload.ctf, ctf_address());
+        assert_eq!(payload.oracle, oracle_address());
+        assert_eq!(payload.conditionId, condition_id());
+        assert_eq!(payload.questionId, question_id());
+        assert_eq!(payload.outcomeSlotCount, U256::from(2));
+        assert_eq!(payload.payoutNumerators, vec![U256::ZERO, U256::from(1)]);
+        assert_eq!(payload.txHash, tx_hash());
+        assert_eq!(payload.logIndex, U256::from(LOG_INDEX));
+        assert_eq!(payload.settlementKind, CTF_CONDITION_RESOLUTION);
+    }
+
+    #[test]
+    fn rejects_filter_condition_mismatch() {
+        let other_condition =
+            b256!("3333333333333333333333333333333333333333333333333333333333333333");
+        let error = decode_condition_resolution_log(
+            &settlement_log(),
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            other_condition,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("condition mismatch"));
+    }
+
+    #[test]
+    fn rejects_condition_not_derived_from_event_identity() {
+        let arbitrary_condition =
+            b256!("3333333333333333333333333333333333333333333333333333333333333333");
+        let log =
+            settlement_log_with_condition(arbitrary_condition, BLOCK_NUMBER, LOG_INDEX, tx_hash());
+        let error = decode_condition_resolution_log(
+            &log,
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            arbitrary_condition,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("does not match oracle"));
+    }
+
+    #[test]
+    fn rejects_invalid_payout_vectors() {
+        let error = validate_payouts(U256::from(1), &[U256::from(1)]).unwrap_err();
+        assert!(error.to_string().contains("at least 2"));
+
+        let error = validate_payouts(U256::from(2), &[U256::ZERO]).unwrap_err();
+        assert!(error.to_string().contains("payout length mismatch"));
+
+        let error = validate_payouts(U256::from(2), &[U256::ZERO, U256::ZERO]).unwrap_err();
+        assert!(error.to_string().contains("all zero"));
+
+        let payouts = vec![U256::from(1); MAX_OUTCOME_SLOT_COUNT + 1];
+        let error = validate_payouts(U256::from(payouts.len()), &payouts).unwrap_err();
+        assert!(error.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn rejects_removed_or_incomplete_log_metadata() {
+        let mut log = settlement_log();
+        log.removed = true;
+        let error = decode_condition_resolution_log(
+            &log,
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            condition_id(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot be removed"));
+
+        let mut log = settlement_log();
+        log.transaction_hash = None;
+        let error = decode_condition_resolution_log(
+            &log,
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            condition_id(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("missing transaction_hash"));
+
+        let mut log = settlement_log();
+        log.transaction_hash = Some(B256::ZERO);
+        let error = decode_condition_resolution_log(
+            &log,
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            condition_id(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("zero transaction_hash"));
+    }
+
+    #[test]
+    fn deduplicates_only_the_same_polygon_log_identity() {
+        let observation = decode_condition_resolution_log(
+            &settlement_log(),
+            MIRROR_ID,
+            DEFAULT_POLYGON_CHAIN_ID,
+            ctf_address(),
+            condition_id(),
+        )
+        .unwrap();
+
+        let mut observations = vec![observation.clone(), observation];
+        sort_and_dedup_observations(&mut observations);
+        assert_eq!(observations.len(), 1);
+
+        let mut distinct = observations[0].clone();
+        distinct.log_index += 1;
+        distinct.tx_hash = second_tx_hash();
+        observations.push(distinct);
+        sort_and_dedup_observations(&mut observations);
+        assert_eq!(observations.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn polls_only_finalized_range_and_emits_terminal_nonce_one() {
+        let cursor = BLOCK_NUMBER - 2;
+        let rpc = MockPolygonRpc::new(137, BLOCK_NUMBER + 5, vec![settlement_log()]);
+        let source = source_with_rpc(rpc.clone(), 0, 0, cursor, 10).unwrap();
+
+        let data = source.poll().await.unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].nonce, 1);
+        assert_eq!(data[0].source_position, BLOCK_NUMBER);
+        assert_eq!(source.cursor(), BLOCK_NUMBER + 5);
+        assert_eq!(source.last_nonce().await, Some(1));
+        assert_eq!(source.last_nonce_position().await, Some(BLOCK_NUMBER));
+        assert_eq!(rpc.chain_id_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(rpc.finalized_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(rpc.log_calls.load(Ordering::Relaxed), 1);
+
+        assert!(source.poll().await.unwrap().is_empty());
+        assert_eq!(rpc.finalized_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(rpc.log_calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_rpc_logs_produce_one_terminal_observation() {
+        let cursor = BLOCK_NUMBER - 2;
+        let log = settlement_log();
+        let rpc = MockPolygonRpc::new(137, BLOCK_NUMBER, vec![log.clone(), log]);
+        let source = source_with_rpc(rpc, 0, 0, cursor, 10).unwrap();
+
+        let data = source.poll().await.unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].nonce, 1);
+    }
+
+    #[tokio::test]
+    async fn distinct_terminal_logs_fail_without_advancing_cursor() {
+        let cursor = BLOCK_NUMBER - 2;
+        let second = settlement_log_at(BLOCK_NUMBER, LOG_INDEX + 1, second_tx_hash());
+        let rpc = MockPolygonRpc::new(137, BLOCK_NUMBER, vec![settlement_log(), second]);
+        let source = source_with_rpc(rpc, 0, 0, cursor, 10).unwrap();
+
+        let error = source.poll().await.unwrap_err();
+
+        assert!(error.to_string().contains("multiple distinct settlements"));
+        assert_eq!(source.cursor(), cursor);
+        assert_eq!(source.last_nonce().await, None);
+    }
+
+    #[tokio::test]
+    async fn empty_finalized_scan_advances_bounded_cursor_without_nonce() {
+        let cursor = BLOCK_NUMBER;
+        let rpc = MockPolygonRpc::new(137, BLOCK_NUMBER + 100, vec![]);
+        let source = source_with_rpc(rpc, 0, 0, cursor, 10).unwrap();
+
+        assert!(source.poll().await.unwrap().is_empty());
+        assert_eq!(source.cursor(), cursor + 10);
+        assert_eq!(source.last_nonce().await, None);
+    }
+
+    #[tokio::test]
+    async fn rejects_rpc_log_outside_requested_finalized_range_without_progress() {
+        let cursor = BLOCK_NUMBER;
+        let finalized = BLOCK_NUMBER + 5;
+        let out_of_range = settlement_log_at(finalized + 1, LOG_INDEX, tx_hash());
+        let rpc = MockPolygonRpc::new(137, finalized, vec![out_of_range]);
+        let source = source_with_rpc(rpc, 0, 0, cursor, 10).unwrap();
+
+        let error = source.poll().await.unwrap_err();
+
+        assert!(error.to_string().contains("outside requested finalized range"));
+        assert_eq!(source.cursor(), cursor);
+        assert_eq!(source.last_nonce().await, None);
+    }
+
+    #[tokio::test]
+    async fn rejects_non_polygon_rpc_before_scanning() {
+        let cursor = BLOCK_NUMBER;
+        let rpc = MockPolygonRpc::new(1, BLOCK_NUMBER + 1, vec![]);
+        let source = source_with_rpc(rpc.clone(), 0, 0, cursor, 10).unwrap();
+
+        let error = source.poll().await.unwrap_err();
+
+        assert!(error.to_string().contains("chain id mismatch"));
+        assert_eq!(source.cursor(), cursor);
+        assert_eq!(rpc.finalized_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(rpc.log_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn reconciles_terminal_progress_and_never_refetches() {
+        let cursor = BLOCK_NUMBER - 10;
+        let rpc = MockPolygonRpc::new(1, BLOCK_NUMBER + 100, vec![settlement_log()]);
+        let source = source_with_rpc(rpc.clone(), 0, 0, cursor, 100).unwrap();
+
+        source.reconcile_progress(1, BLOCK_NUMBER).await.unwrap();
+
+        assert_eq!(source.cursor(), BLOCK_NUMBER);
+        assert_eq!(source.last_nonce().await, Some(1));
+        assert_eq!(source.last_nonce_position().await, Some(BLOCK_NUMBER));
+        assert!(source.poll().await.unwrap().is_empty());
+        assert_eq!(rpc.chain_id_calls.load(Ordering::Relaxed), 0);
+
+        let error = source.reconcile_progress(2, BLOCK_NUMBER + 1).await.unwrap_err();
+        assert!(error.to_string().contains("terminal"));
+    }
+
+    #[test]
+    fn validates_uri_and_terminal_history() {
+        let rpc = MockPolygonRpc::new(137, BLOCK_NUMBER, vec![]);
+
+        let task = parse_oracle_uri(&source_uri(BLOCK_NUMBER, 10)).unwrap();
+        let source = PolymarketSettlementSource::from_task_with_rpc(
+            &task,
+            rpc.clone(),
+            1,
+            BLOCK_NUMBER,
+            BLOCK_NUMBER,
+        )
+        .unwrap();
+        assert_eq!(source.max_blocks_per_poll(), 10);
+
+        let error = PolymarketSettlementSource::from_task_with_rpc(
+            &task,
+            rpc.clone(),
+            2,
+            BLOCK_NUMBER,
+            BLOCK_NUMBER,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("terminal"));
+
+        let error =
+            PolymarketSettlementSource::from_task_with_rpc(&task, rpc.clone(), 0, 1, BLOCK_NUMBER)
+                .unwrap_err();
+        assert!(error.to_string().contains("zero nonce"));
+
+        let error = PolymarketSettlementSource::from_task_with_rpc(
+            &task,
+            rpc,
+            1,
+            BLOCK_NUMBER + 1,
+            BLOCK_NUMBER,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("exceeds scan cursor"));
+    }
+
+    #[test]
+    fn rejects_unsupported_or_missing_uri_parameters() {
+        let rpc = MockPolygonRpc::new(137, BLOCK_NUMBER, vec![]);
+
+        for (uri, expected) in [
+            (
+                format!("{}&unknown=value", source_uri(BLOCK_NUMBER, 10)),
+                "Unsupported Polymarket settlement parameter",
+            ),
+            (
+                format!(
+                    "gravity://6/{MIRROR_ID}/wrong_task?ctf={}&condition={}&fromBlock={BLOCK_NUMBER}",
+                    ctf_address(),
+                    condition_id()
+                ),
+                "requires task type",
+            ),
+            (
+                format!(
+                    "gravity://6/{MIRROR_ID}/polymarket_settlement?ctf={}&condition={}",
+                    ctf_address(),
+                    condition_id()
+                ),
+                "Missing 'fromBlock'",
+            ),
+            (
+                format!(
+                    "gravity://6/{MIRROR_ID}/polymarket_settlement?ctf={}&fromBlock={BLOCK_NUMBER}",
+                    ctf_address()
+                ),
+                "Missing 'condition'",
+            ),
+            (
+                format!(
+                    "gravity://6/{MIRROR_ID}/polymarket_settlement?ctf={}&condition={}&fromBlock={BLOCK_NUMBER}&chainId=1",
+                    ctf_address(),
+                    condition_id()
+                ),
+                "chainId must be 137",
+            ),
+            (
+                source_uri(BLOCK_NUMBER, 0),
+                "maxBlocksPerPoll",
+            ),
+            (
+                source_uri(BLOCK_NUMBER, MAX_BLOCKS_PER_POLL + 1),
+                "maxBlocksPerPoll",
+            ),
+        ] {
+            let task = parse_oracle_uri(&uri).unwrap();
+            let error = PolymarketSettlementSource::from_task_with_rpc(
+                &task,
+                rpc.clone(),
+                0,
+                0,
+                task.from_block(),
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains(expected), "{uri}: {error}");
+        }
+    }
+}

--- a/crates/pipe-exec-layer-ext-v2/relayer/src/uri_parser.rs
+++ b/crates/pipe-exec-layer-ext-v2/relayer/src/uri_parser.rs
@@ -13,6 +13,9 @@
 //! - Binance index kline price feed:
 //!   `gravity://3/2001/price_feed?provider=binance_index_kline_v1&pair=TSLAUSDT&interval=1m&
 //!   bucketStartMs=1710000000000&decimals=8`
+//! - Polygon CTF settlement:
+//!   `gravity://6/9001/polymarket_settlement?ctf=0x4D97...&condition=0x2afe...&
+//!   fromBlock=89000000&chainId=137`
 
 use alloy_primitives::Address;
 use anyhow::{anyhow, Result};
@@ -25,7 +28,7 @@ pub struct ParsedOracleTask {
     /// Original URI string
     pub uri: String,
 
-    /// Source type (`0=BLOCKCHAIN`, `3=PRICE_FEED`)
+    /// Source type (`0=BLOCKCHAIN`, `3=PRICE_FEED`, `6=POLYMARKET_SETTLEMENT`)
     pub source_type: u32,
 
     /// Source identifier (chain ID, etc.)
@@ -64,6 +67,11 @@ impl ParsedOracleTask {
     /// Check if this is a price feed source
     pub const fn is_price_feed(&self) -> bool {
         self.source_type == 3
+    }
+
+    /// Check if this is a Polygon Polymarket settlement source.
+    pub const fn is_polymarket_settlement(&self) -> bool {
+        self.source_type == 6
     }
 }
 
@@ -146,6 +154,18 @@ mod tests {
         assert_eq!(task.task_type, "price_feed");
         assert!(task.is_price_feed());
         assert_eq!(task.params.get("decimals").map(String::as_str), Some("8"));
+    }
+
+    #[test]
+    fn test_parse_polymarket_settlement_uri() {
+        let uri = "gravity://6/9001/polymarket_settlement?ctf=0x4D97DCd97eC945f40cF65F87097ACe5EA0476045&condition=0x2afe86f96be81a0d89ed776bedbd52d1c75bc47b49e6f0f791ddd009f52faf23&fromBlock=89000000&chainId=137";
+        let task = parse_oracle_uri(uri).unwrap();
+
+        assert_eq!(task.source_type, 6);
+        assert_eq!(task.source_id, 9001);
+        assert_eq!(task.task_type, "polymarket_settlement");
+        assert_eq!(task.from_block(), 89_000_000);
+        assert!(task.is_polymarket_settlement());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add relayer source type `6` for one-shot Polymarket CTF settlement mirrors
- scan validator-local Polygon RPC endpoints through bounded finalized ranges
- validate the exact CTF contract, indexed condition, source chain, event identity, payout vector, and returned log range
- emit the final `PolymarketSettlementPayload` ABI consumed by `gravity_chain_core_contracts#115`
- route agreed unsupported-JWK bytes through `NativeOracle.recordBatch` with the standard `500000` callback gas limit
- document market discovery, task registration, finality, cursor, nonce, and restart semantics

## Task URI

```text
gravity://6/<mirrorId>/polymarket_settlement?ctf=<ctf>&condition=<conditionId>&fromBlock=<cursor>&chainId=137&maxBlocksPerPoll=1000
```

RPC URLs and credentials remain validator-local. The on-chain URI contains only deterministic consensus configuration.

## Finality and idempotency

- verifies `eth_chainId == 137`
- takes the upper watermark from `eth_getBlockByNumber("finalized", false)`
- scans at most `maxBlocksPerPoll` blocks per poll
- persists empty finalized scans so restarts do not repeatedly rescan the same range
- sorts by `(blockNumber, logIndex, transactionHash)` and deduplicates only identical log identities
- fails closed without cursor progress when more than one distinct terminal settlement is returned
- uses one terminal delivery nonce, exactly `1`; confirmed nonce `1` disables further Polygon RPC calls
- keeps the settlement block (`sourcePosition`) separate from the later scan cursor

## Contract compatibility

The provider recomputes:

```solidity
conditionId == keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount))
```

Its resolver payload is decoded field-for-field in unit tests against the final struct merged in `Galxe/gravity_chain_core_contracts#115`. The outer wrapper remains:

```solidity
abi.encode(uint128 nonce, uint256 sourcePosition, bytes callbackPayload)
```

No dependency or lockfile changes are included.

## Validation

- `cargo test -p reth-pipe-exec-layer-relayer --no-fail-fast`: 59 passed, 0 failed, 1 external-RPC test ignored
- `cargo test -p reth-pipe-exec-layer-ext-v2 onchain_config::jwk_oracle --no-fail-fast`: 10 passed
- `cargo test -p reth-pipe-exec-layer-ext-v2 onchain_config::oracle_task_helpers --lib --no-fail-fast`: 1 passed
- `cargo +nightly fmt --all -- --check`: passed
- `cargo clippy -p reth-pipe-exec-layer-relayer --all-targets`: passed; reported only pre-existing warnings in untouched code
- full execute library suite: 96 passed, 1 known baseline failure in `system_caller_migration::tests::test_migration_defensive_when_system_caller_absent`; its source and dependency inputs are unchanged by this PR

The relayer tests inject an in-memory Polygon RPC and do not contact an external endpoint.

## Scope

This is the single remaining `gravity-reth` Polymarket provider PR in the oracle split tracked by `Galxe/gravity-audit#1038`. SDK/product E2E wiring follows only after this provider is merged.
