### PR TITLE
feat(hardfork): add TestnetOwnerFixV2 one-shot for Longevity

### DIFF
--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -57,7 +57,7 @@ hardfork!(
     }
 );
 
-/// Longevity Testnet chain id. Gates TestnetOwnerFix / TestnetOwnerFixV2.
+/// Longevity Testnet chain id. Gates `TestnetOwnerFix` / `TestnetOwnerFixV2`.
 pub const LONGEVITY_TESTNET_CHAIN_ID: u64 = 7_771_625;
 
 /// Canonical sender address of every Gravity protocol-injected system transaction

--- a/crates/chainspec/src/gravity.rs
+++ b/crates/chainspec/src/gravity.rs
@@ -16,10 +16,10 @@ hardfork!(
         /// Beta hardfork: consensus-critical filter policy changes.
         ///
         /// Until Beta activates:
-        /// - EIP-7702 lockdown (audit#838): reject type-4 txs and txs from/to
-        ///   currently-delegated accounts.
-        /// - Block-gas packing (audit#646): prefix-cut on cumulative `tx.gas_limit()`
-        ///   and treat the suffix as discarded (pre-Beta STF).
+        /// - EIP-7702 lockdown (audit#838): reject type-4 txs and txs from/to currently-delegated
+        ///   accounts.
+        /// - Block-gas packing (audit#646): prefix-cut on cumulative `tx.gas_limit()` and treat
+        ///   the suffix as discarded (pre-Beta STF).
         ///
         /// From Beta onward, lockdown is released and gas packing becomes last-gate
         /// (invalid txs do not steal budget; packing continues after a non-fit). Gas
@@ -42,11 +42,22 @@ hardfork!(
         /// pipe layer also requires `chain_id == 7771625`; any other chain is a
         /// no-op even when the timestamp key is present. Missing or malformed
         /// configuration leaves the migration disabled (fail-closed).
+        ///
+        /// Longevity already crossed this one-shot with a wrong `new_owner`
+        /// table; do not reschedule it. Use [`Self::TestnetOwnerFixV2`] to
+        /// overwrite `pendingOwner` with cast-derived addresses.
         TestnetOwnerFix,
+        /// Longevity follow-up: same injection as [`Self::TestnetOwnerFix`], but
+        /// a fresh one-shot so the cast-derived `new_owner` table can fire after
+        /// the v1 activation already consumed `testnetOwnerFixTime`.
+        ///
+        /// Activation is timestamp-based via genesis `testnetOwnerFixV2Time`.
+        /// Same Longevity `chain_id` gate and fail-closed parse rules as v1.
+        TestnetOwnerFixV2,
     }
 );
 
-/// Longevity Testnet chain id. Gates [`GravityHardfork::TestnetOwnerFix`].
+/// Longevity Testnet chain id. Gates TestnetOwnerFix / TestnetOwnerFixV2.
 pub const LONGEVITY_TESTNET_CHAIN_ID: u64 = 7_771_625;
 
 /// Canonical sender address of every Gravity protocol-injected system transaction

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -1007,6 +1007,14 @@ impl From<Genesis> for ChainSpec {
                 ForkCondition::Timestamp(testnet_owner_fix_time),
             ));
         }
+        if let Some(testnet_owner_fix_v2_time) =
+            genesis.config.extra_fields.get("testnetOwnerFixV2Time").and_then(|v| v.as_u64())
+        {
+            gravity_hardforks.push((
+                GravityHardfork::TestnetOwnerFixV2.boxed(),
+                ForkCondition::Timestamp(testnet_owner_fix_v2_time),
+            ));
+        }
         let gravity_hardforks = ChainHardforks::new(gravity_hardforks);
 
         // This is intentionally optional: Gravity chains enable the fee floor through genesis,
@@ -2698,6 +2706,26 @@ Post-merge hard forks (timestamp based):
     }
 
     #[test]
+    fn test_parse_testnet_owner_fix_v2_time() {
+        let mut genesis = Genesis::default();
+        genesis
+            .config
+            .extra_fields
+            .insert("testnetOwnerFixV2Time".to_string(), serde_json::json!(99_002));
+
+        let chainspec = ChainSpec::from(genesis);
+        assert_eq!(
+            chainspec.gravity_hardforks.fork(GravityHardfork::TestnetOwnerFixV2),
+            ForkCondition::Timestamp(99_002)
+        );
+        // Independent of v1: missing v1 key stays Never.
+        assert_eq!(
+            chainspec.gravity_hardforks.fork(GravityHardfork::TestnetOwnerFix),
+            ForkCondition::Never
+        );
+    }
+
+    #[test]
     fn test_testnet_owner_fix_time_is_fail_closed() {
         for (key, value) in [
             ("testnetOwnerFixBlock", serde_json::json!(99_001)),
@@ -2710,6 +2738,26 @@ Post-merge hard forks (timestamp based):
             let chainspec = ChainSpec::from(genesis);
             assert_eq!(
                 chainspec.gravity_hardforks.fork(GravityHardfork::TestnetOwnerFix),
+                ForkCondition::Never
+            );
+        }
+    }
+
+    #[test]
+    fn test_testnet_owner_fix_v2_time_is_fail_closed() {
+        for (key, value) in [
+            ("testnetOwnerFixV2Block", serde_json::json!(99_002)),
+            ("testnetOwnerFixV2Time", serde_json::json!("99002")),
+            ("testnet_owner_fix_v2_time", serde_json::json!(99_002)),
+            // v1 key must not schedule v2
+            ("testnetOwnerFixTime", serde_json::json!(99_001)),
+        ] {
+            let mut genesis = Genesis::default();
+            genesis.config.extra_fields.insert(key.to_string(), value);
+
+            let chainspec = ChainSpec::from(genesis);
+            assert_eq!(
+                chainspec.gravity_hardforks.fork(GravityHardfork::TestnetOwnerFixV2),
                 ForkCondition::Never
             );
         }

--- a/crates/ethereum/evm/src/hardfork/testnet_owner_fix.rs
+++ b/crates/ethereum/evm/src/hardfork/testnet_owner_fix.rs
@@ -14,7 +14,7 @@
 //! The txs are written into the block body with `TransactionSenders = old_owner`.
 //!
 //! V2 exists because Longevity already consumed the v1 one-shot with a wrong
-//! (CLI compressed-pubkey) `new_owner` table; Ownable2Step lets a later
+//! (CLI compressed-pubkey) `new_owner` table; `Ownable2Step` lets a later
 //! `transferOwnership` from the same `old_owner` overwrite `pendingOwner`.
 //!
 //! This module owns the hardcoded migration table and calldata encoding.

--- a/crates/ethereum/evm/src/hardfork/testnet_owner_fix.rs
+++ b/crates/ethereum/evm/src/hardfork/testnet_owner_fix.rs
@@ -1,16 +1,21 @@
-//! `TestnetOwnerFix` hardfork — forced `Ownable2Step` `transferOwnership` migration.
+//! `TestnetOwnerFix` / `TestnetOwnerFixV2` — forced `Ownable2Step`
+//! `transferOwnership` migration.
 //!
 //! Longevity Testnet (`chain_id == 7771625`) genesis `StakePool`s used Aptos-era
 //! identity material as `owner`. Those addresses look like EOAs but have no
 //! recoverable secp256k1 private key, so `onlyOwner` admin paths are stuck.
 //!
-//! On the unique Longevity block that crosses `testnetOwnerFixTime`
-//! (`transitions_at_timestamp`, same one-shot gate as Alpha / EIP-2935), the
-//! pipe layer injects four synthetic top-level txs (one per genesis pool) with
-//! `from = old_owner`, calling `transferOwnership(new_owner)`. Gas reuses the
-//! existing Alpha system-tx levers (`gas_price = 0` + `transact_system_txn`
-//! basefee/balance disable). The txs are written into the block body with
-//! `TransactionSenders = old_owner`.
+//! On the unique Longevity block that crosses `testnetOwnerFixTime` or
+//! `testnetOwnerFixV2Time` (`transitions_at_timestamp`, same one-shot gate as
+//! Alpha / EIP-2935), the pipe layer injects four synthetic top-level txs (one
+//! per genesis pool) with `from = old_owner`, calling
+//! `transferOwnership(new_owner)`. Gas reuses the existing Alpha system-tx
+//! levers (`gas_price = 0` + `transact_system_txn` basefee/balance disable).
+//! The txs are written into the block body with `TransactionSenders = old_owner`.
+//!
+//! V2 exists because Longevity already consumed the v1 one-shot with a wrong
+//! (CLI compressed-pubkey) `new_owner` table; Ownable2Step lets a later
+//! `transferOwnership` from the same `old_owner` overwrite `pendingOwner`.
 //!
 //! This module owns the hardcoded migration table and calldata encoding.
 //! There is no slot precheck: any forced-tx revert panics at execution time.
@@ -84,5 +89,41 @@ mod tests {
         let data = transfer_ownership_calldata(MIGRATION_TABLE[0].new_owner);
         assert_eq!(&data[..4], &[0xf2, 0xfd, 0xe3, 0x8b]);
         assert_eq!(data.len(), 4 + 32);
+    }
+
+    /// Pin cast-derived ceremony addresses. The v1 activation used the wrong
+    /// CLI compressed-pubkey hashes; those must never re-enter this table.
+    #[test]
+    fn migration_table_new_owners_are_cast_derived() {
+        assert_eq!(
+            MIGRATION_TABLE[0].new_owner,
+            address!("91a59bae639a3cef0c41e4c61268aa54c71de1ba")
+        );
+        assert_eq!(
+            MIGRATION_TABLE[1].new_owner,
+            address!("6a0da8def2ccd134119c0293ad470d1aa1d6129a")
+        );
+        assert_eq!(
+            MIGRATION_TABLE[2].new_owner,
+            address!("5a1ba49d261e1e58dd1b8cf0aeeb1976d04ac6bd")
+        );
+        assert_eq!(
+            MIGRATION_TABLE[3].new_owner,
+            address!("2326795e2033d209ea12b1022c50ae592ac2b720")
+        );
+
+        let wrong_cli_addrs = [
+            address!("c7536c625758b3072c43eab8e8880c1ae8cb4cf9"),
+            address!("f0de80e6df293be1b81d106afd5ae5430079e9d2"),
+            address!("2c26bab4ebcc88fb0ad580652938a27e906037f0"),
+            address!("3e1b5fab188ddc208c547dd689b0f6b4864b4127"),
+        ];
+        for row in &MIGRATION_TABLE {
+            assert!(
+                !wrong_cli_addrs.contains(&row.new_owner),
+                "{} new_owner must not be the v1 CLI compressed-pubkey address",
+                row.label
+            );
+        }
     }
 }

--- a/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/lib.rs
@@ -1302,8 +1302,8 @@ impl<Storage: GravityStorage> Core<Storage> {
             system_tx_gas_price,
         );
 
-        // Single TestnetOwnerFix seam: after protocol system txs, before user
-        // txs / epoch-block assembly. Longevity-only one-shot via
+        // Single OwnerFix seam (v1 or v2): after protocol system txs, before
+        // user txs / epoch-block assembly. Longevity-only one-shot via
         // transitions_at_timestamp; forced-tx revert → panic inside the helper.
         let fix_owner_results = testnet_owner_fix::execute_forced_transfers(
             &mut *executor,

--- a/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/onchain_config/metadata_txn.rs
@@ -76,7 +76,7 @@ impl SystemTxnResult {
 
     /// Insert this system/protocol-injected transaction into an existing executed block
     /// result at `insert_position`. Position 0 is typically the metadata tx; later
-    /// positions are validator system txs and (on Longevity) TestnetOwnerFix forced txs.
+    /// positions are validator system txs and (on Longevity) `TestnetOwnerFix` forced txs.
     pub(crate) fn insert_to_executed_ordered_block_result(
         self,
         result: &mut crate::ExecuteOrderedBlockResult,

--- a/crates/pipe-exec-layer-ext-v2/execute/src/testnet_owner_fix.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/testnet_owner_fix.rs
@@ -1,4 +1,4 @@
-//! Pipe-layer injection for [`GravityHardfork::TestnetOwnerFix`].
+//! Pipe-layer injection for TestnetOwnerFix / TestnetOwnerFixV2.
 //!
 //! Runs after metadata/DKG/JWK system txs and before user txs. Constructs four
 //! forced `transferOwnership` calls with `from = old_owner`, executes them via
@@ -7,8 +7,13 @@
 //!
 //! One-shot gate matches Alpha / EIP-2935:
 //! `transitions_at_timestamp(current_ts, parent_ts)` — fires only on the unique
-//! Longevity activation block. Wrong chain / non-crossing block → empty vec.
-//! Any forced-tx revert panics so the block is not committed as a success.
+//! Longevity activation block for whichever fork is crossing. Wrong chain /
+//! non-crossing block → empty vec. Any forced-tx revert panics so the block is
+//! not committed as a success.
+//!
+//! V2 is a fresh one-shot for Longevity after v1 already consumed
+//! `testnetOwnerFixTime` with the wrong `new_owner` table. Both forks share
+//! [`MIGRATION_TABLE`] (cast-derived addresses).
 
 use crate::onchain_config::{new_system_call_txn, SystemTxnResult};
 use reth_chainspec::{ChainSpec, EthChainSpec, GravityHardfork, LONGEVITY_TESTNET_CHAIN_ID};
@@ -24,11 +29,12 @@ use tracing::info;
 type Executor<'a> =
     &'a mut dyn ParallelExecutor<Primitives = EthPrimitives, Error = BlockExecutionError>;
 
-/// Execute `TestnetOwnerFix` forced transfers on the Longevity activation block.
+/// Execute forced ownership transfers on a Longevity OwnerFix crossing block.
 ///
-/// Returns an empty vec when `chain_id` is not Longevity or when
-/// `parent_ts < fixTime <= current_ts` is false. Panics if any forced transfer
-/// fails to execute or reverts.
+/// Returns an empty vec when `chain_id` is not Longevity or when neither
+/// `TestnetOwnerFix` nor `TestnetOwnerFixV2` is crossing
+/// (`parent_ts < fixTime <= current_ts`). Panics if any forced transfer fails
+/// to execute or reverts.
 pub(crate) fn execute_forced_transfers(
     executor: Executor<'_>,
     chain_spec: &ChainSpec,
@@ -41,26 +47,34 @@ pub(crate) fn execute_forced_transfers(
     if chain_spec.chain().id() != LONGEVITY_TESTNET_CHAIN_ID {
         return Vec::new();
     }
-    if !chain_spec
+
+    let crossing_v2 = chain_spec
+        .gravity_hardforks()
+        .fork(GravityHardfork::TestnetOwnerFixV2)
+        .transitions_at_timestamp(block_timestamp, parent_timestamp);
+    let crossing_v1 = chain_spec
         .gravity_hardforks()
         .fork(GravityHardfork::TestnetOwnerFix)
-        .transitions_at_timestamp(block_timestamp, parent_timestamp)
-    {
+        .transitions_at_timestamp(block_timestamp, parent_timestamp);
+    if !crossing_v2 && !crossing_v1 {
         return Vec::new();
     }
+    // Prefer V2 label when both somehow share a timestamp (should not happen in
+    // production genesis); still inject only once.
+    let fork_label = if crossing_v2 { "TestnetOwnerFixV2" } else { "TestnetOwnerFix" };
 
     let mut results = Vec::with_capacity(MIGRATION_TABLE.len());
     for row in &MIGRATION_TABLE {
         let result = execute_one(executor, evm_env.clone(), system_tx_gas_price, row)
             .unwrap_or_else(|e| {
                 panic!(
-                    "TestnetOwnerFix: forced transferOwnership failed for {} ({}) at block {block_number}: {e:?}",
+                    "{fork_label}: forced transferOwnership failed for {} ({}) at block {block_number}: {e:?}",
                     row.label, row.stake_pool
                 )
             });
         if !result.result.is_success() {
             panic!(
-                "TestnetOwnerFix: transferOwnership reverted for {} ({}) at block {block_number}: {:?}",
+                "{fork_label}: transferOwnership reverted for {} ({}) at block {block_number}: {:?}",
                 row.label,
                 row.stake_pool,
                 result.result
@@ -75,7 +89,8 @@ pub(crate) fn execute_forced_transfers(
         timestamp = block_timestamp,
         parent_timestamp,
         pools = MIGRATION_TABLE.len(),
-        "TestnetOwnerFix: injected forced transferOwnership txs"
+        fork = fork_label,
+        "OwnerFix: injected forced transferOwnership txs"
     );
     results
 }
@@ -108,16 +123,32 @@ mod tests {
     use std::sync::Arc;
 
     const FIX_TS: u64 = 1_700_000_000;
+    const FIX_V2_TS: u64 = 1_800_000_000;
 
-    fn longevity_spec_with_fix(fix_ts: Option<u64>) -> Arc<ChainSpec> {
+    fn longevity_spec_with_forks(v1_ts: Option<u64>, v2_ts: Option<u64>) -> Arc<ChainSpec> {
         let mut genesis = MAINNET.genesis.clone();
         genesis.config.chain_id = LONGEVITY_TESTNET_CHAIN_ID;
         let mut spec = ChainSpec::from(genesis);
-        if let Some(ts) = fix_ts {
-            spec.gravity_hardforks = ChainHardforks::from([(
-                GravityHardfork::TestnetOwnerFix,
-                ForkCondition::Timestamp(ts),
-            )]);
+        match (v1_ts, v2_ts) {
+            (Some(v1), Some(v2)) => {
+                spec.gravity_hardforks = ChainHardforks::from([
+                    (GravityHardfork::TestnetOwnerFix, ForkCondition::Timestamp(v1)),
+                    (GravityHardfork::TestnetOwnerFixV2, ForkCondition::Timestamp(v2)),
+                ]);
+            }
+            (Some(v1), None) => {
+                spec.gravity_hardforks = ChainHardforks::from([(
+                    GravityHardfork::TestnetOwnerFix,
+                    ForkCondition::Timestamp(v1),
+                )]);
+            }
+            (None, Some(v2)) => {
+                spec.gravity_hardforks = ChainHardforks::from([(
+                    GravityHardfork::TestnetOwnerFixV2,
+                    ForkCondition::Timestamp(v2),
+                )]);
+            }
+            (None, None) => {}
         }
         Arc::new(spec)
     }
@@ -129,10 +160,10 @@ mod tests {
             .cancun_activated()
             .prague_activated()
             .build();
-        spec.gravity_hardforks = ChainHardforks::from([(
-            GravityHardfork::TestnetOwnerFix,
-            ForkCondition::Timestamp(FIX_TS),
-        )]);
+        spec.gravity_hardforks = ChainHardforks::from([
+            (GravityHardfork::TestnetOwnerFix, ForkCondition::Timestamp(FIX_TS)),
+            (GravityHardfork::TestnetOwnerFixV2, ForkCondition::Timestamp(FIX_V2_TS)),
+        ]);
         let spec = Arc::new(spec);
         assert_ne!(spec.chain().id(), LONGEVITY_TESTNET_CHAIN_ID);
 
@@ -145,15 +176,15 @@ mod tests {
             EvmEnv::default(),
             0,
             1,
-            FIX_TS,
-            FIX_TS - 1,
+            FIX_V2_TS,
+            FIX_V2_TS - 1,
         );
         assert!(out.is_empty());
     }
 
     #[test]
     fn unscheduled_fork_is_noop_on_longevity_chain_id() {
-        let spec = longevity_spec_with_fix(None);
+        let spec = longevity_spec_with_forks(None, None);
         assert_eq!(spec.chain().id(), LONGEVITY_TESTNET_CHAIN_ID);
 
         let db = CacheDB::<EmptyDB>::default();
@@ -173,19 +204,54 @@ mod tests {
 
     #[test]
     fn post_activation_block_is_noop_even_when_fork_active() {
-        let spec = longevity_spec_with_fix(Some(FIX_TS));
+        let spec = longevity_spec_with_forks(Some(FIX_TS), Some(FIX_V2_TS));
         assert!(spec
             .gravity_hardforks()
-            .is_fork_active_at_timestamp(GravityHardfork::TestnetOwnerFix, FIX_TS + 1));
+            .is_fork_active_at_timestamp(GravityHardfork::TestnetOwnerFixV2, FIX_V2_TS + 1));
         assert!(!spec
             .gravity_hardforks()
-            .fork(GravityHardfork::TestnetOwnerFix)
-            .transitions_at_timestamp(FIX_TS + 1, FIX_TS));
+            .fork(GravityHardfork::TestnetOwnerFixV2)
+            .transitions_at_timestamp(FIX_V2_TS + 1, FIX_V2_TS));
 
         let db = CacheDB::<EmptyDB>::default();
         let evm_config = EthEvmConfig::new(spec.clone());
         let mut executor = WrapExecutor::new(BasicBlockExecutor::new(evm_config, db));
         // parent_ts already past fixTime ⇒ not a crossing block ⇒ no inject.
+        let out = execute_forced_transfers(
+            &mut executor,
+            spec.as_ref(),
+            EvmEnv::default(),
+            0,
+            2,
+            FIX_V2_TS + 1,
+            FIX_V2_TS,
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn v2_crossing_is_recognized_after_v1_already_active() {
+        // Longevity reality: v1 already crossed; only v2 is still a one-shot.
+        let spec = longevity_spec_with_forks(Some(FIX_TS), Some(FIX_V2_TS));
+        assert!(spec
+            .gravity_hardforks()
+            .is_fork_active_at_timestamp(GravityHardfork::TestnetOwnerFix, FIX_V2_TS));
+        assert!(!spec
+            .gravity_hardforks()
+            .fork(GravityHardfork::TestnetOwnerFix)
+            .transitions_at_timestamp(FIX_V2_TS, FIX_V2_TS - 1));
+        assert!(spec
+            .gravity_hardforks()
+            .fork(GravityHardfork::TestnetOwnerFixV2)
+            .transitions_at_timestamp(FIX_V2_TS, FIX_V2_TS - 1));
+
+        // Gate-only check: chain id + crossing would proceed into execute_one.
+        // EmptyDB has no StakePool code, so we only assert the gate helpers here
+        // (full inject covered by e2e). Non-crossing after v2 stays empty above.
+        let db = CacheDB::<EmptyDB>::default();
+        let evm_config = EthEvmConfig::new(spec.clone());
+        let mut executor = WrapExecutor::new(BasicBlockExecutor::new(evm_config, db));
+        // After v1 time but before v2: neither fork is crossing.
         let out = execute_forced_transfers(
             &mut executor,
             spec.as_ref(),

--- a/crates/pipe-exec-layer-ext-v2/execute/src/testnet_owner_fix.rs
+++ b/crates/pipe-exec-layer-ext-v2/execute/src/testnet_owner_fix.rs
@@ -1,4 +1,4 @@
-//! Pipe-layer injection for TestnetOwnerFix / TestnetOwnerFixV2.
+//! Pipe-layer injection for `TestnetOwnerFix` / `TestnetOwnerFixV2`.
 //!
 //! Runs after metadata/DKG/JWK system txs and before user txs. Constructs four
 //! forced `transferOwnership` calls with `from = old_owner`, executes them via


### PR DESCRIPTION
## Summary

Longevity Testnet already activated `TestnetOwnerFix` (`testnetOwnerFixTime`) with the wrong CLI compressed-pubkey `new_owner` addresses, so `acceptOwnership` cannot be signed. That one-shot will not fire again.

This PR adds **`TestnetOwnerFixV2` / genesis `testnetOwnerFixV2Time`**: same Longevity-gated pipe injection (`from=old_owner` → `transferOwnership(new_owner)`), reusing the cast-derived `MIGRATION_TABLE` from #434, so Ownable2Step can overwrite the bad `pendingOwner`.

**Not scheduled yet** — no activation time is baked in; ops set `testnetOwnerFixV2Time` via rolling `upgrade.json` when ready.

## greth change surface

| Area | Change |
|---|---|
| `GravityHardfork` | new `TestnetOwnerFixV2` |
| genesis parse | `testnetOwnerFixV2Time` (fail-closed; independent of v1 key) |
| pipe seam | existing single inject path; gate on v1 **or** v2 crossing |
| migration table | unchanged (cast addresses from #434) + regression test against wrong CLI addrs |

## Test plan

- [x] `cargo test -p reth-chainspec test_parse_testnet_owner_fix` / `test_testnet_owner_fix`
- [x] `cargo test -p reth-evm-ethereum migration_table_new_owners`
- [x] `cargo test -p reth-pipe-exec-layer-ext-v2 --lib testnet_owner_fix`
- [ ] Review: confirm four `new_owner`s match `cast wallet address` for ceremony keys
- [ ] After merge + release: schedule `testnetOwnerFixV2Time` on testnet only; assert four pools `pendingOwner == cast addr`

## Notes / alternatives

- Snapshot rollback to PRE-`OwnerFix` can avoid landing V2 on `main`; this PR is the hardfork path for review.
- Mainnet: no-op without Longevity `chain_id` + the new genesis key.